### PR TITLE
ci: establish controlled releases and remediation guardrails

### DIFF
--- a/.github/workflows/release-consistency.yml
+++ b/.github/workflows/release-consistency.yml
@@ -1,23 +1,20 @@
 name: Release consistency
 
-# R6-34: on a version-tag push, FAIL unless the tag, the VERSION file, and the
-# CHANGELOG.md heading all agree. Nothing examined tags before (sync-version-badge
-# only warns on a missing CHANGELOG bump), and the 2026-08-10 badge-rot incident
-# showed that tag / VERSION / CHANGELOG can silently drift apart. Read-only.
+# R6-34: on a version-tag push, FAIL unless the tag, VERSION, CHANGELOG heading,
+# and README badge all agree. The 2026-08-10 badge-rot incident showed that
+# release metadata can silently drift apart. Read-only.
 #
-# R9-23 (#402, wontfix-with-comment): this job checks tag/VERSION/CHANGELOG
-# AGREEMENT only — it does NOT re-run the test suite on the tagged commit. That
-# is intentional and mitigated in practice: tags are cut on `main` commits that
-# `tests.yml` already ran green, and the tag points at that exact tree. Adding a
-# suite job here would only re-test an already-tested commit. Revisit only if the
-# release process ever tags a commit that CI has not run (e.g. a hotfix tag off a
-# branch) — then gate the tag on a suite run.
+# R10-01 / reopened #402: this remains a post-tag defense for out-of-band human
+# or app-created tags. The supported release.yml path performs the same metadata
+# check before publication because GitHub intentionally does not recursively
+# trigger push workflows for tags created with GITHUB_TOKEN. release.yml also
+# authenticates the tests.yml push run for the exact current main SHA before it
+# creates the tag and GitHub Release together.
 #
-# Security (mirrors sync-version-badge.yml / TQ-5): the tag and the VERSION bytes
-# are untrusted repo input. VERSION is validated against a strict semver pattern,
-# and both values are passed to the shell via env: (referenced as "$TAG" / built
-# into a plain variable), NEVER textually interpolated into the run script with
-# ${{ }} — so a crafted tag or VERSION cannot inject shell.
+# Security (TQ-5/R8-22): scripts/check_version_metadata.py is the single source
+# for strict VERSION validation and VERSION/CHANGELOG/README agreement. The tag
+# remains untrusted input and is passed to the shell through env:, never textually
+# interpolated into the run script with ${{ }}.
 on:
   push:
     # R7-22: match only version-shaped tags. The old 'v*' also fired on non-release
@@ -33,42 +30,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - name: Tag == VERSION == CHANGELOG heading
+      - name: VERSION, CHANGELOG, and README badge agree
+        run: |
+          python scripts/check_version_metadata.py \
+            --version-file VERSION \
+            --changelog-file CHANGELOG.md \
+            --readme-file README.md
+      - name: Tag equals VERSION
         env:
           TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          # R9-17 (#398): strip ALL whitespace, matching sync-version-badge.yml's
-          # `tr -d '[:space:]'`.  Bare `$(cat VERSION)` only trims the trailing
-          # newline, so a stray INTERIOR space ("1.5. 33") passes the badge job
-          # but hard-fails the semver check here — the two release workflows must
-          # normalize identically or they disagree on the same VERSION bytes.
           file_ver="$(tr -d '[:space:]' < VERSION)"
-          # R7-22: accept the OPTIONAL `-<suffix>` pre-release form, single-sourcing
-          # the exact pattern sync-version-badge.yml validates against (keep the two
-          # in sync). The old strict MAJOR.MINOR.PATCH regex hard-failed a
-          # `1.6.0-rc1` tag that the badge workflow explicitly supports, so a
-          # pre-release could never satisfy both jobs at once. Still excludes every
-          # shell/sed metacharacter, preserving the TQ-5 injection-safety.
-          if ! printf '%s' "$file_ver" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
-            echo "::error::VERSION '$file_ver' is not a valid semantic version (e.g. 1.5.4 or 1.5.4-rc1)"
-            exit 1
-          fi
           tag_ver="${TAG#v}"
           if [ "$tag_ver" != "$file_ver" ]; then
             echo "::error::tag '$TAG' (=$tag_ver) does not match the VERSION file ($file_ver)"
             exit 1
           fi
