### PR TITLE
Record active release trust boundary

### DIFF
--- a/docs/decisions/remediation-guardrails.md
+++ b/docs/decisions/remediation-guardrails.md
@@ -58,7 +58,7 @@ Workspace safety is part of the contract: every handoff command block begins by 
 - Protected `main` must require the three matrix checks; direct automation writes need no broad bypass.
 - Release publication uses the private, repository-scoped GitHub App `vinyl-now-playing-release-lbecker` (App ID `4684884`, Client ID `Iv23lio63JQpLQKjuPyS`). It is installed only on `lanebecker/vinyl-now-playing`; its only explicit permission is repository Contents read/write, plus GitHub-mandatory Metadata read access. It has no webhook or subscribed events.
 - The app private key exists only as the `RELEASE_APP_PRIVATE_KEY` secret in the protected `release` environment; the Client ID is the `RELEASE_APP_CLIENT_ID` environment variable. That environment accepts only `main` and requires Lane's approval after read-only validation succeeds.
-- The approved `Protect release tags` ruleset will restrict creation, deletion, and non-fast-forward updates of `v*` tags, with `vinyl-now-playing-release-lbecker` as its sole bypass actor. The built-in GitHub Actions integration is not an eligible bypass actor for this personal repository. This ruleset is intentionally not active until the app-authenticated workflow merges and its checks pass.
+- Active ruleset `Protect release tags` (ID `21211977`) restricts creation, deletion, and non-fast-forward updates of `refs/tags/v*`, with `vinyl-now-playing-release-lbecker` (App ID `4684884`) as its sole bypass actor, mode `always`. Humans, administrators, ordinary `GITHUB_TOKEN`, and other apps have no bypass. It was activated only after PR #433 merged at `05a1c7b55cccde92786918ab18ee85a6de2aa5cc` and that exact SHA passed metadata, tests, and dependency audits on Python 3.11/3.12/3.13.
 - Third-party Actions remain pinned to full commit SHAs and job permissions remain least-privilege.
 - Workflow edits require GitHub Actions-aware validation; successful generic YAML parsing is insufficient because it does not reject schema-invalid workflow keys.
 
@@ -100,14 +100,9 @@ Workspace safety is part of the contract: every handoff command block begins by 
 - **#416 / R10-07:** the controlled workflow creates the GitHub Release together with the tag; the next public release, rather than rewritten historical tags, restores the Latest Release surface.
 - **#417 / R10-08:** ship the full MIT grant as `LICENSE`, copyright 2026 Lane Becker, and link the README claim to it.
 
-**Operational checkpoint (2026-08-22):** `Protect main` is active with no bypass and the exact Python 3.11/3.12/3.13 checks required. GitHub immutable releases and MIT license detection are enabled. The repository-scoped release app and protected `release` environment have been created and read back with the identities and restrictions above. The app-authenticated workflow bundle is implemented locally and independently break-reviewed, but release-tag protection is not yet active. Wave 0 is not operationally complete until the remaining ordered gates succeed:
+**Verified operational checkpoint (2026-08-22):** PR #433 merged at `05a1c7b55cccde92786918ab18ee85a6de2aa5cc`, and that exact SHA passed version metadata, tests, and dependency audits on Python 3.11/3.12/3.13. `Protect main` (ruleset ID `21204190`) is active with no bypass and requires the exact three Python checks. `Protect release tags` (ruleset ID `21211977`) is active for `refs/tags/v*` with App ID `4684884` as its sole `always` bypass. The repository-scoped App, protected `release` environment, immutable releases, and MIT detection have all been read back. Issues #402 and #415 are closed.
 