-          # R7-29: the old `grep -q "^## \[$file_ver\]"` interpolated the version
-          # into a BRE where `.` is a wildcard, so `## [1x5x24]` would have
-          # satisfied the 1.5.24 check. Escape the dots (the version is validated
-          # above to hold only [0-9A-Za-z.-], so backslash-escaping `.` is
-          # sufficient and safe) and keep the `^## \[…\]` ANCHOR — `grep -F` would
-          # fix the dots but drop the start-of-line anchor, letting a mid-line or
-          # mis-levelled `## [x.y.z]` false-pass.
-          esc_ver="${file_ver//./\\.}"
-          if ! grep -qE "^## \[${esc_ver}\]" CHANGELOG.md; then
-            echo "::error::CHANGELOG.md has no '## [$file_ver]' heading for this release"
-            exit 1
-          fi
-          echo "OK: tag, VERSION, and CHANGELOG all agree on $file_ver"
+          echo "OK: tag, VERSION, CHANGELOG, and README badge all agree on $file_ver"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,123 @@
+name: controlled release
+
+# R10-01 / reopened #402: a release is created only from the current main SHA
+# after all three supported-Python checks have completed successfully for that
+# exact SHA. The workflow creates the tag and GitHub Release together; operators
+# no longer push a tag while CI is still running.
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: write
+  checks: read
+
+concurrency:
+  group: controlled-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Verify selected SHA is current main
+        env:
+          RELEASE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          current_main=$(git rev-parse origin/main)
+          if [ "$RELEASE_SHA" != "$current_main" ]; then
+            echo "::error::selected SHA $RELEASE_SHA is not current main $current_main"
+            exit 1
+          fi
+
+      - name: Read and validate release version
+        id: version
+        run: |
+          set -euo pipefail
+          python scripts/check_version_metadata.py \
+            --version-file VERSION \
+            --changelog-file CHANGELOG.md \
+            --readme-file README.md
+          version=$(tr -d '[:space:]' < VERSION)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+
+      - name: Refuse an existing tag or GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if git rev-parse --verify --quiet "refs/tags/$TAG"; then
+            echo "::error::tag $TAG already exists; releases are immutable"
+            exit 1
+          fi
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::error::GitHub Release $TAG already exists"
+            exit 1
+          fi
+
+      - name: Fetch tests workflow and check runs for the exact SHA
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          gh api \
+            -H 'Accept: application/vnd.github+json' \
+            "repos/$GITHUB_REPOSITORY/actions/workflows/tests.yml/runs?head_sha=$RELEASE_SHA&event=push&per_page=100" \
+            > "$RUNNER_TEMP/test-workflow-runs.json"
+          gh api \
+            -H 'Accept: application/vnd.github+json' \
+            "repos/$GITHUB_REPOSITORY/commits/$RELEASE_SHA/check-runs?filter=latest&per_page=100" \
+            > "$RUNNER_TEMP/release-checks.json"
+
+      - name: Require the complete supported-Python matrix
+        env:
+          RELEASE_SHA: ${{ github.sha }}
+        run: |
+          python scripts/release_gate.py \
+            --sha "$RELEASE_SHA" \
+            --runs-file "$RUNNER_TEMP/test-workflow-runs.json" \
+            --checks-file "$RUNNER_TEMP/release-checks.json" \
+            --require 'test (3.11)' \
+            --require 'test (3.12)' \
+            --require 'test (3.13)'
+
+      - name: Create immutable tag and GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ github.sha }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Close the dispatch-to-publication race: main may have advanced while
+          # this job was waiting for the API or another release invocation.
+          git fetch --no-tags origin main
+          current_main=$(git rev-parse origin/main)
+          if [ "$RELEASE_SHA" != "$current_main" ]; then
+            echo "::error::main advanced to $current_main during this job; $RELEASE_SHA will not be released"
+            exit 1
+          fi
+          prerelease_arg=()
+          if [[ "$TAG" == *-* ]]; then
+            prerelease_arg=(--prerelease)
+          fi
+          gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$RELEASE_SHA" \
+            --title "$TAG" \
+            --generate-notes \
+            "${prerelease_arg[@]}" \
+            --notes "Tested SHA: [$RELEASE_SHA](https://github.com/$GITHUB_REPOSITORY/commit/$RELEASE_SHA)
+
+Supported Python: 3.11, 3.12, 3.13.
+
+Supported Raspberry Pi OS: Bookworm/Legacy (Python 3.11) and Trixie (Python 3.13). See docs/pi-setup-guide.md."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,6 @@ jobs:
             "${prerelease_arg[@]}" \
             --notes "Tested SHA: [$RELEASE_SHA](https://github.com/$GITHUB_REPOSITORY/commit/$RELEASE_SHA)
 
-Supported Python: 3.11, 3.12, 3.13.
+          Supported Python: 3.11, 3.12, 3.13.
 
-Supported Raspberry Pi OS: Bookworm/Legacy (Python 3.11) and Trixie (Python 3.13). See docs/pi-setup-guide.md."
+          Supported Raspberry Pi OS: Bookworm/Legacy (Python 3.11) and Trixie (Python 3.13). See docs/pi-setup-guide.md."

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,40 @@
+name: dependency audit
+
+# R10-03 / reopened #295: Dependabot settings surface fix PRs, while this gate
+# independently fails when the currently resolved requirements contain a known
+# advisory. The official PyPA action is pinned to the v1.1.0 commit.
+on:
+  push:
+    branches: [main]
+    paths:
+      - requirements.txt
+      - .github/workflows/security.yml
+  pull_request:
+    paths:
+      - requirements.txt
+      - .github/workflows/security.yml
+  schedule:
+    - cron: '30 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pip-audit:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11', '3.12', '3.13']
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Audit Python ${{ matrix.python-version }} resolved requirements
+        uses: pypa/gh-action-pip-audit@1220774d901786e6f652ae159f7b6bc8fea6d266  # v1.1.0
+        with:
+          inputs: requirements.txt

--- a/.github/workflows/sync-version-badge.yml
+++ b/.github/workflows/sync-version-badge.yml
@@ -1,89 +1,39 @@
-name: Sync version badge
+name: version metadata
 
-# Runs whenever VERSION is pushed to main.
-# Reads the new version and updates the shields.io badge URL in README.md,
-# then commits the change back so the badge always matches the VERSION file.
-#
-# Also warns (without failing) if CHANGELOG.md was not updated in the same
-# push — a gentle nudge to document what changed before shipping.
-#
-# To cut a release: edit VERSION and CHANGELOG.md, commit, push. That's it.
-#
-# Security (TQ-5, #124): the VERSION file is repo content, so its bytes are
-# treated as untrusted input. The value is validated against a strict semver
-# pattern before use and handed to every shell via env: (referenced as
-# "$VERSION"), NEVER textually interpolated into a run: script with ${{ }} —
-# so a crafted VERSION (e.g. `1.5.2$(...)` or one carrying sed-special
-# characters) cannot inject shell or corrupt the sed in this job, which holds
-# contents: write. Third-party actions are pinned to a full commit SHA, not a
-# floating tag.
-
+# R10-02/#415: validate release metadata on the proposed commit. The previous
+# workflow repaired README after VERSION reached main, then pushed directly back
+# with contents:write. Protected main cannot safely depend on that second write.
+# Contributors now update VERSION, CHANGELOG, and the README badge together; this
+# read-only check fails the PR when any one is stale.
 on:
   push:
     branches: [main]
     paths:
       - VERSION
+      - CHANGELOG.md
+      - README.md
+      - scripts/check_version_metadata.py
+      - .github/workflows/sync-version-badge.yml
+  pull_request:
+    paths:
+      - VERSION
+      - CHANGELOG.md
+      - README.md
+      - scripts/check_version_metadata.py
+      - .github/workflows/sync-version-badge.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
-  sync-badge:
+  check:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          fetch-depth: 2          # need parent commit to diff against
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Read and validate version
-        id: ver
-        # Read VERSION into a shell variable (command substitution of `cat` is
-        # data, not eval) and reject anything that is not a plain semantic
-        # version BEFORE it is published as a step output. The optional
-        # `-<suffix>` keeps pre-release tags like 1.4.0-rc1 working while still
-        # excluding every shell/sed metacharacter ($ ` ( ) | & \ / and space).
+      - name: VERSION, CHANGELOG, and README badge agree
         run: |
-          version="$(tr -d '[:space:]' < VERSION)"
-          if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
-            echo "::error file=VERSION::VERSION content '${version}' is not a valid semantic version (expected e.g. 1.5.4 or 1.5.4-rc1); refusing to proceed."
-            exit 1
-          fi
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-
-      - name: Warn if CHANGELOG.md not updated
-        env:
-          VERSION: ${{ steps.ver.outputs.version }}
-        run: |
-          if git diff --name-only HEAD~1 HEAD | grep -q '^CHANGELOG\.md$'; then
-            echo "✅ CHANGELOG.md was updated alongside VERSION — nice work."
-          else
-            echo "::warning file=VERSION::VERSION was bumped to ${VERSION} but CHANGELOG.md was not updated in this commit. Add a [${VERSION}] section to CHANGELOG.md so the release is documented."
-          fi
-
-      - name: Update badge URL in README
-        env:
-          VERSION: ${{ steps.ver.outputs.version }}
-        # The badge URL is .../badge/version-<VERSION>-blueviolet.  We anchor the
-        # match between the literal "version-" prefix and the literal "-blueviolet"
-        # suffix using sed's negated-class trick: `[^"<)]*` swallows anything that
-        # isn't a URL terminator (quote, angle, paren).  This survives hyphenated
-        # versions like "1.4.0-rc1" that the older `[^-]*` pattern truncated.
-        # ${VERSION} is shell-expanded (not Actions-interpolated) and was
-        # validated above, so it holds no sed delimiter / replacement specials.
-        run: |
-          sed -i -E \
-            "s|(https://img\.shields\.io/badge/version-)[^\"<)]*(-blueviolet)|\1${VERSION}\2|g" \
-            README.md
-
-      - name: Commit if README changed
-        env:
-          VERSION: ${{ steps.ver.outputs.version }}
-        run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git diff --quiet README.md || (
-            git add README.md &&
-            git commit -m "chore: sync version badge to ${VERSION}" &&
-            git push
-          )
+          python scripts/check_version_metadata.py \
+            --version-file VERSION \
+            --changelog-file CHANGELOG.md \
+            --readme-file README.md

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ on:
   # reset any schedule-disable window.)
   workflow_dispatch:
 