-1. Merge the bundle through a `codex/` branch and pull request; do not stage ignored audit artifacts, issue scripts/maps, release-note snapshots, or `config.yaml`.
-2. Observe the tests, version-metadata, and Python 3.11–3.13 dependency-audit workflows on GitHub. Address failures before proceeding.
-3. After the merge SHA is green, activate `Protect release tags` for `refs/tags/v*` with App ID `4684884` as the sole bypass actor; read the ruleset back before the first controlled release dispatch.
-4. Keep #416 open until a controlled release is Latest and its version, newest tag, and linked tested SHA agree.
-
-The pending release-tag ruleset is an intentional sequencing gate, not approval for a manual tag or an early release dispatch.
+No controlled App-backed tag or GitHub Release has been published yet. Issue #416 remains open until the first controlled publication becomes Latest and VERSION, newest tag, and linked tested SHA agree. Manual tag creation remains prohibited.
 
 ### Later waves
 

--- a/docs/superpowers/plans/2026-08-22-release-app.md
+++ b/docs/superpowers/plans/2026-08-22-release-app.md
@@ -4,11 +4,13 @@
 
 **Goal:** Make the protected `release` environment and a repository-scoped GitHub App the only path that can create immutable `v*` tags and GitHub Releases.
 
-**Architecture:** Split the controlled release into a read-only `validate` job and an environment-gated `publish` job. The publish job mints a one-hour, current-repository app token immediately before one `gh release create` call. In the approved target state, the installed app becomes the sole release-tag-ruleset bypass actor only after post-merge Task 7 creates the ruleset and verifies it by API readback; that control is not active yet.
+**Architecture:** Split the controlled release into a read-only `validate` job and an environment-gated `publish` job. The publish job mints a one-hour, current-repository app token immediately before one `gh release create` call. Active ruleset `Protect release tags` (ID `21211977`) makes the installed app the sole release-tag-ruleset bypass actor; it was created only after post-merge Task 7 checks and API readback succeeded.
 
 **Tech Stack:** GitHub Apps, GitHub Actions, repository environments, repository rulesets, `actions/create-github-app-token` v3.2.0, GitHub CLI, Python/pytest, PyYAML, actionlint.
 
 **Spec:** `docs/superpowers/specs/2026-08-22-release-app-design.md`
+
+**Completion readback (2026-08-22):** PR #433 merged at `05a1c7b55cccde92786918ab18ee85a6de2aa5cc`. `Protect main` (ID `21204190`) and `Protect release tags` (ID `21211977`) are active with the verified policies below. Issues #402 and #415 are closed. No controlled App-backed tag or GitHub Release has been published; #416 remains open until the first controlled publication becomes Latest and VERSION, newest tag, and tested SHA agree.
 
 ## Global Constraints
 
@@ -21,7 +23,7 @@
 - The app token requests only `contents: write`, targets only the current repository, and is automatically revoked.
 - The exact token action pin is `actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1` (`v3.2.0`).
 - `Protect main` remains active with no bypass actors and requires `test (3.11)`, `test (3.12)`, and `test (3.13)` from GitHub Actions integration ID `15368`.
-- Approved Task 7 target: `Protect release tags` targets `refs/tags/v*`; its sole bypass actor is the installed release app; it restricts creation and deletion and blocks non-fast-forward updates. It is pending and must not be described as active before Task 7 API readback.
+- Verified Task 7 state: active `Protect release tags` ruleset ID `21211977` targets `refs/tags/v*`; its sole bypass actor is installed release App ID `4684884`; it restricts creation and deletion and blocks non-fast-forward updates.
 - Published releases remain immutable. Never overwrite, delete, move, or blindly retry an ambiguous tag/Release creation.
 - Local git is read-only for Codex. Codex performs every other available operation; the sole unavoidable handoff is explicit-path branch/commit/push.
 - Every unavoidable handoff begins with `cd` to the absolute path of the appropriate active checkout or worktree and verifies its expected branch before mutation. The canonical clone is only the default when it is the active checkout. Handoffs never use `git add -A`.