-# R5-35 (TQ-5 parity with sync-version-badge.yml): scope the token to read-only.
+# R5-35 (TQ-5 parity with the version-metadata workflow): scope the token to read-only.
 # This job installs the full pip dependency tree on every push/PR, so it must not
 # run with the repository-default GITHUB_TOKEN write permissions.
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Versions follow [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.PATCH`.
 
 ---
 
+## [Unreleased]
+
+### Security and release trust
+
+- **Controlled releases now authenticate the exact tested workflow run (#402 / R10-01).** A release may target only the current `main` SHA and must find one successful `push` run of `.github/workflows/tests.yml` for that SHA, with successful Python 3.11/3.12/3.13 jobs linked to that run. Missing, pending, failed, wrong-SHA, wrong-workflow, wrong-run, or mixed-suite checks fail closed. The workflow rechecks `main` immediately before creating the tag and GitHub Release together. GitHub immutable releases is enabled so published tags and assets cannot later be changed or deleted.
+- **Version metadata validation moved before merge (#415 / R10-02).** The historical badge workflow is now a read-only pull-request check: VERSION, CHANGELOG, and the README badge must be updated together. It no longer holds `contents: write` or pushes a repair commit directly to `main`. All three release workflows use one behavior-tested metadata checker.
+- **Dependency advisories now fail CI (#295 / R10-03).** Repository vulnerability alerts and automated security updates are enabled, and a SHA-pinned official PyPA action audits the resolved requirements on relevant changes, weekly, and on demand.
+- **Every public version now has a controlled GitHub Release path (#416 / R10-07).** Generated notes link the tested commit and state the supported Python and Raspberry Pi OS versions; prerelease VERSION suffixes create prereleases.
+- **The promised MIT grant now ships with the repository (#417 / R10-08).** `LICENSE` contains the full MIT text for Copyright (c) 2026 Lane Becker, and README links it.
+
+### Process
+
+- Added a tracked remediation decision ledger and mandatory per-issue regression contract at `docs/decisions/remediation-guardrails.md`, including accepted/deferred alternatives that previously lived only in closed issues and gitignored local audit history.
+
 ## [1.5.34] — 2026-08-13
 
 **R9 Wave 3 — ops & polish (milestone `R9 Wave 3 — ops & polish`; #395–#404).**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,16 @@
 
 Design prototype and production renderer for a vinyl now-playing display (1024×600 Waveshare, Raspberry Pi).
 
+## Repository-specific GitHub workflow
+
+This repository's protected-main and controlled-release rules supersede the generic shared GitHub handoff notes above. Every handoff command block must begin with `cd '/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing'` so no git or project command can run from the wrong directory. Put changes on a `codex/` branch and merge them through a pull request after the required checks pass. Stage explicit paths—never `git add -A`, because this project keeps local audit and handoff artifacts beside the clone. Do not create or push release tags from a handoff command: after the release commit is merged and its Python 3.11/3.12/3.13 checks are green, dispatch `.github/workflows/release.yml`; it creates the immutable tag and GitHub Release together from the tested current `main` SHA.
+
+## Remediation regression contract
+
+Before changing code, workflows, configuration, or behavior for an audit issue, read and apply [`docs/decisions/remediation-guardrails.md`](docs/decisions/remediation-guardrails.md). Record the issue-specific intended change, preserved invariants, prohibited regressions, and verification commands before implementation. Search linked/closed issues, `CHANGELOG.md`, local audit reports, `log.md`, relevant tests/comments, and product/architecture/operations docs rather than trusting the current issue in isolation.
+
+Keep the ledger current whenever Lane changes a listed decision or remediation establishes a new cross-cutting invariant. Preserve user-owned ignored/untracked files, never stage `config.yaml`, and stage explicit paths rather than `git add -A`.
+
 ## Repository Structure
 
 | Path | Purpose |
@@ -64,7 +74,8 @@ Design prototype and production renderer for a vinyl now-playing display (1024×
 | `src/` | Production Python/Pillow/pygame renderer |
 | `src/display/assets/fonts/` | Bundled OFL fonts (Inter Tight, Newsreader, JetBrains Mono) used by the production renderer |
 | `PRODUCT.md` | Product spec |
-| `DESIGN.md` | Design system and production handoff spec |
+| `DESIGN.md` | Maintained design-intent reference; tested production wins where unreconciled |
+| `docs/decisions/remediation-guardrails.md` | Tracked decisions and required regression contract for remediation |
 | `design/.impeccable/design.json` | Design system tokens for impeccable tooling |
 
 ## Prototype vs. Production

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Lane Becker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Copy `config.example.yaml` to `config.yaml` and fill in:
 - [Pi setup guide](docs/pi-setup-guide.md) — hardware bring-up from bare Pi to running app
 - [First-boot checklist](docs/first-boot-checklist.md) — what to verify the first time the appliance runs
 - [Hardware guide](docs/hardware-guide.md) — wiring diagram and parts list
+- [Remediation decision guardrails](docs/decisions/remediation-guardrails.md) — prior decisions and the required regression contract for audit fixes
 
 ## Inspired By
 
@@ -74,4 +75,4 @@ Copy `config.example.yaml` to `config.yaml` and fill in:
 
 ## License
 
-MIT
+[MIT](LICENSE) — Copyright (c) 2026 Lane Becker.

--- a/docs/decisions/remediation-guardrails.md
+++ b/docs/decisions/remediation-guardrails.md
@@ -57,6 +57,7 @@ Workspace safety is part of the contract: every handoff command block begins by 
 - VERSION, CHANGELOG, README badge, tag, GitHub Release, and tested SHA must agree.
 - Protected `main` must require the three matrix checks; direct automation writes need no broad bypass.
 - Third-party Actions remain pinned to full commit SHAs and job permissions remain least-privilege.
+- Workflow edits require GitHub Actions-aware validation; successful generic YAML parsing is insufficient because it does not reject schema-invalid workflow keys.
 
 ### Recognition and optional services
 

--- a/docs/decisions/remediation-guardrails.md
+++ b/docs/decisions/remediation-guardrails.md
@@ -1,0 +1,116 @@
+# Remediation Decision Guardrails
+
+This is the tracked ledger of decisions that remediation work must preserve. It exists because the detailed audit reports and `log.md` are intentionally local and gitignored, while closed issues, comments, and source-level ratifications can otherwise be easy to miss.
+
+Update this file whenever the owner changes a listed decision, a remediation establishes a new cross-cutting invariant, or a closed/deferred issue becomes relevant again. Do not duplicate detailed implementation history here; link to its durable source.
+
+**Last reconciled:** 2026-08-22, before Round 10 remediation.
+
+## Authority and conflict order
+
+When sources disagree, stop and resolve the conflict in this order:
+
+1. The owner's latest explicit decision.
+2. Tested, currently shipped production behavior for already-ratified behavior.
+3. GitHub issue bodies, owner comments, and closure rationale.
+4. `PRODUCT.md`, `docs/architecture.md`, `docs/roadmap.md`, and operational checklists.
+5. `DESIGN.md` and the prototype for design intent only. Tested production wins while an outdated section awaits reconciliation.
+6. Local audit reports and `log.md` as historical evidence, not as the only durable authority.
+
+Never treat a test as proof that its behavior is intentional without checking the linked decision. Once intent is confirmed, keep or add a behavior-level regression test.
+
+## Required contract for every remediation
+
+Before changing code, configuration, workflows, or behavior:
+
+1. Read the current issue and every linked predecessor or conflict.
+2. Search this ledger, `CHANGELOG.md`, local `CODE_REVIEW_*.md`, and `log.md` for the issue number and touched symbols.
+3. Identify the tests and source comments that encode behavior the change must preserve.
+4. Check product, architecture, roadmap, setup, testing, and first-boot documentation relevant to the change.
+5. Write an issue-specific contract naming: intended change, preserved invariants, prohibited regressions, verification commands, and any hardware/external-state proof that remains necessary.
+6. Use RED-first tests for behavior changes. Run the targeted preserved-behavior tests before and after, then the supported CI matrix.
+7. Update this ledger if the remediation creates or changes a cross-cutting decision.
+
+Workspace safety is part of the contract: every handoff command block begins by changing to `/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing` with an absolute path; preserve user-owned ignored/untracked files, never stage `config.yaml`, and stage explicit paths rather than `git add -A`.
+
+## Global invariants
+
+### Data integrity
+
+- Prefer a missed Discogs credit to a phantom or wrong-record credit.
+- Ambiguous external-write outcomes are not retried automatically when a retry could double-apply.
+- Discogs write targets require safe release and instance identity; never guess across ambiguous owned releases.
+- Confirmation, session epoch, side coverage, and per-spin deduplication gates remain load-bearing unless the owner explicitly changes the product behavior.
+
+### Runtime and deployment
+
+- Supported Python is 3.11, 3.12, and 3.13; Raspberry Pi OS compatibility, not the local Python 3.9 `.venv`, controls dependency decisions.
+- The application remains a system service. Preserve the network/time ordering and retry semantics established by #83 and #201.
+- `config.yaml` contains write-capable secrets, remains untracked, and must be mode `0600` on the appliance.
+- Hardware-only claims stay hypotheses until the first-boot checklist records real-device evidence.
+
+### Release and repository governance
+
+- A release is the exact current `main` SHA after all three supported-Python checks succeed for that SHA.
+- Every public version receives one immutable tag and one GitHub Release created together by the controlled workflow. Tags alone are not the supported release surface.
+- GitHub immutable releases remains enabled so a published release's tag and assets cannot be modified or deleted.
+- VERSION, CHANGELOG, README badge, tag, GitHub Release, and tested SHA must agree.
+- Protected `main` must require the three matrix checks; direct automation writes need no broad bypass.
+- Third-party Actions remain pinned to full commit SHAs and job permissions remain least-privilege.
+
+### Recognition and optional services
+
+- Recognition freshness is bounded; do not replace drop-oldest/coalescing behavior with an unbounded queue.
+- Last.fm remains best-effort: preserve confirmation-time timestamps and per-spin deduplication; retry only definite failures in memory, never ambiguous outcomes, and do not add a durable outbox without a new owner decision.
+
+### Display and design
+
+- Production targets the 1024×600 Waveshare display and preserves the existing legibility floors and font fallback behavior.
+- All rendered text roles maintain at least 4.5:1 contrast on their actual backgrounds.
+- Production palette extraction remains authentic and order-independent; cross-album Hue Diversity is prototype-only.
+- Cross-side PREV/NEXT adjacency, square chips, and the muted-blended divider are ratified production behavior.
+- Prototype palette changes require rendered 1024×600 current-versus-candidate views for all five albums and owner approval before implementation.
+- Impeccable remains part of the design workflow. Only the project-specific stale `design/.impeccable/design.json` snapshot is scheduled for archival; live configuration and critique history stay.
+
+## Deliberately deferred or rejected alternatives
+
+| Decision | Durable source | Revisit trigger |
+|---|---|---|
+| No production cross-album Hue Diversity registry | [#73](https://github.com/lanebecker/vinyl-now-playing/issues/73) | Similar back-to-back physical-display palettes are genuinely distracting. |
+| Do not persist the Discogs collection index | [#169](https://github.com/lanebecker/vinyl-now-playing/issues/169) | A persistence design safely handles remove/re-add instance changes. |
+| Do not guess through the reprise/bookend ambiguity | [#227](https://github.com/lanebecker/vinyl-now-playing/issues/227) | A signal distinguishes a genuine same-release replay without phantom credit. |
+| Do not wildcard `Various` compilation matching | [#265](https://github.com/lanebecker/vinyl-now-playing/issues/265) | Real evidence justifies a rule that cannot over-credit the wrong release. |
+| Keep `ChunkAssembler`'s bounded `np.concatenate` copy | [#259](https://github.com/lanebecker/vinyl-now-playing/issues/259) | Measured Pi performance makes the copy material. |
+| Keep `np.mean(audio ** 2)` for silence RMS | [#404](https://github.com/lanebecker/vinyl-now-playing/issues/404) | An alternative preserves the exact documented threshold boundary. |
+| Keep the bounded 128-entry label cache | [#372](https://github.com/lanebecker/vinyl-now-playing/issues/372) | Measured churn becomes visible or operationally material. |
+| Accept the cover-header slow-drip residual | [#176](https://github.com/lanebecker/vinyl-now-playing/issues/176) | Executed evidence shows a practical hang or denial-of-service path. |
+| Verify custom Discogs-folder writes on hardware | [#366](https://github.com/lanebecker/vinyl-now-playing/issues/366) | Wave 1 first-boot probe determines whether code changes are needed. |
+
+## Round 10 wave contracts
+
+### Wave 0 — release trust and security
+
+- **#402 / R10-01:** authenticate the exact-SHA `push` run of `.github/workflows/tests.yml` and require its successful `test (3.11)`, `test (3.12)`, and `test (3.13)` jobs; keep the tag consistency workflow for out-of-band tag pushes; fail closed on missing, pending, failed, wrong-SHA, wrong-workflow, or wrong-run checks; recheck `main` immediately before publication.
+- **#415 / R10-02:** protect `main`, require all three checks, block force-push/deletion, and remove the badge bot's direct write instead of granting a broad Actions bypass.
+- **#295 / R10-03:** keep Dependabot and repository security features enabled; retain a failing dependency-advisory CI scan; preserve Python 3.11/Pi compatibility and document any security-update waiver.
+- **#416 / R10-07:** the controlled workflow creates the GitHub Release together with the tag; the next public release, rather than rewritten historical tags, restores the Latest Release surface.
+- **#417 / R10-08:** ship the full MIT grant as `LICENSE`, copyright 2026 Lane Becker, and link the README claim to it.
+
+**Operational checkpoint (2026-08-22):** the first Wave 0 bundle is implemented locally and independently break-reviewed. It is not operationally complete until the following ordered gates succeed:
+
+1. Merge the bundle through a `codex/` branch and pull request; do not stage ignored audit artifacts, issue scripts/maps, release-note snapshots, or `config.yaml`.
+2. Observe the tests, version-metadata, and Python 3.11–3.13 dependency-audit workflows on GitHub. Address failures before making any new check required.
+3. Activate the `main` ruleset only after the read-only metadata workflow is present on `main`: require pull requests and `test (3.11)`, `test (3.12)`, and `test (3.13)`; block force-push and deletion; include administrators and grant no broad bypass.
+4. Activate a `v*` tag-creation ruleset that permits the controlled release workflow while preventing ad-hoc release-tag creation. Do this before the first controlled release dispatch.
+5. Verify GitHub detects `LICENSE` as MIT before closing #417. Keep #416 open until a controlled release is Latest and its version, newest tag, and linked tested SHA agree.
+
+GitHub immutable releases is already enabled. The pre-merge live-state check still reports unprotected `main` and no rulesets; that is an intentional sequencing gate, not approval to dispatch a release.
+
+### Later waves
+
+- Wave 1 preserves the system-service decision and treats #366 as a real-hardware gate.
+- Wave 2 preserves immortal positive collection reads during normal operation; only a definitive missing-instance write may invalidate, refresh, and permit one identity-safe retry.
+- Wave 3 preserves recognition freshness, confirmation timestamps, epoch gates, and spin deduplication while isolating Last.fm latency.
+- Wave 4 keeps floor-based dependency manifests and Python 3.11 compatibility; it does not introduce a platform-specific lockfile implicitly.
+- Wave 5 begins with design-source reconciliation and owner-visible render approval; it cannot use outdated `DESIGN.md` alone as evidence that production is defective.
+- Wave 6 remains post-launch architecture work unless an earlier point fix makes the same refactor unavoidable.

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -181,21 +181,29 @@ diagnostic aid, not a gate — the suite does not enforce a minimum percentage.
 
 ## Continuous integration
 
-Two GitHub Actions workflows live in `.github/workflows/`:
+Five GitHub Actions workflows live in `.github/workflows/`:
 
-- **`tests.yml`** — runs `pytest -q` on every push and pull request, on Python
-  3.11 (the Raspberry Pi OS bookworm system Python and the version the app
-  targets). It sets `SDL_VIDEODRIVER=dummy` / `SDL_AUDIODRIVER=dummy` so pygame
-  is headless, and `tests/conftest.py` stubs `sounddevice` before any test
-  module loads, so no PortAudio or display hardware is needed on the runner.
-- **`sync-version-badge.yml`** — runs when `VERSION` is pushed to `main`,
-  revalidates the new version against a strict semver pattern (TQ-5, the file is
-  treated as untrusted repo content), and rewrites the shields.io badge in
-  `README.md` so it always matches `VERSION`. It also warns — without failing —
-  if `CHANGELOG.md` was not touched in the same push. **Release reminder:** a
-  release means editing **both `VERSION` and `CHANGELOG.md`** and pushing; the
-  badge sync only fires on a `VERSION` change, so bumping the changelog alone
-  leaves the badge (and any VERSION-derived display) stale.
+- **`tests.yml`** — runs `pytest -q` on every `main` push and pull request across
+  Python 3.11, 3.12, and 3.13. It sets `SDL_VIDEODRIVER=dummy` /
+  `SDL_AUDIODRIVER=dummy` so pygame is headless, and `tests/conftest.py` stubs
+  `sounddevice` before any test module loads, so no PortAudio or display
+  hardware is needed on the runner.
+- **`sync-version-badge.yml`** — despite its historical filename, this is now a
+  read-only version-metadata check on pull requests and `main`. It fails unless
+  `VERSION`, the `CHANGELOG.md` release heading, and the README badge agree;
+  contributors update all three in the release PR. It never commits or pushes.
+- **`release.yml`** — manually creates a controlled release from the current
+  `main` SHA only after the Python 3.11/3.12/3.13 checks have succeeded for that
+  exact SHA. It creates the immutable tag and GitHub Release together.
+- **`release-consistency.yml`** — post-tag defense that verifies the tag,
+  VERSION, changelog heading, and README badge still agree for out-of-band tag
+  pushes. The controlled workflow performs the same check before publication;
+  GitHub does not recursively start this push workflow for its `GITHUB_TOKEN`.
+- **`security.yml`** — audits the resolved `requirements.txt` dependency graph
+  for known advisories on Python 3.11, 3.12, and 3.13 on relevant pull requests,
+  `main`, a weekly schedule, and manual dispatch. The matrix makes marker-only
+  dependencies such as the 3.13 `audioop-lts` backport visible. Dependabot
+  remains the complementary update mechanism.
 
 ---
 

--- a/scripts/check_version_metadata.py
+++ b/scripts/check_version_metadata.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Fail closed unless VERSION, CHANGELOG, and README badge agree."""
+import argparse
+import re
+from pathlib import Path
+
+
+SEMVER = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.]+)?")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version-file", required=True, type=Path)
+    parser.add_argument("--changelog-file", required=True, type=Path)
+    parser.add_argument("--readme-file", required=True, type=Path)
+    args = parser.parse_args()
+
+    version = "".join(args.version_file.read_text().split())
+    if SEMVER.fullmatch(version) is None:
+        parser.error("VERSION is not valid release semver")
+
+    changelog = args.changelog_file.read_text()
+    if re.search(rf"^## \[{re.escape(version)}\]", changelog, re.MULTILINE) is None:
+        parser.error(f"CHANGELOG has no ## [{version}] heading")
+
+    readme = args.readme_file.read_text()
+    badge_versions = re.findall(
+        r"\[!\[version\]\(https://img\.shields\.io/badge/version-(.+?)-blueviolet\)\]"
+        r"\(VERSION\)",
+        readme,
+    )
+    if badge_versions != [version]:
+        parser.error(f"README version badge does not match VERSION {version}")
+
+    print(f"version metadata passed for {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_gate.py
+++ b/scripts/release_gate.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Fail closed unless required GitHub checks passed for one exact release SHA."""
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sha", required=True)
+    parser.add_argument("--runs-file", required=True, type=Path)
+    parser.add_argument("--checks-file", required=True, type=Path)
+    parser.add_argument("--require", action="append", required=True)
+    args = parser.parse_args()
+
+    if re.fullmatch(r"[0-9a-f]{40}", args.sha) is None:
+        parser.error("sha must be exactly 40 lowercase hexadecimal characters")
+
+    runs_payload = json.loads(args.runs_file.read_text())
+    matching_runs = [
+        run
+        for run in runs_payload["workflow_runs"]
+        if run.get("head_sha") == args.sha
+        and run.get("path") == ".github/workflows/tests.yml"
+        and run.get("event") == "push"
+    ]
+    if not matching_runs:
+        parser.error("no successful tests.yml push run for exact SHA")
+    selected_run = max(matching_runs, key=lambda run: run.get("run_number", -1))
+    if (
+        selected_run.get("status") != "completed"
+        or selected_run.get("conclusion") != "success"
+    ):
+        parser.error("newest tests.yml push run for exact SHA is not successful")
+    run_id = selected_run.get("id")
+    if not isinstance(run_id, int):
+        parser.error("selected tests.yml run has no numeric id")
+    selected_suite_id = selected_run.get("check_suite_id")
+    if not isinstance(selected_suite_id, int):
+        parser.error("selected tests.yml run has no numeric check suite id")
+
+    payload = json.loads(args.checks_file.read_text())
+    run_marker = f"/actions/runs/{run_id}/job/"
+    eligible = [
+        check
+        for check in payload["check_runs"]
+        if check.get("head_sha") == args.sha
+        and check.get("app", {}).get("slug") == "github-actions"
+        and run_marker in check.get("details_url", "")
+    ]
+    passed_checks = []
+    missing = []
+    for name in args.require:
+        matches = [check for check in eligible if check.get("name") == name]
+        if (
+            len(matches) != 1
+            or matches[0].get("status") != "completed"
+            or matches[0].get("conclusion") != "success"
+        ):
+            missing.append(name)
+        else:
+            passed_checks.append(matches[0])
+    if missing:
+        parser.error("required checks not successful: " + ", ".join(missing))
+
+    suite_ids = {
+        check.get("check_suite", {}).get("id") for check in passed_checks
+    }
+    if len(suite_ids) != 1 or None in suite_ids:
+        parser.error("required checks do not belong to one GitHub Actions suite")
+    if suite_ids != {selected_suite_id}:
+        parser.error("required checks do not match selected tests.yml suite")
+
+    print(f"release gate passed for {args.sha} via tests run {run_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_integrity_r8.py
+++ b/tests/test_ci_integrity_r8.py
@@ -11,16 +11,11 @@ interpreter, so each matrix leg can genuinely FAIL on an import breakage —
 on 3.13 that exercises the audioop-lts backport path specifically (3.11/3.12
 have stdlib audioop and exercise the plain import).
 
-R8-22/#363: R7-22 asked for a single-sourced release-version regex; v1.5.25
-shipped two byte-identical copies with "keep in sync" comments — the exact
-drift mechanism the finding described, one edit from recurring. Per the issue's
-accept-with-a-stronger-tripwire option: this test extracts both patterns and
-diffs them, going RED the moment they drift.
+R8-22/#363's duplicated release-version regexes were retired by R10-02/#415.
+All three workflows now execute ``scripts/check_version_metadata.py``; its
+supported and rejected release forms are behavior-tested in
+``test_version_metadata_r10.py`` instead of source-text-diffed here.
 """
-import re
-from pathlib import Path
-
-REPO = Path(__file__).resolve().parent.parent
 
 
 def test_shazamio_imports_on_this_interpreter():
@@ -42,38 +37,3 @@ def test_recognition_probe_passes_with_the_real_importer():
 
     cfg = AppConfig.from_dict(_valid_raw())
     verify_recognition_backend_importable(cfg)   # must not raise
-
-
-def _version_regexes() -> dict:
-    """Extract the release-semver grep pattern from each workflow that carries
-    one.  Anchored single-quoted grep -Eq patterns starting ^[0-9]."""
-    out = {}
-    for wf in ("release-consistency.yml", "sync-version-badge.yml"):
-        text = (REPO / ".github" / "workflows" / wf).read_text()
-        found = re.findall(r"grep -Eq '(\^\[0-9\][^']*)'", text)
-        assert found, f"{wf}: expected a version regex (did it move?)"
-        out[wf] = set(found)
-    return out
-
-
-def test_r8_22_version_regexes_have_not_drifted():
-    """R8-22 (#363): the two workflows carry deliberately-duplicated version
-    regexes ("keep in sync" comments) — this tripwire fails the suite the
-    moment one is edited without the other."""
-    regexes = _version_regexes()
-    all_patterns = set().union(*regexes.values())
-    assert len(all_patterns) == 1, (
-        f"the release-version regexes have DRIFTED between workflows "
-        f"(R7-22/R8-22): {regexes}"
-    )
-
-
-def test_r8_22_the_shared_regex_still_accepts_release_and_prerelease():
-    """Control: the shared pattern accepts what the release flow produces —
-    plain semver and the pre-release form — and rejects the known evils."""
-    (pattern,) = set().union(*_version_regexes().values())
-    rx = re.compile(pattern)
-    for good in ("1.5.29", "10.0.1", "1.6.0-rc.1", "2.0.0-beta2"):
-        assert rx.search(good), f"{pattern!r} must accept {good!r}"
-    for bad in ("1x5x29", "v1.5.29", "1.5", "1.5.29 ", ""):
-        assert not rx.search(bad), f"{pattern!r} must reject {bad!r}"

--- a/tests/test_release_gate_r10.py
+++ b/tests/test_release_gate_r10.py
@@ -1,0 +1,205 @@
+"""Behavior tests for the workflow-authenticated release gate in #402."""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parent.parent
+GATE = REPO / "scripts" / "release_gate.py"
+SHA = "a" * 40
+RUN_ID = 98765
+SUITE_ID = 12345
+REQUIRED = ("test (3.11)", "test (3.12)", "test (3.13)")
+
+
+def _run_record(
+    *,
+    run_id=RUN_ID,
+    head_sha=SHA,
+    path=".github/workflows/tests.yml",
+    event="push",
+    status="completed",
+    conclusion="success",
+    run_number=100,
+    suite_id=SUITE_ID,
+):
+    return {
+        "id": run_id,
+        "head_sha": head_sha,
+        "path": path,
+        "event": event,
+        "status": status,
+        "conclusion": conclusion,
+        "run_number": run_number,
+        "check_suite_id": suite_id,
+    }
+
+
+def _check(
+    name,
+    *,
+    run_id=RUN_ID,
+    head_sha=SHA,
+    status="completed",
+    conclusion="success",
+    suite_id=SUITE_ID,
+    app_slug="github-actions",
+):
+    return {
+        "name": name,
+        "head_sha": head_sha,
+        "status": status,
+        "conclusion": conclusion,
+        "app": {"slug": app_slug},
+        "check_suite": {"id": suite_id},
+        "details_url": f"https://github.com/example/repo/actions/runs/{run_id}/job/1",
+    }
+
+
+def _invoke(tmp_path, checks, *, runs=None, sha=SHA):
+    checks_file = tmp_path / "checks.json"
+    runs_file = tmp_path / "runs.json"
+    checks_file.write_text(json.dumps({"check_runs": checks}))
+    runs_file.write_text(json.dumps({"workflow_runs": runs or [_run_record()]}))
+    return subprocess.run(
+        [
+            sys.executable,
+            str(GATE),
+            "--sha",
+            sha,
+            "--runs-file",
+            str(runs_file),
+            "--checks-file",
+            str(checks_file),
+            *[part for name in REQUIRED for part in ("--require", name)],
+        ],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_release_gate_accepts_exact_sha_only_after_authenticated_matrix_passes(tmp_path):
+    """Removing workflow/run authentication must make this guarantee disappear."""
+    result = _invoke(tmp_path, [_check(name) for name in REQUIRED])
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == f"release gate passed for {SHA} via tests run {RUN_ID}"
+
+
+def test_release_gate_rejects_a_non_commit_sha_before_considering_checks(tmp_path):
+    """Removing full-hex SHA validation must make symbolic refs releasable."""
+    result = _invoke(tmp_path, [_check(name, head_sha="main") for name in REQUIRED], sha="main")
+
+    assert result.returncode != 0
+    assert "sha must be exactly 40 lowercase hexadecimal characters" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("broken_name", "head_sha", "status", "conclusion"),
+    [
+        ("test (3.11)", SHA, "completed", "failure"),
+        ("test (3.12)", SHA, "in_progress", None),
+        ("test (3.13)", "b" * 40, "completed", "success"),
+    ],
+)
+def test_release_gate_fails_closed_on_failed_pending_or_wrong_sha_job(
+    tmp_path, broken_name, head_sha, status, conclusion
+):
+    checks = [
+        _check(
+            name,
+            head_sha=head_sha if name == broken_name else SHA,
+            status=status if name == broken_name else "completed",
+            conclusion=conclusion if name == broken_name else "success",
+        )
+        for name in REQUIRED
+    ]
+    result = _invoke(tmp_path, checks)
+
+    assert result.returncode != 0
+    assert f"required checks not successful: {broken_name}" in result.stderr
+
+
+def test_release_gate_rejects_same_name_success_from_an_untrusted_app(tmp_path):
+    """Ignoring app provenance must let a foreign app mask a failed CI leg."""
+    checks = [_check(name) for name in REQUIRED]
+    checks[0]["conclusion"] = "failure"
+    checks.append(_check(REQUIRED[0], app_slug="not-github-actions"))
+
+    result = _invoke(tmp_path, checks)
+
+    assert result.returncode != 0
+    assert f"required checks not successful: {REQUIRED[0]}" in result.stderr
+
+
+def test_release_gate_rejects_a_successful_impostor_workflow(tmp_path):
+    """Trusting names/suite alone must let another workflow impersonate tests.yml."""
+    result = _invoke(
+        tmp_path,
+        [_check(name) for name in REQUIRED],
+        runs=[_run_record(path=".github/workflows/impostor.yml")],
+    )
+
+    assert result.returncode != 0
+    assert "no successful tests.yml push run for exact SHA" in result.stderr
+
+
+def test_release_gate_ignores_duplicate_names_from_a_different_run(tmp_path):
+    """Filtering names globally must block a safe SHA after a scheduled run."""
+    checks = [_check(name) for name in REQUIRED]
+    checks.extend(
+        _check(name, run_id=RUN_ID + 1, suite_id=SUITE_ID + 1)
+        for name in REQUIRED
+    )
+    runs = [
+        _run_record(),
+        _run_record(run_id=RUN_ID + 1, event="schedule", run_number=101),
+    ]
+
+    result = _invoke(tmp_path, checks, runs=runs)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_release_gate_rejects_required_jobs_split_across_suites(tmp_path):
+    """Dropping the shared-suite rule must combine unrelated job sets."""
+    checks = [_check(name) for name in REQUIRED]
+    checks[-1]["check_suite"] = {"id": SUITE_ID + 1}
+
+    result = _invoke(tmp_path, checks)
+
+    assert result.returncode != 0
+    assert "required checks do not belong to one GitHub Actions suite" in result.stderr
+
+
+def test_release_gate_rejects_newest_tests_run_when_it_failed(tmp_path):
+    """Filtering for success before selecting newest must revive an older green run."""
+    runs = [
+        _run_record(),
+        _run_record(
+            run_id=RUN_ID + 1,
+            run_number=101,
+            suite_id=SUITE_ID + 1,
+            conclusion="failure",
+        ),
+    ]
+
+    result = _invoke(tmp_path, [_check(name) for name in REQUIRED], runs=runs)
+
+    assert result.returncode != 0
+    assert "newest tests.yml push run for exact SHA is not successful" in result.stderr
+
+
+def test_release_gate_rejects_jobs_not_in_selected_runs_declared_suite(tmp_path):
+    """Checking only that jobs agree must accept a suite the selected run does not own."""
+    checks = [_check(name, suite_id=SUITE_ID + 1) for name in REQUIRED]
+
+    result = _invoke(tmp_path, checks)
+
+    assert result.returncode != 0
+    assert "required checks do not match selected tests.yml suite" in result.stderr

--- a/tests/test_version_metadata_r10.py
+++ b/tests/test_version_metadata_r10.py
@@ -1,0 +1,143 @@
+"""Behavior tests for the read-only version metadata gate in #415 / R10-02."""
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parent.parent
+CHECK = REPO / "scripts" / "check_version_metadata.py"
+
+
+def _run_check(tmp_path, *, version="1.5.35", heading="1.5.35", badge="1.5.35"):
+    version_file = tmp_path / "VERSION"
+    changelog_file = tmp_path / "CHANGELOG.md"
+    readme_file = tmp_path / "README.md"
+    version_file.write_text(version + "\n")
+    changelog_file.write_text(f"# Changelog\n\n## [{heading}] - 2026-08-22\n")
+    readme_file.write_text(
+        f"[![version](https://img.shields.io/badge/version-{badge}-blueviolet)](VERSION)\n"
+    )
+    return subprocess.run(
+        [
+            sys.executable,
+            str(CHECK),
+            "--version-file",
+            str(version_file),
+            "--changelog-file",
+            str(changelog_file),
+            "--readme-file",
+            str(readme_file),
+        ],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_version_metadata_gate_accepts_one_consistent_release_candidate(tmp_path):
+    """A valid candidate gives contributors one deterministic green check."""
+    result = _run_check(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "version metadata passed for 1.5.35"
+
+
+def test_version_metadata_gate_rejects_a_stale_readme_badge(tmp_path):
+    """Removing the badge comparison must let this stale public version pass."""
+    result = _run_check(tmp_path, badge="1.5.34")
+
+    assert result.returncode != 0
+    assert "README version badge does not match VERSION 1.5.35" in result.stderr
+
+
+def test_version_metadata_gate_rejects_stale_badge_even_if_expected_url_is_elsewhere(
+    tmp_path,
+):
+    """A substring search must not let a comment hide a stale rendered badge."""
+    version_file = tmp_path / "VERSION"
+    changelog_file = tmp_path / "CHANGELOG.md"
+    readme_file = tmp_path / "README.md"
+    version_file.write_text("1.5.35\n")
+    changelog_file.write_text("## [1.5.35] - 2026-08-22\n")
+    readme_file.write_text(
+        "<!-- https://img.shields.io/badge/version-1.5.35-blueviolet -->\n"
+        "[![version](https://img.shields.io/badge/version-1.5.34-blueviolet)](VERSION)\n"
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(CHECK),
+            "--version-file",
+            str(version_file),
+            "--changelog-file",
+            str(changelog_file),
+            "--readme-file",
+            str(readme_file),
+        ],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "README version badge does not match VERSION 1.5.35" in result.stderr
+
+
+def test_version_metadata_gate_rejects_a_missing_changelog_heading(tmp_path):
+    """Removing the changelog comparison must let an undocumented version pass."""
+    result = _run_check(tmp_path, heading="1.5.34")
+
+    assert result.returncode != 0
+    assert "CHANGELOG has no ## [1.5.35] heading" in result.stderr
+
+
+def test_version_metadata_gate_rejects_untrusted_version_bytes(tmp_path):
+    """Removing strict semver validation must accept shell/sed-hostile input."""
+    result = _run_check(tmp_path, version="1.5.35$(id)", heading="1.5.35$(id)", badge="1.5.35$(id)")
+
+    assert result.returncode != 0
+    assert "VERSION is not valid release semver" in result.stderr
+
+
+@pytest.mark.parametrize("version", ["1.5.35", "10.0.1", "1.6.0-rc.1", "2.0.0-beta2"])
+def test_version_metadata_gate_preserves_supported_release_forms(tmp_path, version):
+    """Narrowing the historical release grammar must reject one of these forms."""
+    result = _run_check(tmp_path, version=version, heading=version, badge=version)
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize("version", ["1x5x35", "v1.5.35", "1.5", ""])
+def test_version_metadata_gate_preserves_known_rejections(tmp_path, version):
+    """Loosening the historical release grammar must accept one of these values."""
+    result = _run_check(tmp_path, version=version, heading=version, badge=version)
+
+    assert result.returncode != 0
+    assert "VERSION is not valid release semver" in result.stderr
+
+
+def test_repository_version_metadata_is_currently_consistent():
+    """A release-prep omission in any of the three tracked files must fail CI."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(CHECK),
+            "--version-file",
+            str(REPO / "VERSION"),
+            "--changelog-file",
+            str(REPO / "CHANGELOG.md"),
+            "--readme-file",
+            str(REPO / "README.md"),
+        ],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/test_workflow_integrity_r10.py
+++ b/tests/test_workflow_integrity_r10.py
@@ -1,0 +1,28 @@
+"""Behavior checks for the Wave 0 GitHub Actions workflow definitions."""
+from pathlib import Path
+
+import yaml
+
+
+REPO = Path(__file__).resolve().parent.parent
+WORKFLOW_TOP_LEVEL_KEYS = {
+    "concurrency",
+    "defaults",
+    "env",
+    "jobs",
+    "name",
+    "on",
+    True,  # PyYAML 5 follows YAML 1.1 and decodes the unquoted key `on` as true.
+    "permissions",
+    "run-name",
+}
+
+
+def test_controlled_release_has_no_deindented_step_content_at_workflow_scope():
+    """Deindenting block-scalar lines must not create invalid workflow keys."""
+    workflow = yaml.safe_load(
+        (REPO / ".github" / "workflows" / "release.yml").read_text()
+    )
+
+    unexpected = set(workflow) - WORKFLOW_TOP_LEVEL_KEYS
+    assert unexpected == set(), f"unexpected workflow-level keys: {sorted(unexpected)}"


### PR DESCRIPTION
## Summary

- authenticate controlled releases against the newest exact-SHA tests.yml push run
- replace the write-capable badge bot with read-only metadata validation
- audit dependencies across Python 3.11, 3.12, and 3.13
- add the MIT license and durable remediation guardrails
- enable immutable release-compatible workflows and release provenance
- add RED-first regression coverage for release, metadata, and workflow integrity

## Verification

- 28 focused tests pass locally
- 1,534 tests collect
- all five GitHub Actions workflows pass actionlint 1.7.12
- version metadata validates 1.5.34
- live release-gate payload validates authenticated tests run 32297600460
- independent adversarial review: QUALITY PASS / SPEC CONDITIONAL PASS

## Remaining post-merge gates

- observe the metadata and dependency-audit workflows on GitHub
- activate protected-main and controlled-only v* tag rulesets
- verify GitHub detects the MIT license
- verify the first controlled release becomes Latest

Refs #295, #402, #415, #416, #417