@@ -420,10 +422,10 @@ Under release governance, record:
 ```markdown
 - Release publication uses the repository-scoped `vinyl-now-playing-release-lbecker` GitHub App. Its only explicit permission is repository Contents read/write, plus GitHub-mandatory Metadata read access; it is installed only on this repository.
 - The app private key exists only as `RELEASE_APP_PRIVATE_KEY` in the protected `release` environment; its Client ID is `RELEASE_APP_CLIENT_ID`. Lane approves the environment after validation succeeds.
-- After the bundle merges and its checks pass, `Protect release tags` will permit only that app to create, delete, or non-fast-forward-update `v*` tags. The built-in GitHub Actions integration is not an eligible bypass actor for this personal repository. Do not record the ruleset as active until Task 7 API readback succeeds.
+- After the bundle merged and its checks passed, Task 7 created active `Protect release tags` ruleset ID `21211977`, permitting only App ID `4684884` to bypass creation, deletion, or non-fast-forward-update restrictions for `v*` tags. The built-in GitHub Actions integration is not an eligible bypass actor for this personal repository.
 ```
 
-Change the Wave 0 operational checkpoint from pending ruleset setup to the actual live state only after API readback succeeds.
+The Wave 0 operational checkpoint now records the API-verified live state, exact merge SHA, both ruleset IDs, issue closures, and the still-pending first controlled publication.
 
 - [x] **Step 2: Update the testing guide**
 
@@ -527,7 +529,7 @@ For each accepted finding: add or strengthen a RED-first test, observe RED, make
 - Consumes: locally verified diff and independent PASS/conditional-PASS verdict.
 - Produces: the already-existing `codex/release-app-identity` branch pushed for a pull request; post-merge current-main SHA with green workflows.
 
-- [ ] **Step 1: Perform the sole unavoidable git handoff**
+- [x] **Step 1: Perform the sole unavoidable git handoff**
 
 The branch already exists and is checked out in the isolated worktree; do not create it again. The handoff must use this one failure-stopping chain, verify the branch before mutation, stage only the named files, run the cached diff check, commit with the issue references, and push:
 
@@ -553,15 +555,15 @@ git push -u origin codex/release-app-identity
 
 It must not stage audit reports, issue scripts/maps, release-note snapshots, `config.yaml`, any private key, or any file not listed above. It must never use `git add -A` or create/push a release tag.
 
-- [ ] **Step 2: Create the PR directly with GitHub CLI**
+- [x] **Step 2: Create the PR directly with GitHub CLI**
 
 Codex creates the PR, listing local verification, external app/environment scope, independent review verdict, and the remaining post-merge tag-ruleset gate.
 
-- [ ] **Step 3: Monitor every PR check**
+- [x] **Step 3: Monitor every PR check**
 
 Require version metadata; dependency audit on 3.11/3.12/3.13; and tests on 3.11/3.12/3.13. Verify the PR file list contains only intended files and GitHub reports `MERGEABLE/CLEAN` before asking Lane to merge.
 
-- [ ] **Step 4: Verify post-merge current main**
+- [x] **Step 4: Verify post-merge current main**
 
 Wait for the merge-SHA metadata, dependency-audit matrix, and test matrix. Do not create tag protection while any post-merge check is pending or failing.
 
@@ -576,7 +578,7 @@ Wait for the merge-SHA metadata, dependency-audit matrix, and test matrix. Do no
 - Consumes: installed release App ID and merged app-authenticated workflow.
 - Produces: only the release app can create/update/delete matching `v*` tags.
 
-- [ ] **Step 1: Create the ruleset payload with the Task 1 App ID**
+- [x] **Step 1: Create the ruleset payload with the Task 1 App ID**
 
 Store the numeric App ID read in Task 1 in the shell variable `release_app_id`, then generate the payload without stringifying the ID:
 
@@ -605,11 +607,11 @@ jq -n --argjson app_id "$release_app_id" '{
 
 Run `jq -e '.bypass_actors[0].actor_id | type == "number"' /tmp/vnp-release-tag-ruleset.json` before POSTing.
 
-- [ ] **Step 2: Create and read back the ruleset**
+- [x] **Step 2: Create and read back the ruleset**
 
 POST the payload to `repos/lanebecker/vinyl-now-playing/rulesets`, capture the returned ID, then GET that exact ID. Expected: active tag target, `refs/tags/v*`, exactly one bypass actor matching the custom app, and exactly the three specified rules.
 
-- [ ] **Step 3: Verify the complete live release trust boundary**
+- [x] **Step 3: Verify the complete live release trust boundary**
 
 Read back:
 
@@ -627,10 +629,10 @@ release.yml: ordinary token read-only, publish job environment-gated,
              final GH_TOKEN comes only from app-token output
 ```
 
-- [ ] **Step 4: Update status records**
+- [x] **Step 4: Update status records**
 
 Append the verified ruleset/environment/app IDs and post-merge SHA to the ignored audit report and `log.md`. Mark #415 complete only after main and tag protection readbacks both match. Keep #416 open until the first real app-backed release becomes Latest and its VERSION/tag/tested SHA agree.
 
-- [ ] **Step 5: Prepare the first controlled-release checklist**
+- [x] **Step 5: Prepare the first controlled-release checklist**
 
 Before the next version dispatch, confirm the version bump updates VERSION, CHANGELOG, and the rendered README badge in one PR. After the merge SHA's three tests pass, dispatch from `main`, wait for `validate`, approve `release`, observe `publish`, and inspect the resulting immutable Release before any retry or issue closure.

--- a/docs/superpowers/specs/2026-08-22-release-app-design.md
+++ b/docs/superpowers/specs/2026-08-22-release-app-design.md
@@ -1,8 +1,8 @@
 # Dedicated Release App Design
 
-**Status:** Owner-approved design; implementation in progress; release-tag ruleset pending post-merge Task 7
+**Status:** Implemented and externally verified; first controlled publication remains pending
 **Date:** 2026-08-22
-**Issues:** #402, #415, #416
+**Issues:** #402 closed; #415 closed; #416 open pending first controlled Latest Release
 **Decision authority:** `docs/decisions/remediation-guardrails.md`
 
 ## Outcome
@@ -11,7 +11,7 @@ Public `v*` tags and GitHub Releases will be created only by a repository-scoped
 
 This closes the gap exposed when GitHub rejected its built-in Actions integration as a tag-ruleset bypass actor for this personal repository. It preserves the existing rule that the tag and GitHub Release are created together by one controlled API call.
 
-This document defines the approved target trust boundary. The App and protected environment are live and the workflow implementation is in progress, but no release-tag ruleset is active until Task 7 creates it after merge and verifies it by API readback.
+This trust boundary is implemented and externally verified. PR #433 merged at `05a1c7b55cccde92786918ab18ee85a6de2aa5cc`; `Protect main` (ID `21204190`) and `Protect release tags` (ID `21211977`) are active with their approved no-bypass and sole-App-bypass policies. No controlled App-backed tag or GitHub Release has been published yet.
 
 ## Security requirements
 
@@ -23,7 +23,7 @@ This document defines the approved target trust boundary. The App and protected 
 - The environment permits deployments only from `main`, requires Lane Becker (`lanebecker`, user ID `3211673`) as reviewer, and permits self-review so the sole owner can approve a release they dispatched.
 - The workflow's ordinary `GITHUB_TOKEN` has `contents: read`, `actions: read`, and `checks: read`; it cannot publish.
 - The app token explicitly requests only `contents: write`, is scoped to the current repository, is masked, expires within one hour, and is revoked automatically after its job.
-- After Task 7 activation and API readback, the `v*` tag ruleset names the installed release app as its sole bypass actor and restricts creation, deletion, and non-fast-forward updates. Until then this is approved target state, not a live control.
+- The API-verified `Protect release tags` ruleset targets `refs/tags/v*`, names the installed release app as its sole bypass actor in `always` mode, and restricts creation, deletion, and non-fast-forward updates. Humans, administrators, ordinary `GITHUB_TOKEN`, and other apps have no bypass.
 - GitHub immutable releases remains enabled.
 
 ## External objects
@@ -54,20 +54,20 @@ The app is not public and is not installed on any other repository.
 
 GitHub must withhold the environment secret until the required reviewer approves the job.
 
-### Release-tag ruleset (approved target; pending Task 7)
+### Release-tag ruleset (active and API-verified)
 
 - **Name:** `Protect release tags`
 - **Target:** tags matching `refs/tags/v*`
-- **Current state:** not active; creation is intentionally deferred until the merged workflow and post-merge checks are green
-- **Target enforcement after Task 7 API readback:** active
+- **Ruleset ID:** `21211977`
+- **Current enforcement:** active; created only after PR #433 merged and exact-SHA post-merge checks passed
 - **Bypass actors:** the installed `vinyl-now-playing-release-lbecker` app only, mode `always`
 - **Rules:** restrict creation, restrict deletion, block non-fast-forward updates
 
-The existing `Protect main` ruleset remains separate and retains no bypass actors.
+`Protect main` (ruleset ID `21204190`) remains separate and retains no bypass actors.
 
 ## Workflow architecture
 
-`.github/workflows/release.yml` becomes a two-job workflow.
+`.github/workflows/release.yml` is a two-job workflow.
 
 ```mermaid
 flowchart LR
@@ -153,18 +153,18 @@ Before merge:
 - `git diff --check` passes;
 - the PR's Python 3.11/3.12/3.13 tests and dependency audits pass.
 
-After merge and post-merge checks:
+Verified after merge and post-merge checks:
 
 - the app installation lists only `vinyl-now-playing`;
 - the environment lists only `main`, Lane as reviewer, the Client ID variable, and the private-key secret;
 - `Protect main` remains active with no bypass;
 - the built-in `GITHUB_TOKEN` no longer has write permission in `release.yml`;
 
-After Task 7 creates the ruleset and API readback verifies it:
+Verified after Task 7 creation and API readback:
 
 - `Protect release tags` is active with only the release app bypass;
 
-After the first controlled publication:
+Still pending — after the first controlled publication:
 
 - the first controlled publication produces one immutable tag and one GitHub Release for the same tested current-main SHA.
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -229,9 +229,13 @@ ordinary workflow token remains read-only.
 5. If the release API fails or times out, inspect both tag and GitHub Release
    state before rerunning. Never retry an ambiguous creation blindly.
 
-Do not dispatch a real release until post-merge verification is green and the
-`Protect release tags` ruleset has been activated and read back with App ID
-`4684884` as its sole bypass actor.
+Active ruleset `Protect release tags` (ID `21211977`) has been read back with App
+ID `4684884` as its sole bypass actor. A real release still requires a green
+exact-`main` matrix, successful read-only validation, and Lane's environment
+approval; never bypass that sequence or retry an ambiguous creation blindly.
+No controlled App-backed tag or GitHub Release has been published yet; #416
+remains open until the first controlled publication is Latest and its VERSION,
+newest tag, and tested SHA agree.
 
 ---
 


### PR DESCRIPTION
## Summary

- update the durable release guardrail, design, implementation plan, and testing guide from pending Task 7 state to the verified active state
- record merge SHA `05a1c7b55cccde92786918ab18ee85a6de2aa5cc`, Protect main ruleset `21204190`, and Protect release tags ruleset `21211977`
- record #402 and #415 closed while #416 remains open until the first controlled App-backed Latest Release
- preserve the explicit fact that no controlled release has been dispatched yet

## Verification

- documentation-only four-file scope, rebased cleanly on current main
- version metadata passes for 1.5.34
- `git diff --check` clean
- independent status-document review: SPEC PASS / QUALITY PASS, zero open findings

No workflow, credential, App, environment, ruleset, tag, Release, or product behavior changes are included in this PR.