### PR TITLE
Wave 1: harden Pi preflight and deployment gates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,5 +87,16 @@ jobs:
           pip install -r requirements.txt
       - name: Smoke-test audio backend
         run: python -I scripts/check_audio_backend.py
+      - name: Render and verify system service
+        run: |
+          set -euo pipefail
+          tmp_dir="$(mktemp -d)"
+          app_dir="$tmp_dir/app"
+          mkdir -p "$app_dir/venv/bin"
+          touch "$app_dir/config.yaml" "$app_dir/main.py" "$tmp_dir/Xauthority"
+          chmod 600 "$app_dir/config.yaml"
+          ln -s "$(command -v python)" "$app_dir/venv/bin/python3"
+          python -I scripts/render_system_service.py --user root --app-dir "$app_dir" --display :0 --xauthority "$tmp_dir/Xauthority" --output "$tmp_dir/vinyl-now-playing.service"
+          systemd-analyze verify "$tmp_dir/vinyl-now-playing.service"
       - name: Run tests
         run: pytest -q

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,6 +97,6 @@ jobs:
           chmod 600 "$app_dir/config.yaml"
           ln -s "$(command -v python)" "$app_dir/venv/bin/python3"
           python -I scripts/render_system_service.py --user root --app-dir "$app_dir" --display :0 --xauthority "$tmp_dir/Xauthority" --output "$tmp_dir/vinyl-now-playing.service"
-          systemd-analyze verify "$tmp_dir/vinyl-now-playing.service"
+          /usr/bin/systemd-analyze verify "$tmp_dir/vinyl-now-playing.service"
       - name: Run tests
         run: pytest -q

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,6 +86,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Smoke-test audio backend
-        run: python scripts/check_audio_backend.py
+        run: python -I scripts/check_audio_backend.py
       - name: Run tests
         run: pytest -q

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,8 +63,8 @@ jobs:
         python-version: ['3.11', '3.12', '3.13']   # R6-33: 3.12 now tested (pi-setup-guide claims it)
     env:
       # Make pygame headless: SDL needs no real video/audio device in CI. The
-      # sounddevice import is stubbed by tests/conftest.py before any test module
-      # loads, so no PortAudio system package is required either.
+      # test fallback remains hardware-free, but a separate process proves the
+      # real sounddevice package and PortAudio boundary before pytest starts.
       SDL_VIDEODRIVER: dummy
       SDL_AUDIODRIVER: dummy
     steps:
@@ -77,9 +77,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+      - name: Install PortAudio
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libportaudio2
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Smoke-test audio backend
+        run: python scripts/check_audio_backend.py
       - name: Run tests
         run: pytest -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ Versions follow [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.PATCH`.
 
 ## [Unreleased]
 
+### Security and deployment controls
+
+- **Wave 1 software preflight controls are implemented (#418, #156, #419).**
+  Startup rejects group/other-readable POSIX `config.yaml` files before parsing;
+  CI installs PortAudio and authenticates the installed `sounddevice` API surface
+  before pytest; and the repository now owns a validated, atomic renderer for
+  the system service that CI parses with `/usr/bin/systemd-analyze verify`.
+  These controls do not claim UCA222 operation, session authorization, cold boot,
+  time sync, or shutdown success on a Pi.
+- **The #366 Discogs live probe now requires an explicit named record and write
+  authorization.** It remains read-only by default and requires a designated
+  custom-folder record plus an interactive exact `yes` (or pre-authorized
+  `--yes`) before one write. The live folder result remains pending; no
+  folder-ID propagation change is implied or closed yet.
+
 ## [1.5.35] — 2026-08-22
 
 ### Security and release trust

--- a/conftest.py
+++ b/conftest.py
@@ -10,28 +10,52 @@ test_*.py filename — so pytest never collects it and the old collect_ignore
 workaround (T-7) is no longer needed.
 
 TQ-6: capture.py and main.py import ``sounddevice``, which needs the PortAudio
-system library at import time.  This conftest is imported before any test
-module, so installing a stub here (module scope) makes those imports succeed on
-machines without PortAudio — replacing the two ``sys.modules.setdefault(...)``
-lines that used to sit at module scope in test_capture.py and test_main_wiring.py
-and were NEVER restored (a MagicMock leaked into sys.modules for the rest of the
-process, visible to every other test module).  ``setdefault`` semantics are
-preserved: a real sounddevice (a dev Mac with PortAudio) is left untouched, and
-every test patches ``src.audio.capture.sd`` explicitly regardless.  The
-``pytest_sessionfinish`` hook removes ONLY a stub we installed, so it can't leak
-into a larger enclosing process.
+system library at import time. This conftest is imported before any test module,
+so it first tries the installed backend, then installs a fallback stub only when
+that import fails. This replaces the two ``sys.modules.setdefault(...)`` lines
+that used to sit at module scope in test_capture.py and test_main_wiring.py and
+were NEVER restored (a MagicMock leaked into sys.modules for the rest of the
+process, visible to every other test module). Every test patches
+``src.audio.capture.sd`` explicitly regardless. The ``pytest_sessionfinish``
+hook removes ONLY the exact stub object this conftest installed, so it cannot
+remove a real or third-party-owned module.
 """
+import importlib
 import sys
 from unittest.mock import MagicMock
 
-# Install before any test module imports capture.py / main.py. Record whether we
-# actually installed it, so teardown never pops a real sounddevice.
-_SOUNDDEVICE_STUB_INSTALLED = "sounddevice" not in sys.modules
-if _SOUNDDEVICE_STUB_INSTALLED:
-    sys.modules["sounddevice"] = MagicMock()
+
+def _load_sounddevice_or_install_stub(importer=importlib.import_module, modules=None):
+    """Retain an importable backend, or install and return this conftest's stub."""
+    if modules is None:
+        modules = sys.modules
+
+    try:
+        return importer("sounddevice"), None
+    except Exception:
+        # A third party can have supplied a module after a failed import attempt.
+        # It is not ours to overwrite or later remove.
+        existing_module = modules.get("sounddevice")
+        if existing_module is not None:
+            return existing_module, None
+
+        stub = MagicMock(name="sounddevice-test-fallback")
+        modules["sounddevice"] = stub
+        return stub, stub
+
+
+def _remove_owned_sounddevice_stub(modules, owned_stub):
+    """Remove the fallback only while it remains the exact object we installed."""
+    if owned_stub is not None and modules.get("sounddevice") is owned_stub:
+        modules.pop("sounddevice", None)
+
+
+# Install before any test module imports capture.py / main.py. The CI workflow
+# validates the real package in a separate process before pytest starts; this
+# fallback keeps hardware-free unit tests runnable on development machines.
+_SOUNDDEVICE_MODULE, _SOUNDDEVICE_STUB = _load_sounddevice_or_install_stub()
 
 
 def pytest_sessionfinish(session, exitstatus):
     """Remove the sounddevice stub we planted, if any (TQ-6 teardown)."""
-    if _SOUNDDEVICE_STUB_INSTALLED:
-        sys.modules.pop("sounddevice", None)
+    _remove_owned_sounddevice_stub(sys.modules, _SOUNDDEVICE_STUB)

--- a/deploy/vinyl-now-playing.service.in
+++ b/deploy/vinyl-now-playing.service.in
@@ -1,0 +1,21 @@
+[Unit]
+Description=vinyl-now-playing
+Wants=network-online.target
+After=network-online.target time-sync.target graphical.target
+StartLimitIntervalSec=300
+StartLimitBurst=10
+
+[Service]
+Type=simple
+User=@SERVICE_USER@
+WorkingDirectory=@APP_DIR@
+Environment="DISPLAY=@DISPLAY@"
+Environment="XAUTHORITY=@XAUTHORITY@"
+ExecStart=@APP_DIR@/venv/bin/python3 @APP_DIR@/main.py
+Restart=on-failure
+RestartPreventExitStatus=78
+RestartSec=15
+TimeoutStopSec=30
+
+[Install]
+WantedBy=graphical.target

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -996,7 +996,10 @@ The only remaining feature/validation work requires hardware:
   `sd.InputStream` integration only: the overlapping-window logic is
   unit-tested hardware-free via `tests/test_chunking.py`, and device
   matching, config guards, and constructor plumbing via `tests/test_capture.py`
-  (v1.3.5, using a stubbed sounddevice module)
+  (v1.3.5, explicitly patching the capture surface). Root `conftest.py` retains
+  a real `sounddevice` import when available and installs an owned fallback only
+  when import fails; CI separately authenticates the installed backend before
+  pytest.
 - **Shazam recognition testing** — needs real audio input
 - **Display rendering testing** — needs the Waveshare HDMI display
 - **End-to-end integration** — full needle-drop → Discogs-updated flow on hardware

--- a/docs/decisions/remediation-guardrails.md
+++ b/docs/decisions/remediation-guardrails.md
@@ -127,7 +127,9 @@ The first controlled App-backed publication is immutable Latest Release `v1.5.35
   proves the installed `sounddevice` distribution exposes `query_devices`,
   `InputStream`, `_terminate`, and `_initialize` before pytest. Root
   `conftest.py` owns a fallback stub only when real import fails. CI is not USB
-  or stream-operation proof.
+  or stream-operation proof; Pi acceptance still requires the app-level real
+  `InputStream`/unplug/replug procedure, capture recovery, and an unchanged
+  system-service MainPID.
 - **#419 / R10-15:** `deploy/vinyl-now-playing.service.in` plus
   `scripts/render_system_service.py` are the only supported service source and
   renderer. Rendering validates literal-safe values, a `0600` config, and
@@ -140,9 +142,9 @@ The first controlled App-backed publication is immutable Latest Release `v1.5.35
 
 ### Later waves
 
-- Wave 1 software controls are implemented; #418/#419 Pi evidence and #366's
-  real custom-folder result remain pending. The system-service decision is
-  preserved throughout.
+- Wave 1 software controls are implemented; #418/#419 Pi evidence, #156's real
+  InputStream/hot-plug recovery, and #366's real custom-folder result remain
+  pending. The system-service decision is preserved throughout.
 - Wave 2 preserves immortal positive collection reads during normal operation; only a definitive missing-instance write may invalidate, refresh, and permit one identity-safe retry.
 - Wave 3 preserves recognition freshness, confirmation timestamps, epoch gates, and spin deduplication while isolating Last.fm latency.
 - Wave 4 keeps floor-based dependency manifests and Python 3.11 compatibility; it does not introduce a platform-specific lockfile implicitly.

--- a/docs/decisions/remediation-guardrails.md
+++ b/docs/decisions/remediation-guardrails.md
@@ -4,7 +4,7 @@ This is the tracked ledger of decisions that remediation work must preserve. It 
 
 Update this file whenever the owner changes a listed decision, a remediation establishes a new cross-cutting invariant, or a closed/deferred issue becomes relevant again. Do not duplicate detailed implementation history here; link to its durable source.
 
-**Last reconciled:** 2026-08-22, during Round 10 release-trust remediation.
+**Last reconciled:** 2026-08-22, during Wave 1 Pi-preflight implementation.
 
 ## Authority and conflict order
 
@@ -40,13 +40,26 @@ Workspace safety is part of the contract: every handoff command block begins by 
 - Prefer a missed Discogs credit to a phantom or wrong-record credit.
 - Ambiguous external-write outcomes are not retried automatically when a retry could double-apply.
 - Discogs write targets require safe release and instance identity; never guess across ambiguous owned releases.
+- The #366 diagnostic remains read-only by default. A live write requires explicit
+  artist and album plus exact interactive confirmation (or an already-authorized
+  `--yes`); record a custom-folder before/after/outcome and inspect ambiguity
+  before any retry.
 - Confirmation, session epoch, side coverage, and per-spin deduplication gates remain load-bearing unless the owner explicitly changes the product behavior.
 
 ### Runtime and deployment
 
 - Supported Python is 3.11, 3.12, and 3.13; Raspberry Pi OS compatibility, not the local Python 3.9 `.venv`, controls dependency decisions.
-- The application remains a system service. Preserve the network/time ordering and retry semantics established by #83 and #201.
-- `config.yaml` contains write-capable secrets, remains untracked, and must be mode `0600` on the appliance.
+- The application remains a system service. Its versioned template/renderer—not
+  a copied or hand-edited unit—preserves the network/time ordering and retry
+  semantics established by #83 and #201. Do not substitute a user-service
+  migration for image-specific Wayland/Xwayland diagnosis.
+- `config.yaml` contains write-capable secrets, remains untracked, and must be
+  mode `0600` on the appliance. Startup checks the open file before parsing;
+  the renderer checks it without changing it.
+- CI must install PortAudio and authenticate the installed `sounddevice`
+  distribution/API surface before pytest's fallback stub can exist. This does
+  not establish real UCA222, stream, hot-plug, session-auth, cold-boot, or
+  shutdown behavior.
 - Hardware-only claims stay hypotheses until the first-boot checklist records real-device evidence.
 
 ### Release and repository governance
@@ -104,9 +117,32 @@ Workspace safety is part of the contract: every handoff command block begins by 
 
 The first controlled App-backed publication is immutable Latest Release `v1.5.35`, created by run `32600568406` from exact tested `main` SHA `4b79513b6811c1884be42dadbb1d45f2354d70a6` after Lane approved the protected environment. VERSION, tag target, Release target, and linked tested SHA agree; its notes record supported Python and Raspberry Pi OS versions; post-tag consistency run `32600637687` passed. Exact-SHA dependency-audit run `32600494489` also passed on Python 3.11/3.12/3.13. Issues #295, #402, #415, #416, and #417 are closed. Manual tag creation remains prohibited.
 
+### Wave 1 — Pi preflight and deployability
+
+- **#418 / R10-04:** POSIX startup rejects a `config.yaml` with any group/other
+  mode bit before YAML parsing and names the `chmod 600` repair without exposing
+  contents. Unsupported mode semantics warn and continue. The appliance mode
+  readback remains a first-boot gate.
+- **#156 / R10-06:** every supported Ubuntu leg installs `libportaudio2` and
+  proves the installed `sounddevice` distribution exposes `query_devices`,
+  `InputStream`, `_terminate`, and `_initialize` before pytest. Root
+  `conftest.py` owns a fallback stub only when real import fails. CI is not USB
+  or stream-operation proof.
+- **#419 / R10-15:** `deploy/vinyl-now-playing.service.in` plus
+  `scripts/render_system_service.py` are the only supported service source and
+  renderer. Rendering validates literal-safe values, a `0600` config, and
+  output/template identity; it writes atomically and leaves credentials alone.
+  CI runs `/usr/bin/systemd-analyze verify`; actual display auth, cold boot,
+  synchronized time, and SIGTERM remain Pi evidence gates.
+- **#366:** the safer explicit write probe is implemented, but the custom-folder
+  result is pending. Do not add folder-ID propagation or close the issue until
+  one designated non-default-folder record has a documented before/after/outcome.
+
 ### Later waves
 
-- Wave 1 preserves the system-service decision and treats #366 as a real-hardware gate.
+- Wave 1 software controls are implemented; #418/#419 Pi evidence and #366's
+  real custom-folder result remain pending. The system-service decision is
+  preserved throughout.
 - Wave 2 preserves immortal positive collection reads during normal operation; only a definitive missing-instance write may invalidate, refresh, and permit one identity-safe retry.
 - Wave 3 preserves recognition freshness, confirmation timestamps, epoch gates, and spin deduplication while isolating Last.fm latency.
 - Wave 4 keeps floor-based dependency manifests and Python 3.11 compatibility; it does not introduce a platform-specific lockfile implicitly.

--- a/docs/first-boot-checklist.md
+++ b/docs/first-boot-checklist.md
@@ -60,13 +60,69 @@ contents into this checklist.
 | Gate | Command / observation | Non-secret evidence to record | Good result |
 |---|---|---|---|
 | Private config (#418) | `stat -c '%a %n' /home/pi/vinyl-now-playing/config.yaml` | Path and mode | `600`; any other mode is repaired with `chmod 600`, then the app is restarted. |
-| Real audio package and UCA222 (#156) | `cd /home/pi/vinyl-now-playing && venv/bin/python3 -I scripts/check_audio_backend.py`; then `venv/bin/python3 -c "import sounddevice; print(sounddevice.query_devices())"` | Package/API smoke result; selected UCA222 name/index/input channels; unplug/replug result | Smoke succeeds and the UCA222 is enumerated again after one unplug/replug. |
-| Display/session choice (#419) | In the logged-in graphical terminal: `printf 'DISPLAY=%s\\nXAUTHORITY=%s\\n' "$DISPLAY" "${XAUTHORITY:-<unset>}"` | Chosen `DISPLAY`, absolute Xauthority/session-auth path, and whether Xwayland was used | The selected values are rendered into the system service and it opens the display. |
-| Cold boot, clock, and shutdown (#83/#201/#419) | Reboot once; inspect `timedatectl`, `systemctl status vinyl-now-playing`, and the journal; then issue `sudo systemctl stop vinyl-now-playing` | Cold-boot result; `System clock synchronized` value; service status; SIGTERM stop outcome/time | Clock is synchronized before startup, the service survives the graphical-session race, and SIGTERM stops cleanly within `TimeoutStopSec=30`. |
-| Custom-folder Discogs probe (#366) | Follow the explicit confirmed command in `docs/testing-guide.md` for one sacrificial non-default-folder record | Artist/album, release ID, instance ID, field name, before/after values, HTTP/outcome; no token | Success disproves the hypothesis. A 404 or ambiguity is preserved as evidence with no blind retry. |
+| Real audio package and UCA222 (#156) | Follow the live InputStream/hot-plug procedure below after the package smoke | Package/API smoke result; selected UCA222 name/index/input channels; stream-open/audio evidence; loss/recovery journal lines; MainPID before/after; whether restart was needed | The app receives audio before and after one unplug/replug with the same MainPID. |
+| Display/session choice (#419) | In the logged-in graphical terminal: `printf 'DISPLAY=%s\nXAUTHORITY=%s\n' "$DISPLAY" "${XAUTHORITY:-<unset>}"`; if unset, use the read-only Xwayland `-auth` discovery in `pi-setup-guide.md` §12 | Chosen `DISPLAY`, absolute Xauthority/session-auth path, service-user readability, whether Xwayland was used, cold-boot path stability | The selected values are rendered into the system service, readable by its user, and work again after cold boot. |
+| Cold boot, clock, and shutdown (#83/#201/#419) | Reboot once; inspect `timedatectl`, `systemctl status vinyl-now-playing`, and the journal; use the timed SIGTERM procedure below | Cold-boot result; `System clock synchronized` value; service status; timed SIGTERM outcome; post-stop restart/status | Clock is synchronized before startup, the service survives the graphical-session race, and SIGTERM stops cleanly within `TimeoutStopSec=30`. |
+| Custom-folder Discogs probe (#366) | Follow the same-target read-only and one confirmed-write commands in `docs/testing-guide.md` | Artist/album, release ID, instance ID, custom-folder name/ID, field name, before/after values, HTTP/outcome; no token | Success disproves the hypothesis. A 404 or ambiguity is preserved as evidence with no blind retry. |
 
 CI has already checked the installed package/API boundary and system-unit syntax;
 it cannot close any of these hardware or external-state gates.
+
+### Real InputStream and hot-plug proof (#156)
+
+Run this only after the service is rendered and started. It does not change
+configuration or write to Discogs. Keep a journal window visible, then play a
+record long enough to produce a `Play session started.` event: that proves the
+application's real `sd.InputStream` is delivering callbacks, not merely that the
+device table can be queried.
+
+```bash
+cd /home/pi/vinyl-now-playing
+venv/bin/python3 -I scripts/check_audio_backend.py
+sudo systemctl restart vinyl-now-playing
+VNP_MAINPID_BEFORE="$(sudo systemctl show --property=MainPID --value vinyl-now-playing)"
+test "$VNP_MAINPID_BEFORE" -gt 0
+printf 'MainPID before unplug=%s\n' "$VNP_MAINPID_BEFORE"
+sudo journalctl -u vinyl-now-playing --since '2 minutes ago' -f
+```
+
+With the journal following, confirm the initial audio event, unplug the UCA222
+while capture is active, wait at least five seconds, then replug it and play
+audio again. Record the capture-loss evidence (`audio stream stalled` or `Audio
+capture error`), the post-replug audio event, and any `Using audio device [...]`
+line. Stop the journal follow with `Ctrl+C` (do not restart the service), then
+prove the process did not restart:
+
+```bash
+VNP_MAINPID_AFTER="$(sudo systemctl show --property=MainPID --value vinyl-now-playing)"
+printf 'MainPID after replug=%s\n' "$VNP_MAINPID_AFTER"
+test "$VNP_MAINPID_BEFORE" = "$VNP_MAINPID_AFTER"
+sudo systemctl status vinyl-now-playing
+```
+
+**Good:** input callbacks produce an event both before and after replug, the
+journal shows the retry/recovery path, and the MainPID is unchanged. A changed
+PID, no post-replug audio event, or a private-API degradation warning is failed
+hardware evidence; record it rather than claiming #156 complete.
+
+### Timed SIGTERM proof and restart
+
+After recording normal service behavior, measure the managed stop, inspect its
+journal result, then bring the appliance back for the remaining checklist:
+
+```bash
+VNP_STOP_STARTED="$(date +%s)"
+sudo systemctl stop vinyl-now-playing
+VNP_STOP_FINISHED="$(date +%s)"
+printf 'SIGTERM stop elapsed=%ss\n' "$((VNP_STOP_FINISHED - VNP_STOP_STARTED))"
+sudo journalctl -u vinyl-now-playing --since "@$VNP_STOP_STARTED" --no-pager
+sudo systemctl start vinyl-now-playing
+sudo systemctl status vinyl-now-playing
+```
+
+Record the elapsed seconds and relevant shutdown journal lines. The stop must
+complete within `TimeoutStopSec=30`; the final status command must show the
+service started again before moving on.
 
 ## 2. Audio input is the right device
 

--- a/docs/first-boot-checklist.md
+++ b/docs/first-boot-checklist.md
@@ -21,14 +21,15 @@ above the traceback (ARCH-10). Three failure modes:
   could not open a video device. Check, in order: (1) the HDMI cable is seated and
   the panel was powered on **before** the Pi booted (HDMI hot-plug is unreliable on
   the Pi); (2) a desktop / X server is actually running on the target `DISPLAY`
-  (default `:0`) — the systemd unit sets `Environment="DISPLAY=:0"` and
-  `Environment="XAUTHORITY=/home/pi/.Xauthority"`, so those must match your logged-in
-  session; `echo $DISPLAY` in the Pi's desktop terminal confirms the value.
+  (often `:0`) — the rendered systemd unit's `DISPLAY` and `XAUTHORITY` values
+  must match the logged-in session; `echo $DISPLAY` in the Pi's desktop terminal
+  confirms only the display value.
   ⚠️ On current Raspberry Pi OS the default session is **Wayland** (labwc/wayfire):
   `DISPLAY=:0` reaches it via Xwayland, but `/home/pi/.Xauthority` often doesn't
-  exist there, so if the unit can't open the display see the "Wayland note" beside
-  the systemd unit in `pi-setup-guide.md` §12 (point `XAUTHORITY` at the Xwayland
-  auth file, or use a systemd *user* service). Check the live mode with
+  exist there, so if the unit can't open the display see the "Wayland/Xwayland
+  evidence required" note in `pi-setup-guide.md` §12. Keep the system service;
+  point its rendered `XAUTHORITY` at the selected session-auth file. Check the
+  live mode with
   `wlr-randr`, not `xrandr` (the latter shows only an XWAYLAND virtual output).
 - **"Failed to construct the application components … cover_art_cache_dir … not
   writable."** The on-disk cover cache directory can't be created. Check that
@@ -51,7 +52,23 @@ times and then drop to a `failed` state rather than loop forever — so `systemc
 status vinyl-now-playing` showing `failed`/`start-limit-hit` here means "fix the
 above and `systemctl reset-failed`", not "the Pi is wedged".
 
-## 1. Audio input is the right device
+## 1. Wave 1 deployability evidence (record before calling it complete)
+
+Record values only; never paste a config value, Discogs token, or auth-file
+contents into this checklist.
+
+| Gate | Command / observation | Non-secret evidence to record | Good result |
+|---|---|---|---|
+| Private config (#418) | `stat -c '%a %n' /home/pi/vinyl-now-playing/config.yaml` | Path and mode | `600`; any other mode is repaired with `chmod 600`, then the app is restarted. |
+| Real audio package and UCA222 (#156) | `cd /home/pi/vinyl-now-playing && venv/bin/python3 -I scripts/check_audio_backend.py`; then `venv/bin/python3 -c "import sounddevice; print(sounddevice.query_devices())"` | Package/API smoke result; selected UCA222 name/index/input channels; unplug/replug result | Smoke succeeds and the UCA222 is enumerated again after one unplug/replug. |
+| Display/session choice (#419) | In the logged-in graphical terminal: `printf 'DISPLAY=%s\\nXAUTHORITY=%s\\n' "$DISPLAY" "${XAUTHORITY:-<unset>}"` | Chosen `DISPLAY`, absolute Xauthority/session-auth path, and whether Xwayland was used | The selected values are rendered into the system service and it opens the display. |
+| Cold boot, clock, and shutdown (#83/#201/#419) | Reboot once; inspect `timedatectl`, `systemctl status vinyl-now-playing`, and the journal; then issue `sudo systemctl stop vinyl-now-playing` | Cold-boot result; `System clock synchronized` value; service status; SIGTERM stop outcome/time | Clock is synchronized before startup, the service survives the graphical-session race, and SIGTERM stops cleanly within `TimeoutStopSec=30`. |
+| Custom-folder Discogs probe (#366) | Follow the explicit confirmed command in `docs/testing-guide.md` for one sacrificial non-default-folder record | Artist/album, release ID, instance ID, field name, before/after values, HTTP/outcome; no token | Success disproves the hypothesis. A 404 or ambiguity is preserved as evidence with no blind retry. |
+
+CI has already checked the installed package/API boundary and system-unit syntax;
+it cannot close any of these hardware or external-state gates.
+
+## 2. Audio input is the right device
 
 The config matches `audio.device_name` as a **case-insensitive substring** against
 the device list and uses the *first* match.
@@ -65,7 +82,7 @@ the device list and uses the *first* match.
 
 **Good:** one clean "Using audio device" line naming the UCA222, no multi-match warning.
 
-## 2. Tune `audio.silence_threshold_rms` to the room (the big knob)
+## 3. Tune `audio.silence_threshold_rms` to the room (the big knob)
 
 This is the one value that genuinely can't be set without the hardware — it's the
 RMS energy line between "music" and "silence," and it depends on your turntable,
@@ -94,7 +111,7 @@ though the log shows no `MUSIC_STOPPED`, the run-out noise is sitting in the
 hysteresis dead band `[½·threshold, threshold)`; raise the threshold so the dead
 band clears it.
 
-## 3. Cover-art download works over the real network (S-7 smoke test)
+## 4. Cover-art download works over the real network (S-7 smoke test)
 
 The SSRF-hardened, **IP-pinned HTTPS** cover fetch (resolve once → connect to the
 vetted IP → TLS verified against the hostname) is unit-tested with a *mocked*
@@ -127,7 +144,7 @@ real CDN**. Verify it once on the Pi.
 - If a cover fails to decode and you see it re-fetch within the track, that's the
   B-18 corrupt-file recovery working as intended.
 
-## 4. Recognition + the churn breadcrumb
+## 5. Recognition + the churn breadcrumb
 
 Real Shazam calls only happen on hardware.
 
@@ -138,7 +155,7 @@ Real Shazam calls only happen on hardware.
   records bleeding, room noise), not failing outright. Conservative by design; the
   log is the signal, not a bug.
 
-## 5. Display geometry at the real resolution
+## 6. Display geometry at the real resolution
 
 The layout is resolution-independent and unit-tested across a matrix, but the
 renderer's **runtime title push-down** (long track titles shrinking/wrapping in
@@ -148,7 +165,7 @@ renderer's **runtime title push-down** (long track titles shrinking/wrapping in
   shrinks/wraps without colliding the artist/album/chips or the bottom
   meta/prev-next strip, at your actual 1024×600 panel.
 
-## 6. Full pipeline + autostart
+## 7. Full pipeline + autostart
 
 - Let a full side play through to the end and confirm: last track detected →
   after silence, `SESSION_ENDED` → **Discogs Play Count increments** (and Last
@@ -159,17 +176,17 @@ renderer's **runtime title push-down** (long track titles shrinking/wrapping in
 
 ---
 
-## 7. R8 bring-up probes (one-time checks from the Round-8 audit; R8-19/#362)
+## 8. R8 bring-up probes (one-time checks from the Round-8 audit; R8-19/#362)
 
 - **Pre-flight the recognition import on the Pi's own Python** before first run:
   `python3 -c "import shazamio"`. CI now hard-imports it per matrix leg
   (R8-08/#361), but the Pi's interpreter is the one that matters — a broken
   import surfaces only as NO MATCH FOUND under a healthy-looking service.
-- **Credit a record filed in a NON-default Discogs folder (R8-10/#366).** The
-  field write POSTs to virtual folder `0`; Discogs may 404 field edits for
-  instances filed in a custom folder. Watch the write succeed — if it 404s,
-  #366 jumps from hypothesis to fix (store the instance's real `folder_id` in
-  the index).
+- **Credit a record filed in a NON-default Discogs folder (R8-10/#366).** Follow
+  the explicit, interactive custom-folder probe in `docs/testing-guide.md` and
+  fill the evidence row above. The field write still uses virtual folder `0`; a
+  404 is evidence for a separate folder-ID propagation change, not a reason to
+  retry or to edit source constants.
 - **One Discogs token = one rate budget** for reader AND writer: during a long
   honoured Retry-After on a credit, recognition resolves may 429 and the
   display may briefly show NO MATCH FOUND. Self-heals — don't misdiagnose it

--- a/docs/first-boot-checklist.md
+++ b/docs/first-boot-checklist.md
@@ -60,7 +60,7 @@ contents into this checklist.
 | Gate | Command / observation | Non-secret evidence to record | Good result |
 |---|---|---|---|
 | Private config (#418) | `stat -c '%a %n' /home/pi/vinyl-now-playing/config.yaml` | Path and mode | `600`; any other mode is repaired with `chmod 600`, then the app is restarted. |
-| Real audio package and UCA222 (#156) | Follow the live InputStream/hot-plug procedure below after the package smoke | Package/API smoke result; selected UCA222 name/index/input channels; stream-open/audio evidence; loss/recovery journal lines; MainPID before/after; whether restart was needed | The app receives audio before and after one unplug/replug with the same MainPID. |
+| Real audio package and UCA222 (#156) | Follow the live InputStream/hot-plug procedure below after the package smoke | Package/API smoke result; selected UCA222 name/index/input channels; stream-open/audio evidence; loss/recovery journal lines; MainPID before/after; whether restart was needed; any Discogs/Last.fm side effect | The app receives audio before and after one unplug/replug with the same MainPID. |
 | Display/session choice (#419) | In the logged-in graphical terminal: `printf 'DISPLAY=%s\nXAUTHORITY=%s\n' "$DISPLAY" "${XAUTHORITY:-<unset>}"`; if unset, use the read-only Xwayland `-auth` discovery in `pi-setup-guide.md` §12 | Chosen `DISPLAY`, absolute Xauthority/session-auth path, service-user readability, whether Xwayland was used, cold-boot path stability | The selected values are rendered into the system service, readable by its user, and work again after cold boot. |
 | Cold boot, clock, and shutdown (#83/#201/#419) | Reboot once; inspect `timedatectl`, `systemctl status vinyl-now-playing`, and the journal; use the timed SIGTERM procedure below | Cold-boot result; `System clock synchronized` value; service status; timed SIGTERM outcome; post-stop restart/status | Clock is synchronized before startup, the service survives the graphical-session race, and SIGTERM stops cleanly within `TimeoutStopSec=30`. |
 | Custom-folder Discogs probe (#366) | Follow the same-target read-only and one confirmed-write commands in `docs/testing-guide.md` | Artist/album, release ID, instance ID, custom-folder name/ID, field name, before/after values, HTTP/outcome; no token | Success disproves the hypothesis. A 404 or ambiguity is preserved as evidence with no blind retry. |
@@ -71,10 +71,18 @@ it cannot close any of these hardware or external-state gates.
 ### Real InputStream and hot-plug proof (#156)
 
 Run this only after the service is rendered and started. It does not change
-configuration or write to Discogs. Keep a journal window visible, then play a
-record long enough to produce a `Play session started.` event: that proves the
-application's real `sd.InputStream` is delivering callbacks, not merely that the
-device table can be queried.
+configuration, but it runs the fully configured production app: recognizable
+audio can trigger its normal Discogs and Last.fm behavior, including a credit on
+failure/shutdown paths. Before restarting, the owner must authorize the probe and
+confirm the current app state is idle and unarmed (no current tracked record or
+pending completion). Start with non-recognizable audio where practical; obtain
+fresh owner authorization before using recognizable music. Record any external
+side effect—or the absence of one—alongside the hardware evidence.
+
+Keep a journal window visible, then play a record long enough to produce a
+`Play session started.` event: that proves the application's real
+`sd.InputStream` is delivering callbacks, not merely that the device table can
+be queried.
 
 ```bash
 cd /home/pi/vinyl-now-playing

--- a/docs/pi-setup-guide.md
+++ b/docs/pi-setup-guide.md
@@ -199,7 +199,16 @@ nano config.yaml
 > 🔒 `config.yaml` holds two write-scope secrets (the Discogs user token and the
 > Last.fm session key). `cp` creates it world-readable (`644`) under the default
 > umask, so `chmod 600` restricts it to your user — matching the `0600` the
-> session-key helper already used for its own output.
+> session-key helper already used for its own output. Startup and the system-unit
+> renderer reject any group/other-readable mode before parsing or deploying the
+> file; verify the mode without printing its contents:
+
+```bash
+stat -c '%a %n' config.yaml
+```
+
+**Good:** `600 config.yaml`. Repair any other result with `chmod 600 config.yaml`;
+do not place secrets on a command line or in the service unit.
 
 Key values to fill in:
 
@@ -311,9 +320,15 @@ python scripts/discogs_live_check.py
 
 Up to four read-only tests run (`get_tracklist` runs only if your test album is
 found in the collection, so a collection miss shows three). All that run should
-pass. If test 1 (search_collection) misses, see `docs/testing-guide.md` — the
-album strings at the top of the script may need adjusting to match a record you
-actually own. (R8-25/#365)
+pass. If test 1 (`search_collection`) misses, pass the desired record explicitly,
+without editing source constants:
+
+```bash
+python scripts/discogs_live_check.py --artist "Artist" --album "Album"
+```
+
+The write probe is documented in `docs/testing-guide.md`; it must use a named,
+reversible custom-folder record and explicit authorization. (R8-25/#365)
 
 ---
 
@@ -372,52 +387,72 @@ To exit: `Ctrl+C`.
 
 ---
 
-## 12. Set up autostart with systemd
+## 12. Set up autostart with the versioned system service
 
-Once the manual run works, set it up to start automatically on boot.
+The supported architecture is a **system service**. Do not copy a unit into
+`/etc` or migrate to a user service as a Wayland workaround: the repository's
+versioned `deploy/vinyl-now-playing.service.in` and renderer preserve the
+network/time ordering and retry behavior already ratified in #83 and #201.
 
-Create the service file:
+From a terminal in the logged-in graphical session, record the values that the
+installed image actually uses before rendering. Raspberry Pi OS sessions vary:
+on Wayland, pygame reaches the desktop through Xwayland and the correct
+Xauthority/session-auth path is image-specific. Do not assume
+`/home/pi/.Xauthority` exists.
 
 ```bash
-sudo nano /etc/systemd/system/vinyl-now-playing.service
+printf 'DISPLAY=%s\nXAUTHORITY=%s\n' "$DISPLAY" "${XAUTHORITY:-<unset>}"
 ```
 
-Paste this (adjust the username if you're not using `pi`):
+Choose the working X display (for example `:0`) and the absolute auth-file path
+from that session. The renderer accepts only literal-safe absolute paths. The
+following uses the common Xwayland example; replace **only** the values after
+`--display` and `--xauthority` with the values you observed.
 
-```ini
-[Unit]
-Description=vinyl-now-playing
-Wants=network-online.target
-After=network-online.target time-sync.target graphical.target
-StartLimitIntervalSec=300
-StartLimitBurst=10
+Before replacing an existing known-good unit, preserve it for rollback:
 
-[Service]
-Type=simple
-User=pi
-WorkingDirectory=/home/pi/vinyl-now-playing
-Environment="DISPLAY=:0"
-Environment="XAUTHORITY=/home/pi/.Xauthority"
-ExecStart=/home/pi/vinyl-now-playing/venv/bin/python3 main.py
-Restart=on-failure
-RestartPreventExitStatus=78
-RestartSec=15
-TimeoutStopSec=30
-
-[Install]
-WantedBy=graphical.target
+```bash
+sudo cp -p /etc/systemd/system/vinyl-now-playing.service \
+  /etc/systemd/system/vinyl-now-playing.service.last-known-good
 ```
 
-> ⚠️ **Wayland note (#200) — verify on your image.** This unit assumes the app can
-> reach an **X11** display via `DISPLAY=:0` + `~/.Xauthority`. The app uses
-> pygame/SDL2, which reaches the default Wayland session through Xwayland — but
-> `/home/pi/.Xauthority` may not exist on a Wayland session, in which case SDL2
-> can fail to open the display and the service won't start. After enabling the
-> unit, confirm it actually comes up: `journalctl -u vinyl-now-playing -n 50`. If
-> it can't open the display, the fix is session-specific (point `XAUTHORITY` at
-> the running Xwayland auth file, or run this as a systemd **user** service, which
-> inherits the session's `DISPLAY`/`WAYLAND_DISPLAY`/`XDG_RUNTIME_DIR`) — treat it
-> as a bring-up step, since the right value depends on your flashed image.
+Skip that backup only on the first installation, when the destination does not
+yet exist. Then render, parse-check, load, enable, and start the unit:
+
+```bash
+cd /home/pi/vinyl-now-playing
+stat -c '%a %n' config.yaml
+sudo /home/pi/vinyl-now-playing/venv/bin/python3 \
+  /home/pi/vinyl-now-playing/scripts/render_system_service.py \
+  --user pi \
+  --app-dir /home/pi/vinyl-now-playing \
+  --display :0 \
+  --xauthority /home/pi/.Xauthority \
+  --output /etc/systemd/system/vinyl-now-playing.service
+sudo /usr/bin/systemd-analyze verify /etc/systemd/system/vinyl-now-playing.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now vinyl-now-playing
+sudo systemctl status vinyl-now-playing
+```
+
+The `stat` command must report `600 config.yaml`; the renderer refuses to write
+the unit otherwise and never changes that mode for you. It is idempotent:
+re-running it with the same inputs reports that the service is already current.
+`/usr/bin/systemd-analyze verify` checks unit syntax before systemd consumes it;
+it does not prove that the selected display/auth file is valid on this Pi.
+
+The rendered unit preserves `Wants=network-online.target`,
+`After=network-online.target time-sync.target graphical.target`,
+`StartLimitIntervalSec=300`, `StartLimitBurst=10`, `RestartSec=15`,
+`RestartPreventExitStatus=78`, and `TimeoutStopSec=30`. Those are operational
+requirements, not values to tune ad hoc in `/etc`.
+
+> ⚠️ **Wayland/Xwayland evidence required.** If the service cannot open the
+> display, keep the system-service design and correct the selected
+> `DISPLAY`/Xauthority path from the live session, then re-render and re-verify.
+> Record the observed session values and the result in
+> `docs/first-boot-checklist.md`; they cannot be inferred from CI or another Pi
+> image.
 
 `TimeoutStopSec=30` (CRIT-3) is the backstop for shutdown. On SIGTERM the app
 cancels its legs, drains any in-flight end-of-session Discogs credit (bounded to
@@ -452,7 +487,7 @@ crash still exits with a different non-zero code and restarts as normal.
 > `Restart=on-failure` restarts a *crash* (non-zero exit) but NOT a clean exit (`0`)
 > — and closing the display window or pressing **ESC** quits the app cleanly. So a
 > stray keyboard tap or an accidental window close stops the service until you run
-> `sudo systemctl restart vinyl-now-playing` (or `--user` for a user unit). If this
+> `sudo systemctl restart vinyl-now-playing`. If this
 > bites in practice, avoid ESC on the appliance; the window is fullscreen, so an
 > accidental close is unlikely.
 
@@ -528,25 +563,35 @@ systemd-time-wait-sync.service` shows it still starting, blocking on the clock,
 and `journalctl -u vinyl-now-playing` stays quiet rather than logging an error).
 It needs the network for recognition anyway, so this costs nothing in practice.
 
-Enable and start:
-
-```bash
-sudo systemctl daemon-reload
-sudo systemctl enable vinyl-now-playing
-sudo systemctl start vinyl-now-playing
-```
-
-Check status:
-
-```bash
-sudo systemctl status vinyl-now-playing
-```
-
 View live logs:
 
 ```bash
 journalctl -u vinyl-now-playing -f
 ```
+
+### Roll back without weakening credentials
+
+After a successful first boot, record the release tag/commit and interpreter
+that proved good, and keep the rendered-unit backup above with the corresponding
+known-good virtual environment or release checkout. On a later regression,
+restore the saved unit, point the application directory and `venv` back to that
+recorded tag/checkout, then verify and restart:
+
+```bash
+cd /home/pi/vinyl-now-playing
+git describe --tags --always
+venv/bin/python3 --version
+sudo cp -p /etc/systemd/system/vinyl-now-playing.service.last-known-good \
+  /etc/systemd/system/vinyl-now-playing.service
+sudo /usr/bin/systemd-analyze verify /etc/systemd/system/vinyl-now-playing.service
+sudo systemctl daemon-reload
+sudo systemctl restart vinyl-now-playing
+```
+
+If the last-known-good release lives in a different checkout, restore its saved
+venv and re-render its unit with that checkout as `--app-dir` before the verify
+step. Never recover by loosening `config.yaml` permissions, copying its contents,
+or editing the generated unit by hand.
 
 ### Cap the log disk usage (recommended for the SD card)
 
@@ -674,8 +719,9 @@ discogs.com/settings/developers.
 
 **systemd service fails to start**
 Check `journalctl -u vinyl-now-playing -n 50` for the actual error. Common
-causes: `DISPLAY` not set (add `Environment="DISPLAY=:0"` to the service file),
-or the venv path is wrong (verify with `which python3` inside the activated venv).
+causes: an incorrect observed `DISPLAY`/Xauthority path or a wrong app/venv path.
+Correct the renderer inputs, then render and run `/usr/bin/systemd-analyze verify`
+again; do not edit the generated unit in place.
 
 **App starts but pygame window is invisible, or the unit lands in `failed`**
 The system service can start before the autologin *session* is up and accepting
@@ -685,9 +731,8 @@ target exists only in the per-*user* systemd manager, and the system manager
 silently ignores ordering on units it doesn't have. The unit above already
 mitigates the race with `RestartSec=15` + `StartLimitBurst=10` (#201), retrying
 across ~2.5 min of session bring-up instead of exhausting five tries in ~50s. If a
-slow cold boot still outlasts that, either:
-- recover with `sudo systemctl reset-failed vinyl-now-playing && sudo systemctl start vinyl-now-playing`, or
-- make startup wait for the display socket by adding, under `[Service]`:
-  `ExecStartPre=/bin/sh -c 'until [ -S /tmp/.X11-unix/X0 ]; do sleep 1; done'`
-  (bounded by `TimeoutStartSec`; on the Wayland-default session the socket
-  appears once Xwayland is up).
+slow cold boot still outlasts that, recover with
+`sudo systemctl reset-failed vinyl-now-playing && sudo systemctl start vinyl-now-playing`
+after diagnosing the selected session-auth path. Preserve the versioned unit;
+capture the evidence and make any additional readiness behavior a reviewed
+template change rather than an ad hoc edit under `/etc`.

--- a/docs/pi-setup-guide.md
+++ b/docs/pi-setup-guide.md
@@ -402,15 +402,18 @@ date. Configure the timezone, enable the waiter, and confirm synchronization
 **before** the first `enable --now` or `start` of `vinyl-now-playing`:
 
 ```bash
-cd /home/pi/vinyl-now-playing
-sudo timedatectl set-timezone America/Chicago   # replace with your IANA timezone
-sudo systemctl enable --now systemd-time-wait-sync.service
-timedatectl
-timedatectl show --property=NTPSynchronized --value
+(
+  set -euo pipefail
+  cd /home/pi/vinyl-now-playing
+  sudo timedatectl set-timezone America/Chicago   # replace with your IANA timezone
+  sudo systemctl enable --now systemd-time-wait-sync.service
+  timedatectl
+  test "$(timedatectl show --property=NTPSynchronized --value)" = yes
+)
 ```
 
-Do not start the app until the final command prints `yes` and `timedatectl`
-shows the chosen timezone. If it does not, inspect
+Do not start the app until this block succeeds and `timedatectl` shows the chosen
+timezone. If it fails, inspect
 `systemctl status systemd-time-wait-sync.service`; an offline Pi should wait for
 network time rather than write stale dates.
 
@@ -462,19 +465,24 @@ Skip that backup only on the first installation, when the destination does not
 yet exist. Then render, parse-check, load, enable, and start the unit:
 
 ```bash
-cd /home/pi/vinyl-now-playing
-stat -c '%a %n' config.yaml
-sudo /home/pi/vinyl-now-playing/venv/bin/python3 \
-  /home/pi/vinyl-now-playing/scripts/render_system_service.py \
-  --user pi \
-  --app-dir /home/pi/vinyl-now-playing \
-  --display "$VNP_DISPLAY" \
-  --xauthority "$VNP_XAUTHORITY" \
-  --output /etc/systemd/system/vinyl-now-playing.service
-sudo /usr/bin/systemd-analyze verify /etc/systemd/system/vinyl-now-playing.service
-sudo systemctl daemon-reload
-sudo systemctl enable --now vinyl-now-playing
-sudo systemctl status vinyl-now-playing
+(
+  set -euo pipefail
+  : "${VNP_DISPLAY:?Run the session-auth discovery block first.}"
+  : "${VNP_XAUTHORITY:?Run the session-auth discovery block first.}"
+  cd /home/pi/vinyl-now-playing
+  test "$(stat -c '%a' config.yaml)" = 600
+  sudo /home/pi/vinyl-now-playing/venv/bin/python3 \
+    /home/pi/vinyl-now-playing/scripts/render_system_service.py \
+    --user pi \
+    --app-dir /home/pi/vinyl-now-playing \
+    --display "$VNP_DISPLAY" \
+    --xauthority "$VNP_XAUTHORITY" \
+    --output /etc/systemd/system/vinyl-now-playing.service
+  sudo /usr/bin/systemd-analyze verify /etc/systemd/system/vinyl-now-playing.service
+  sudo systemctl daemon-reload
+  sudo systemctl enable --now vinyl-now-playing
+  sudo systemctl status vinyl-now-playing
+)
 ```
 
 The `stat` command must report `600 config.yaml`; the renderer refuses to write
@@ -594,21 +602,47 @@ create a detached known-good worktree and copy its working virtual environment.
 This does not read, print, or copy `config.yaml`.
 
 ```bash
-cd /home/pi/vinyl-now-playing
-VNP_KNOWN_GOOD_REF="$(git rev-parse HEAD)"
-VNP_KNOWN_GOOD_DIR=/home/pi/vinyl-now-playing-known-good
-test ! -e "$VNP_KNOWN_GOOD_DIR"
-git worktree add --detach "$VNP_KNOWN_GOOD_DIR" "$VNP_KNOWN_GOOD_REF"
-cp -a venv "$VNP_KNOWN_GOOD_DIR/venv"
-sudo cp -p /etc/systemd/system/vinyl-now-playing.service \
-  /etc/systemd/system/vinyl-now-playing.service.last-known-good
-printf 'known-good ref=%s\nknown-good venv=%s\n' "$VNP_KNOWN_GOOD_REF" \
-  "$VNP_KNOWN_GOOD_DIR/venv"
+(
+  set -euo pipefail
+  cd /home/pi/vinyl-now-playing
+  VNP_KNOWN_GOOD_REF="$(git rev-parse HEAD)"
+  VNP_KNOWN_GOOD_DIR=/home/pi/vinyl-now-playing-known-good
+  VNP_UNIT_BACKUP=/etc/systemd/system/vinyl-now-playing.service.last-known-good
+  VNP_WORKTREE_ADDED=0
+  cleanup_known_good() {
+    local exit_status=$?
+    trap - ERR
+    if [ "$VNP_WORKTREE_ADDED" -eq 1 ]; then
+      git worktree remove --force "$VNP_KNOWN_GOOD_DIR" || true
+    fi
+    exit "$exit_status"
+  }
+  trap cleanup_known_good ERR
+  test ! -e "$VNP_KNOWN_GOOD_DIR"
+  test ! -e "$VNP_UNIT_BACKUP"
+  git worktree add --detach "$VNP_KNOWN_GOOD_DIR" "$VNP_KNOWN_GOOD_REF"
+  VNP_WORKTREE_ADDED=1
+  cp -a venv "$VNP_KNOWN_GOOD_DIR/venv"
+  "$VNP_KNOWN_GOOD_DIR/venv/bin/python3" --version
+  "$VNP_KNOWN_GOOD_DIR/venv/bin/python3" -m pip check
+  (
+    cd "$VNP_KNOWN_GOOD_DIR"
+    "$VNP_KNOWN_GOOD_DIR/venv/bin/python3" -I scripts/check_audio_backend.py
+    "$VNP_KNOWN_GOOD_DIR/venv/bin/python3" -I -c 'import shazamio'
+  )
+  sudo cp -p /etc/systemd/system/vinyl-now-playing.service "$VNP_UNIT_BACKUP"
+  trap - ERR
+  printf 'known-good ref=%s\nknown-good venv=%s\n' "$VNP_KNOWN_GOOD_REF" \
+    "$VNP_KNOWN_GOOD_DIR/venv"
+)
 ```
 
 The detached worktree preserves the exact application source, and its copied
-venv preserves the interpreter/dependency set that was observed working. Keep
-the recorded display/auth values with the first-boot evidence. Do not alter the
+venv preserves the interpreter/dependency set that was observed working. The
+block refuses an existing worktree or unit-backup target, removes a newly-added
+worktree if setup fails, and proves the relocated interpreter, dependency graph,
+audio smoke, and Shazam import before declaring the target known-good. Keep the
+recorded display/auth values with the first-boot evidence. Do not alter the
 known-good worktree while testing an upgrade.
 
 ### Roll back without weakening credentials
@@ -619,24 +653,27 @@ that worktree's unit and restart it. Replace the two recorded values below with
 the values that passed the session-auth evidence gate.
 
 ```bash
-cd /home/pi/vinyl-now-playing
-VNP_KNOWN_GOOD_DIR=/home/pi/vinyl-now-playing-known-good
-VNP_DISPLAY=:0                         # replace with the recorded display
-VNP_XAUTHORITY=/absolute/auth/path      # replace with the recorded auth path
-sudo systemctl stop vinyl-now-playing
-mv /home/pi/vinyl-now-playing/config.yaml "$VNP_KNOWN_GOOD_DIR/config.yaml"
-stat -c '%a %n' "$VNP_KNOWN_GOOD_DIR/config.yaml"
-sudo "$VNP_KNOWN_GOOD_DIR/venv/bin/python3" \
-  "$VNP_KNOWN_GOOD_DIR/scripts/render_system_service.py" \
-  --user pi \
-  --app-dir "$VNP_KNOWN_GOOD_DIR" \
-  --display "$VNP_DISPLAY" \
-  --xauthority "$VNP_XAUTHORITY" \
-  --output /etc/systemd/system/vinyl-now-playing.service
-sudo /usr/bin/systemd-analyze verify /etc/systemd/system/vinyl-now-playing.service
-sudo systemctl daemon-reload
-sudo systemctl start vinyl-now-playing
-sudo systemctl status vinyl-now-playing
+(
+  set -euo pipefail
+  cd /home/pi/vinyl-now-playing
+  VNP_KNOWN_GOOD_DIR=/home/pi/vinyl-now-playing-known-good
+  VNP_DISPLAY=:0                         # replace with the recorded display
+  VNP_XAUTHORITY=/absolute/auth/path      # replace with the recorded auth path
+  sudo systemctl stop vinyl-now-playing
+  mv /home/pi/vinyl-now-playing/config.yaml "$VNP_KNOWN_GOOD_DIR/config.yaml"
+  test "$(stat -c '%a' "$VNP_KNOWN_GOOD_DIR/config.yaml")" = 600
+  sudo "$VNP_KNOWN_GOOD_DIR/venv/bin/python3" \
+    "$VNP_KNOWN_GOOD_DIR/scripts/render_system_service.py" \
+    --user pi \
+    --app-dir "$VNP_KNOWN_GOOD_DIR" \
+    --display "$VNP_DISPLAY" \
+    --xauthority "$VNP_XAUTHORITY" \
+    --output /etc/systemd/system/vinyl-now-playing.service
+  sudo /usr/bin/systemd-analyze verify /etc/systemd/system/vinyl-now-playing.service
+  sudo systemctl daemon-reload
+  sudo systemctl start vinyl-now-playing
+  sudo systemctl status vinyl-now-playing
+)
 ```
 
 The mode readback must remain `600`. The primary checkout intentionally has no

--- a/docs/pi-setup-guide.md
+++ b/docs/pi-setup-guide.md
@@ -608,30 +608,38 @@ This does not read, print, or copy `config.yaml`.
   VNP_KNOWN_GOOD_REF="$(git rev-parse HEAD)"
   VNP_KNOWN_GOOD_DIR=/home/pi/vinyl-now-playing-known-good
   VNP_UNIT_BACKUP=/etc/systemd/system/vinyl-now-playing.service.last-known-good
-  VNP_WORKTREE_ADDED=0
+  VNP_UNIT_BACKUP_TMP=/etc/systemd/system/.vinyl-now-playing.service.last-known-good.$$.tmp
+  VNP_WORKTREE_ATTEMPTED=0
   cleanup_known_good() {
-    local exit_status=$?
-    trap - ERR
-    if [ "$VNP_WORKTREE_ADDED" -eq 1 ]; then
-      git worktree remove --force "$VNP_KNOWN_GOOD_DIR" || true
+    local exit_status="$1"
+    # Work from a directory outside the worktree before removing that worktree.
+    cd /home/pi || exit "$exit_status"
+    if [ "$VNP_WORKTREE_ATTEMPTED" -eq 1 ]; then
+      git -C /home/pi/vinyl-now-playing worktree remove --force "$VNP_KNOWN_GOOD_DIR" || true
+    fi
+    # This is the one exact temporary file used for the atomic unit backup.
+    if [ -e "$VNP_UNIT_BACKUP_TMP" ]; then
+      sudo rm -f -- "$VNP_UNIT_BACKUP_TMP" || true
     fi
     exit "$exit_status"
   }
-  trap cleanup_known_good ERR
-  test ! -e "$VNP_KNOWN_GOOD_DIR"
-  test ! -e "$VNP_UNIT_BACKUP"
-  git worktree add --detach "$VNP_KNOWN_GOOD_DIR" "$VNP_KNOWN_GOOD_REF"
-  VNP_WORKTREE_ADDED=1
-  cp -a venv "$VNP_KNOWN_GOOD_DIR/venv"
-  "$VNP_KNOWN_GOOD_DIR/venv/bin/python3" --version
-  "$VNP_KNOWN_GOOD_DIR/venv/bin/python3" -m pip check
+  test ! -e "$VNP_KNOWN_GOOD_DIR" || exit 1
+  test ! -e "$VNP_UNIT_BACKUP" || exit 1
+  test ! -e "$VNP_UNIT_BACKUP_TMP" || exit 1
+  test -f /etc/systemd/system/vinyl-now-playing.service || exit 1
+  VNP_WORKTREE_ATTEMPTED=1
+  git worktree add --detach "$VNP_KNOWN_GOOD_DIR" "$VNP_KNOWN_GOOD_REF" || cleanup_known_good $?
+  cp -a venv "$VNP_KNOWN_GOOD_DIR/venv" || cleanup_known_good $?
+  "$VNP_KNOWN_GOOD_DIR/venv/bin/python3" --version || cleanup_known_good $?
+  "$VNP_KNOWN_GOOD_DIR/venv/bin/python3" -m pip check || cleanup_known_good $?
   (
     cd "$VNP_KNOWN_GOOD_DIR"
     "$VNP_KNOWN_GOOD_DIR/venv/bin/python3" -I scripts/check_audio_backend.py
     "$VNP_KNOWN_GOOD_DIR/venv/bin/python3" -I -c 'import shazamio'
-  )
-  sudo cp -p /etc/systemd/system/vinyl-now-playing.service "$VNP_UNIT_BACKUP"
-  trap - ERR
+  ) || cleanup_known_good $?
+  sudo cp -p /etc/systemd/system/vinyl-now-playing.service "$VNP_UNIT_BACKUP_TMP" || cleanup_known_good $?
+  sudo mv -f -- "$VNP_UNIT_BACKUP_TMP" "$VNP_UNIT_BACKUP" || cleanup_known_good $?
+  VNP_UNIT_BACKUP_TMP=
   printf 'known-good ref=%s\nknown-good venv=%s\n' "$VNP_KNOWN_GOOD_REF" \
     "$VNP_KNOWN_GOOD_DIR/venv"
 )
@@ -640,10 +648,13 @@ This does not read, print, or copy `config.yaml`.
 The detached worktree preserves the exact application source, and its copied
 venv preserves the interpreter/dependency set that was observed working. The
 block refuses an existing worktree or unit-backup target, removes a newly-added
-worktree if setup fails, and proves the relocated interpreter, dependency graph,
-audio smoke, and Shazam import before declaring the target known-good. Keep the
-recorded display/auth values with the first-boot evidence. Do not alter the
-known-good worktree while testing an upgrade.
+worktree if any post-worktree step fails, and proves the relocated interpreter,
+dependency graph, audio smoke, and Shazam import before declaring the target
+known-good. The unit backup is copied only to its exact temporary path, then
+atomically moved into place; failed attempts remove that exact temporary path so
+they cannot block a retry. Keep the recorded display/auth values with the
+first-boot evidence. Do not alter the known-good worktree while testing an
+upgrade.
 
 ### Roll back without weakening credentials
 

--- a/docs/pi-setup-guide.md
+++ b/docs/pi-setup-guide.md
@@ -394,6 +394,26 @@ The supported architecture is a **system service**. Do not copy a unit into
 versioned `deploy/vinyl-now-playing.service.in` and renderer preserve the
 network/time ordering and retry behavior already ratified in #83 and #201.
 
+### Prepare the clock gate before the first application start
+
+The Raspberry Pi has no battery-backed real-time clock. Starting the app before
+network time is synchronized can write a wrong, irreversible **Last Played**
+date. Configure the timezone, enable the waiter, and confirm synchronization
+**before** the first `enable --now` or `start` of `vinyl-now-playing`:
+
+```bash
+cd /home/pi/vinyl-now-playing
+sudo timedatectl set-timezone America/Chicago   # replace with your IANA timezone
+sudo systemctl enable --now systemd-time-wait-sync.service
+timedatectl
+timedatectl show --property=NTPSynchronized --value
+```
+
+Do not start the app until the final command prints `yes` and `timedatectl`
+shows the chosen timezone. If it does not, inspect
+`systemctl status systemd-time-wait-sync.service`; an offline Pi should wait for
+network time rather than write stale dates.
+
 From a terminal in the logged-in graphical session, record the values that the
 installed image actually uses before rendering. Raspberry Pi OS sessions vary:
 on Wayland, pygame reaches the desktop through Xwayland and the correct
@@ -401,13 +421,35 @@ Xauthority/session-auth path is image-specific. Do not assume
 `/home/pi/.Xauthority` exists.
 
 ```bash
-printf 'DISPLAY=%s\nXAUTHORITY=%s\n' "$DISPLAY" "${XAUTHORITY:-<unset>}"
+cd /home/pi/vinyl-now-playing
+VNP_DISPLAY="${DISPLAY:?Run this in the logged-in graphical session.}"
+if [ -n "${XAUTHORITY:-}" ]; then
+  VNP_XAUTHORITY="$XAUTHORITY"
+else
+  VNP_XWAYLAND_PID="$(pgrep -n -u "$USER" Xwayland)" || {
+    echo "No Xwayland process found for $USER; inspect the active graphical session." >&2
+    exit 1
+  }
+  VNP_XAUTHORITY="$(tr '\0' '\n' < "/proc/$VNP_XWAYLAND_PID/cmdline" | \
+    awk 'previous == "-auth" { print; exit } { previous = $0 }')"
+fi
+if ! { test -n "$VNP_XAUTHORITY" && test -f "$VNP_XAUTHORITY" && test -r "$VNP_XAUTHORITY"; }; then
+  echo "No readable Xauthority path was found; do not render the service yet." >&2
+  exit 1
+fi
+if ! sudo -u pi test -r "$VNP_XAUTHORITY"; then
+  echo "The system-service user pi cannot read $VNP_XAUTHORITY; do not render yet." >&2
+  exit 1
+fi
+printf 'DISPLAY=%s\nXAUTHORITY=%s\n' "$VNP_DISPLAY" "$VNP_XAUTHORITY"
 ```
 
-Choose the working X display (for example `:0`) and the absolute auth-file path
-from that session. The renderer accepts only literal-safe absolute paths. The
-following uses the common Xwayland example; replace **only** the values after
-`--display` and `--xauthority` with the values you observed.
+The fallback branch reads the running Xwayland command line only, extracts the
+argument after `-auth`, and verifies that the system-service user (`pi` in this
+guide) can read it. Keep this shell open: the variables are passed directly to
+the renderer. The renderer accepts only literal-safe absolute paths. A later
+cold boot must prove that the selected auth path remains valid; a path found in
+one desktop session is not universal evidence.
 
 Before replacing an existing known-good unit, preserve it for rollback:
 
@@ -426,8 +468,8 @@ sudo /home/pi/vinyl-now-playing/venv/bin/python3 \
   /home/pi/vinyl-now-playing/scripts/render_system_service.py \
   --user pi \
   --app-dir /home/pi/vinyl-now-playing \
-  --display :0 \
-  --xauthority /home/pi/.Xauthority \
+  --display "$VNP_DISPLAY" \
+  --xauthority "$VNP_XAUTHORITY" \
   --output /etc/systemd/system/vinyl-now-playing.service
 sudo /usr/bin/systemd-analyze verify /etc/systemd/system/vinyl-now-playing.service
 sudo systemctl daemon-reload
@@ -523,36 +565,12 @@ with the in-process absolute page cap (`_MAX_COLLECTION_PAGES`, `reader.py`) tha
 bounds any *single* index build; the two together mean neither a runaway build nor
 a runaway restart can sit on the rate limit.
 
-**Why the `[Unit]` ordering matters — read this before enabling.** The Raspberry
-Pi has no battery-backed real-time clock, so at boot its clock is whatever
-`fake-hwclock` last saved — stale, sometimes by hours or days — until
-`systemd-timesyncd` reaches an NTP server *over the network*. If the app starts
-before that happens, every **Last Played** date it stamps into your Discogs
-collection is wrong, and the error is silent and irreversible. The ordering above
-holds the service until the network is actually up (`network-online.target`,
-which must be pulled in by the matching `Wants=` — ordering after it alone does
-nothing) and the clock has been synchronized (`time-sync.target`).
-
-One catch: `After=time-sync.target` only has teeth if the unit that *waits* for
-the clock is enabled. With plain `systemd-timesyncd`, `time-sync.target` can be
-reached **before** the clock is actually set. Enable the waiter once:
-
-```bash
-sudo systemctl enable systemd-time-wait-sync.service
-```
-
-Also set the Pi's timezone, so Last Played is stamped in your local time rather
-than the default zone:
-
-```bash
-sudo raspi-config
-```
-
-Choose **Localisation Options → Timezone**. (Non-interactive equivalent, using
-your own zone: `sudo timedatectl set-timezone America/Los_Angeles`.)
-
-Confirm both took effect with `timedatectl` — it should report
-`System clock synchronized: yes` and your chosen `Time zone`.
+**Why the `[Unit]` ordering matters.** The pre-start clock gate above gives
+`After=time-sync.target` real force: the unit waits for an actual synchronized
+clock and for `network-online.target`, which the matching `Wants=` pulls in.
+Without `systemd-time-wait-sync.service`, plain `systemd-timesyncd` can reach
+`time-sync.target` before the clock is set. The required `timedatectl` readback
+is therefore a first-start gate, not a best-effort post-install check.
 
 Two things to know about this gate. Enabling `systemd-time-wait-sync.service` is
 system-wide — it delays *every* unit ordered after `time-sync.target`; on this
@@ -569,29 +587,64 @@ View live logs:
 journalctl -u vinyl-now-playing -f
 ```
 
-### Roll back without weakening credentials
+### Prepare a concrete known-good rollback target before upgrading
 
-After a successful first boot, record the release tag/commit and interpreter
-that proved good, and keep the rendered-unit backup above with the corresponding
-known-good virtual environment or release checkout. On a later regression,
-restore the saved unit, point the application directory and `venv` back to that
-recorded tag/checkout, then verify and restart:
+After a successful first boot and **before** upgrading the primary checkout,
+create a detached known-good worktree and copy its working virtual environment.
+This does not read, print, or copy `config.yaml`.
 
 ```bash
 cd /home/pi/vinyl-now-playing
-git describe --tags --always
-venv/bin/python3 --version
-sudo cp -p /etc/systemd/system/vinyl-now-playing.service.last-known-good \
-  /etc/systemd/system/vinyl-now-playing.service
-sudo /usr/bin/systemd-analyze verify /etc/systemd/system/vinyl-now-playing.service
-sudo systemctl daemon-reload
-sudo systemctl restart vinyl-now-playing
+VNP_KNOWN_GOOD_REF="$(git rev-parse HEAD)"
+VNP_KNOWN_GOOD_DIR=/home/pi/vinyl-now-playing-known-good
+test ! -e "$VNP_KNOWN_GOOD_DIR"
+git worktree add --detach "$VNP_KNOWN_GOOD_DIR" "$VNP_KNOWN_GOOD_REF"
+cp -a venv "$VNP_KNOWN_GOOD_DIR/venv"
+sudo cp -p /etc/systemd/system/vinyl-now-playing.service \
+  /etc/systemd/system/vinyl-now-playing.service.last-known-good
+printf 'known-good ref=%s\nknown-good venv=%s\n' "$VNP_KNOWN_GOOD_REF" \
+  "$VNP_KNOWN_GOOD_DIR/venv"
 ```
 
-If the last-known-good release lives in a different checkout, restore its saved
-venv and re-render its unit with that checkout as `--app-dir` before the verify
-step. Never recover by loosening `config.yaml` permissions, copying its contents,
-or editing the generated unit by hand.
+The detached worktree preserves the exact application source, and its copied
+venv preserves the interpreter/dependency set that was observed working. Keep
+the recorded display/auth values with the first-boot evidence. Do not alter the
+known-good worktree while testing an upgrade.
+
+### Roll back without weakening credentials
+
+If an upgrade must be reversed, stop the failed service, **move** (never print
+or copy) the already-private config into the known-good worktree, then render
+that worktree's unit and restart it. Replace the two recorded values below with
+the values that passed the session-auth evidence gate.
+
+```bash
+cd /home/pi/vinyl-now-playing
+VNP_KNOWN_GOOD_DIR=/home/pi/vinyl-now-playing-known-good
+VNP_DISPLAY=:0                         # replace with the recorded display
+VNP_XAUTHORITY=/absolute/auth/path      # replace with the recorded auth path
+sudo systemctl stop vinyl-now-playing
+mv /home/pi/vinyl-now-playing/config.yaml "$VNP_KNOWN_GOOD_DIR/config.yaml"
+stat -c '%a %n' "$VNP_KNOWN_GOOD_DIR/config.yaml"
+sudo "$VNP_KNOWN_GOOD_DIR/venv/bin/python3" \
+  "$VNP_KNOWN_GOOD_DIR/scripts/render_system_service.py" \
+  --user pi \
+  --app-dir "$VNP_KNOWN_GOOD_DIR" \
+  --display "$VNP_DISPLAY" \
+  --xauthority "$VNP_XAUTHORITY" \
+  --output /etc/systemd/system/vinyl-now-playing.service
+sudo /usr/bin/systemd-analyze verify /etc/systemd/system/vinyl-now-playing.service
+sudo systemctl daemon-reload
+sudo systemctl start vinyl-now-playing
+sudo systemctl status vinyl-now-playing
+```
+
+The mode readback must remain `600`. The primary checkout intentionally has no
+`config.yaml` after a rollback; leave it that way until a deliberate retry. When
+preparing that retry, stop the service and move the same file back, verify `0600`,
+then render the selected worktree again. Never use a destructive checkout, loosen
+permissions, copy credential contents, or hand-edit the generated unit as a
+recovery shortcut.
 
 ### Cap the log disk usage (recommended for the SD card)
 

--- a/docs/pi-setup-guide.md
+++ b/docs/pi-setup-guide.md
@@ -632,11 +632,9 @@ This does not read, print, or copy `config.yaml`.
   cp -a venv "$VNP_KNOWN_GOOD_DIR/venv" || cleanup_known_good $?
   "$VNP_KNOWN_GOOD_DIR/venv/bin/python3" --version || cleanup_known_good $?
   "$VNP_KNOWN_GOOD_DIR/venv/bin/python3" -m pip check || cleanup_known_good $?
-  (
-    cd "$VNP_KNOWN_GOOD_DIR"
-    "$VNP_KNOWN_GOOD_DIR/venv/bin/python3" -I scripts/check_audio_backend.py
-    "$VNP_KNOWN_GOOD_DIR/venv/bin/python3" -I -c 'import shazamio'
-  ) || cleanup_known_good $?
+  cd "$VNP_KNOWN_GOOD_DIR" || cleanup_known_good $?
+  "$VNP_KNOWN_GOOD_DIR/venv/bin/python3" -I scripts/check_audio_backend.py || cleanup_known_good $?
+  "$VNP_KNOWN_GOOD_DIR/venv/bin/python3" -I -c 'import shazamio' || cleanup_known_good $?
   sudo cp -p /etc/systemd/system/vinyl-now-playing.service "$VNP_UNIT_BACKUP_TMP" || cleanup_known_good $?
   sudo mv -f -- "$VNP_UNIT_BACKUP_TMP" "$VNP_UNIT_BACKUP" || cleanup_known_good $?
   VNP_UNIT_BACKUP_TMP=

--- a/docs/pi-setup-guide.md
+++ b/docs/pi-setup-guide.md
@@ -346,7 +346,38 @@ appears as an input device — it should show a positive number of input channel
 
 ---
 
-## 11. First manual run
+## 11. Synchronize time, then run manually
+
+### Gate every application start on synchronized time
+
+The Raspberry Pi has no battery-backed real-time clock. Starting the app before
+network time is synchronized can write a wrong, irreversible **Last Played**
+date. The `NTPSynchronized=yes` gate applies to **every** application start,
+whether you run `main.py` manually or systemd starts
+`vinyl-now-playing.service`.
+
+Configure the timezone, enable the persistent waiter, and verify the current
+boot before this first manual run:
+
+```bash
+(
+  set -euo pipefail
+  cd /home/pi/vinyl-now-playing
+  sudo timedatectl set-timezone America/Chicago   # replace with your IANA timezone
+  sudo systemctl enable --now systemd-time-wait-sync.service
+  timedatectl
+  test "$(timedatectl show --property=NTPSynchronized --value)" = yes
+)
+```
+
+Do not start the app—manually or through systemd—until this block succeeds and
+`timedatectl` shows the chosen timezone. If it fails, inspect
+`systemctl status systemd-time-wait-sync.service`; an offline Pi should wait for
+network time rather than write stale dates. Before each later manual start,
+repeat the `NTPSynchronized` readback and require `yes`. Section 12's versioned
+system unit preserves the enabled waiter's time-ordering gate for systemd starts.
+
+### First manual run
 
 With the display connected, the UCA222 plugged in, and your turntable's RCA
 output going into the UCA222's inputs:
@@ -393,29 +424,6 @@ The supported architecture is a **system service**. Do not copy a unit into
 `/etc` or migrate to a user service as a Wayland workaround: the repository's
 versioned `deploy/vinyl-now-playing.service.in` and renderer preserve the
 network/time ordering and retry behavior already ratified in #83 and #201.
-
-### Prepare the clock gate before the first application start
-
-The Raspberry Pi has no battery-backed real-time clock. Starting the app before
-network time is synchronized can write a wrong, irreversible **Last Played**
-date. Configure the timezone, enable the waiter, and confirm synchronization
-**before** the first `enable --now` or `start` of `vinyl-now-playing`:
-
-```bash
-(
-  set -euo pipefail
-  cd /home/pi/vinyl-now-playing
-  sudo timedatectl set-timezone America/Chicago   # replace with your IANA timezone
-  sudo systemctl enable --now systemd-time-wait-sync.service
-  timedatectl
-  test "$(timedatectl show --property=NTPSynchronized --value)" = yes
-)
-```
-
-Do not start the app until this block succeeds and `timedatectl` shows the chosen
-timezone. If it fails, inspect
-`systemctl status systemd-time-wait-sync.service`; an offline Pi should wait for
-network time rather than write stale dates.
 
 From a terminal in the logged-in graphical session, record the values that the
 installed image actually uses before rendering. Raspberry Pi OS sessions vary:

--- a/docs/superpowers/plans/2026-08-22-wave1-pi-preflight.md
+++ b/docs/superpowers/plans/2026-08-22-wave1-pi-preflight.md
@@ -267,19 +267,19 @@ hardware-success claims, unsafe write instructions, and stale file paths.
 
 **Files:** all intended Wave 1 files; no production edits by reviewer.
 
-- [ ] **Step 1: Run focused local verification**
+- [x] **Step 1: Run focused local verification**
 
 ```bash
 cd '/private/tmp/vnp-release-app-identity' && test "$(git branch --show-current)" = 'codex/r10-wave1-pi-preflight' && '/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m py_compile src/config.py scripts/check_audio_backend.py scripts/render_system_service.py scripts/discogs_live_check.py && '/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m pytest -q tests/test_config.py tests/test_audio_backend_smoke.py tests/test_capture.py tests/test_main_wiring.py tests/test_ops_polish_r9.py tests/test_system_service.py tests/test_discogs_live_check.py tests/test_deployment_integrity_r10.py tests/test_workflow_integrity_r10.py && git diff --check
 ```
 
-- [ ] **Step 2: Run repository security/scope checks**
+- [x] **Step 2: Run repository security/scope checks**
 
 Verify no secret/private-key material, no tracked `config.yaml`, no user-service
 artifact, no unintended files, no staged files, and an explicit intended diff.
 Run workflow lint using the repository's pinned/cached actionlint procedure.
 
-- [ ] **Step 3: Independent broad adversarial review**
+- [x] **Step 3: Independent broad adversarial review**
 
 Review config TOCTOU/redaction, CI fake-package bypass, exact production API
 coverage, system-unit injection/partial writes/semantic drift, Discogs write

--- a/docs/superpowers/plans/2026-08-22-wave1-pi-preflight.md
+++ b/docs/superpowers/plans/2026-08-22-wave1-pi-preflight.md
@@ -234,7 +234,7 @@ ambiguous response paths. No reviewer executes a live network call.
 - Modify: `docs/decisions/remediation-guardrails.md`
 - Modify: `CHANGELOG.md`
 
-- [ ] **Step 1: Replace copy/paste drift with the versioned path**
+- [x] **Step 1: Replace copy/paste drift with the versioned path**
 
 Document exact renderer usage for `/etc/systemd/system/vinyl-now-playing.service`,
 then `systemd-analyze verify`, `daemon-reload`, enable/start, and status. Preserve
@@ -242,20 +242,20 @@ the system-service decision, #83/#201 rationale, time-sync waiter, and the
 image-specific Wayland/Xwayland warning. Remove any instruction suggesting a
 user-service migration as the Wave 1 fallback.
 
-- [ ] **Step 2: Add rollback and evidence forms**
+- [x] **Step 2: Add rollback and evidence forms**
 
 Document backup/restore of the last known-good rendered unit and venv/tag,
 `config.yaml` `0600` readback, UCA222 import/enumeration/hot-plug results,
 cold-boot/display/session/time-sync outcomes, and a redacted Discogs record
 before/after/HTTP result. Explicitly say CI does not close hardware gates.
 
-- [ ] **Step 3: Update durable status without premature closure**
+- [x] **Step 3: Update durable status without premature closure**
 
 Update the guardrail and changelog with the implemented software controls.
 Leave #366 and Wave 1 hardware state pending until observed. Correct the stale
 `tests/conftest.py` reference to root `conftest.py`.
 
-- [ ] **Step 4: Independent documentation review**
+- [x] **Step 4: Independent documentation review**
 
 Review against live issues #418/#156/#419/#366 and closed #83/#201/#301.
 Search for contradictory service type, retry values, permission advice,

--- a/docs/superpowers/plans/2026-08-22-wave1-pi-preflight.md
+++ b/docs/superpowers/plans/2026-08-22-wave1-pi-preflight.md
@@ -94,7 +94,7 @@ finding and rerun the focused suite before explicit-path staging.
 - Modify: `.github/workflows/tests.yml`
 - Modify: a focused workflow-integrity test file selected after inspecting current ownership
 
-- [ ] **Step 1: Write RED behavior and workflow tests**
+- [x] **Step 1: Write RED behavior and workflow tests**
 
 Test a pure `validate_backend(module)` function with a complete fake and one
 missing/non-callable case for each of `query_devices`, `InputStream`,
@@ -112,7 +112,7 @@ cd '/private/tmp/vnp-release-app-identity' && test "$(git branch --show-current)
 Expected RED: new script/API and workflow steps do not exist and conftest still
 tests only `sys.modules` membership.
 
-- [ ] **Step 2: Implement the isolated smoke and scoped fallback**
+- [x] **Step 2: Implement the isolated smoke and scoped fallback**
 
 Create a dependency-free CLI that imports `sounddevice`, validates the exact
 four callables, prints package version only as non-secret diagnostics, and exits
@@ -121,13 +121,13 @@ before pip dependencies and run `python scripts/check_audio_backend.py` before
 pytest on every matrix leg. Refactor conftest to attempt the real import and
 install/remove only its own fallback stub if that import fails.
 
-- [ ] **Step 3: Verify GREEN**
+- [x] **Step 3: Verify GREEN**
 
 Run the RED command, `tests/test_capture.py`, `tests/test_main_wiring.py`, and
 `tests/test_ops_polish_r9.py`, then `git diff --check`. Do not claim live device
 coverage.
 
-- [ ] **Step 4: Independent adversarial review**
+- [x] **Step 4: Independent adversarial review**
 
 Reviewer must mutate every required API away, move the smoke after pytest,
 remove PortAudio, simulate a pre-existing third-party module, and test teardown

--- a/docs/superpowers/plans/2026-08-22-wave1-pi-preflight.md
+++ b/docs/superpowers/plans/2026-08-22-wave1-pi-preflight.md
@@ -191,7 +191,7 @@ and a renderer that mutates config. Resolve all confirmed findings.
 - Modify: `scripts/discogs_live_check.py`
 - Modify: `tests/test_discogs_live_check.py`
 
-- [ ] **Step 1: Write RED tests**
+- [x] **Step 1: Write RED tests**
 
 Test `--artist` and `--album` flow through every displayed/search operation.
 Test that `--test-write` aborts without calling `increment_play_count` on `n`,
@@ -210,14 +210,14 @@ cd '/private/tmp/vnp-release-app-identity' && test "$(git branch --show-current)
 Expected RED: fixed constants and unconditional `--test-write` do not satisfy
 the selection/confirmation contract.
 
-- [ ] **Step 2: Implement selection and confirmation**
+- [x] **Step 2: Implement selection and confirmation**
 
 Make artist/album explicit CLI inputs with current constants only for read-only
 compatibility. A write requires both inputs to have been supplied explicitly.
 Prompt immediately before the one writer call; accept only `yes`. `--yes` is
 the noninteractive equivalent and must remain visually loud in the summary.
 
-- [ ] **Step 3: Verify GREEN and no-write mutations**
+- [x] **Step 3: Verify GREEN and no-write mutations**
 
 Run the focused suite and `git diff --check`. Reviewer must attempt absent
 arguments, EOF, whitespace/case variations, failed search, exception, and

--- a/docs/superpowers/plans/2026-08-22-wave1-pi-preflight.md
+++ b/docs/superpowers/plans/2026-08-22-wave1-pi-preflight.md
@@ -92,7 +92,7 @@ finding and rerun the focused suite before explicit-path staging.
 - Create: `tests/test_audio_backend_smoke.py`
 - Modify: `conftest.py`
 - Modify: `.github/workflows/tests.yml`
-- Modify: a focused workflow-integrity test file selected after inspecting current ownership
+- Modify: `tests/test_deployment_integrity_r10.py`
 
 - [x] **Step 1: Write RED behavior and workflow tests**
 
@@ -106,7 +106,7 @@ import is retained while import failure receives a centrally-owned stub.
 Run:
 
 ```bash
-cd '/private/tmp/vnp-release-app-identity' && test "$(git branch --show-current)" = 'codex/r10-wave1-pi-preflight' && '/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m pytest -q tests/test_audio_backend_smoke.py tests/test_workflow_integrity_r10.py
+cd '/private/tmp/vnp-release-app-identity' && test "$(git branch --show-current)" = 'codex/r10-wave1-pi-preflight' && '/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m pytest -q tests/test_audio_backend_smoke.py tests/test_deployment_integrity_r10.py
 ```
 
 Expected RED: new script/API and workflow steps do not exist and conftest still
@@ -142,7 +142,7 @@ ownership. Resolve confirmed findings before explicit-path staging.
 - Create: `scripts/render_system_service.py`
 - Create: `tests/test_system_service.py`
 - Modify: `.github/workflows/tests.yml`
-- Modify: the same focused workflow-integrity test file selected in Task 2
+- Modify: `tests/test_deployment_integrity_r10.py`
 
 - [x] **Step 1: Write RED renderer and invariant tests**
 
@@ -157,7 +157,7 @@ Ubuntu.
 Run:
 
 ```bash
-cd '/private/tmp/vnp-release-app-identity' && test "$(git branch --show-current)" = 'codex/r10-wave1-pi-preflight' && '/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m pytest -q tests/test_system_service.py tests/test_workflow_integrity_r10.py
+cd '/private/tmp/vnp-release-app-identity' && test "$(git branch --show-current)" = 'codex/r10-wave1-pi-preflight' && '/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m pytest -q tests/test_system_service.py tests/test_deployment_integrity_r10.py
 ```
 
 Expected RED: template, renderer, and CI verification do not exist.
@@ -270,7 +270,7 @@ hardware-success claims, unsafe write instructions, and stale file paths.
 - [ ] **Step 1: Run focused local verification**
 
 ```bash
-cd '/private/tmp/vnp-release-app-identity' && test "$(git branch --show-current)" = 'codex/r10-wave1-pi-preflight' && '/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m py_compile src/config.py scripts/check_audio_backend.py scripts/render_system_service.py scripts/discogs_live_check.py && '/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m pytest -q tests/test_config.py tests/test_audio_backend_smoke.py tests/test_capture.py tests/test_main_wiring.py tests/test_ops_polish_r9.py tests/test_system_service.py tests/test_discogs_live_check.py tests/test_workflow_integrity_r10.py && git diff --check
+cd '/private/tmp/vnp-release-app-identity' && test "$(git branch --show-current)" = 'codex/r10-wave1-pi-preflight' && '/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m py_compile src/config.py scripts/check_audio_backend.py scripts/render_system_service.py scripts/discogs_live_check.py && '/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m pytest -q tests/test_config.py tests/test_audio_backend_smoke.py tests/test_capture.py tests/test_main_wiring.py tests/test_ops_polish_r9.py tests/test_system_service.py tests/test_discogs_live_check.py tests/test_deployment_integrity_r10.py tests/test_workflow_integrity_r10.py && git diff --check
 ```
 
 - [ ] **Step 2: Run repository security/scope checks**

--- a/docs/superpowers/plans/2026-08-22-wave1-pi-preflight.md
+++ b/docs/superpowers/plans/2026-08-22-wave1-pi-preflight.md
@@ -1,0 +1,337 @@
+# Wave 1 Pi Preflight Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Apply superpowers:test-driven-development to every code or behavior change and superpowers:verification-before-completion before any pass claim. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make first deployment fail closed on exposed credentials, prove the real audio package in CI, version the supported system-service deployment, and make the deferred Discogs live write safe to execute.
+
+**Architecture:** Four narrow boundaries remain independent: open-file config security, a pre-pytest installed-package smoke, a validated system-unit renderer, and an explicitly confirmed live-write probe. CI/software tests establish deployability; the target Pi establishes hardware, session, and external-write truth.
+
+**Tech Stack:** Python 3.11–3.13, pytest, PyYAML, GitHub Actions, Ubuntu/apt, sounddevice/PortAudio, systemd, Discogs API.
+
+**Spec:** `docs/superpowers/specs/2026-08-22-wave1-pi-preflight-design.md`
+
+## Global Constraints
+
+- Work only in `/private/tmp/vnp-release-app-identity` on branch `codex/r10-wave1-pi-preflight`, based on `origin/main` SHA `3d92432396473aafbe6ee9db38c98109f5d36449`.
+- `DESIGN.md` is noncanonical. Preserve the owner-ratified system-service model and the historical contracts from #83 and #201.
+- Never read, print, stage, copy, or rewrite the ignored live `config.yaml`. It has already been contained at mode `0600` in the canonical clone.
+- Never use `git add -A`; stage only the explicit files owned by the current task.
+- Every test begins RED for the intended reason before production implementation. Record RED and GREEN commands/results in the SDD task report.
+- Use the canonical clone's venv only as this absolute interpreter:
+  `/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python`.
+- The local interpreter is unsupported Python 3.9.6 and the sandbox denies socket binds/fonts. The full local baseline is 16 failed, 1522 passed, 3 warnings. Do not normalize those known failures into product defects; require exact supported GitHub CI before merge.
+- No task may claim real UCA222, Wayland/Xwayland, cold-boot, time-sync, display, or Discogs semantics from mocks or CI.
+- Do not execute the Discogs write until Lane supplies the exact custom-folder artist/album and explicitly approves that one external write.
+
+## File and interface map
+
+| Task | Owns | Interface consumed by later tasks |
+|---|---|---|
+| 1 | `src/config.py`, `tests/test_config.py` | `load_config` rejects unsafe POSIX modes before YAML parsing. |
+| 2 | `scripts/check_audio_backend.py`, `tests/test_audio_backend_smoke.py`, `conftest.py`, `.github/workflows/tests.yml`, focused CI-contract tests | CLI returns nonzero unless the real installed module exposes every production-used API. |
+| 3 | `deploy/vinyl-now-playing.service.in`, `scripts/render_system_service.py`, `tests/test_system_service.py`, `.github/workflows/tests.yml` | Renderer validates inputs/config mode and atomically emits the sole supported system unit. |
+| 4 | `scripts/discogs_live_check.py`, `tests/test_discogs_live_check.py` | Write is impossible without explicit record selection plus confirmation/`--yes`. |
+| 5 | `docs/pi-setup-guide.md`, `docs/first-boot-checklist.md`, `docs/testing-guide.md`, `docs/decisions/remediation-guardrails.md`, `CHANGELOG.md` | One durable procedure and hardware evidence form for Tasks 1–4. |
+| 6 | all Wave 1 files | Fresh integrated verification and adversarial review; no implementation. |
+| 7 | GitHub PR/issues/milestone and target Pi | Exact-SHA CI, merge, issue evidence, then hardware-only closeout. |
+
+---
+
+### Task 1: Enforce `config.yaml` POSIX permissions before parsing (#418)
+
+**Files:**
+- Modify: `src/config.py`
+- Modify: `tests/test_config.py`
+
+- [ ] **Step 1: Write focused RED tests**
+
+Add a helper that writes valid YAML and explicitly chmods it `0600`. Add tests proving:
+
+1. `0600` parses normally.
+2. Each of `0640`, `0604`, and `0644` raises `ConfigError` naming the path and `chmod 600 <path>` without the sentinel token value.
+3. The permission decision uses `os.fstat` on the opened descriptor before `yaml.safe_load`; a mocked parser must not be called for an unsafe file.
+4. An injected unsupported-mode result logs one warning and continues.
+5. Existing empty/UTF-8/unreadable/directory tests retain their original error class/meaning; valid file fixtures use `0600`.
+
+Run:
+
+```bash
+cd '/private/tmp/vnp-release-app-identity' && test "$(git branch --show-current)" = 'codex/r10-wave1-pi-preflight' && '/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m pytest -q tests/test_config.py
+```
+
+Expected RED: only the new permission-contract tests fail because no open-file mode check exists.
+
+- [ ] **Step 2: Implement the minimum open-file guard**
+
+Inside the existing `with open(...) as f`, call a small private helper with
+`os.fstat(f.fileno())` before reading. On POSIX, evaluate `stat.S_IMODE` and
+raise `ConfigError` when `mode & 0o077`. When mode semantics are unavailable,
+log one warning and continue. Preserve all existing `ConfigError` normalization;
+do not chmod or inspect ownership in this change.
+
+- [ ] **Step 3: Verify GREEN and regression scope**
+
+Run the focused command above, then:
+
+```bash
+cd '/private/tmp/vnp-release-app-identity' && test "$(git branch --show-current)" = 'codex/r10-wave1-pi-preflight' && '/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m pytest -q tests/test_config.py tests/test_ops_polish_r9.py && git diff --check
+```
+
+- [ ] **Step 4: Independent spec and quality review**
+
+Reviewer must attempt secret-bearing `0644`, parse-before-check, directory,
+missing-file, and unsupported-platform mutations. Resolve every confirmed
+finding and rerun the focused suite before explicit-path staging.
+
+---
+
+### Task 2: Prove the installed audio backend before pytest stubbing (#156)
+
+**Files:**
+- Create: `scripts/check_audio_backend.py`
+- Create: `tests/test_audio_backend_smoke.py`
+- Modify: `conftest.py`
+- Modify: `.github/workflows/tests.yml`
+- Modify: a focused workflow-integrity test file selected after inspecting current ownership
+
+- [ ] **Step 1: Write RED behavior and workflow tests**
+
+Test a pure `validate_backend(module)` function with a complete fake and one
+missing/non-callable case for each of `query_devices`, `InputStream`,
+`_terminate`, and `_initialize`. Test CLI import failure redaction/actionability.
+Add workflow assertions requiring `libportaudio2` installation and the smoke
+command before `pytest`. Add a conftest helper test proving a successful real
+import is retained while import failure receives a centrally-owned stub.
+
+Run:
+
+```bash
+cd '/private/tmp/vnp-release-app-identity' && test "$(git branch --show-current)" = 'codex/r10-wave1-pi-preflight' && '/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m pytest -q tests/test_audio_backend_smoke.py tests/test_workflow_integrity_r10.py
+```
+
+Expected RED: new script/API and workflow steps do not exist and conftest still
+tests only `sys.modules` membership.
+
+- [ ] **Step 2: Implement the isolated smoke and scoped fallback**
+
+Create a dependency-free CLI that imports `sounddevice`, validates the exact
+four callables, prints package version only as non-secret diagnostics, and exits
+nonzero with an actionable message on failure. In CI install `libportaudio2`
+before pip dependencies and run `python scripts/check_audio_backend.py` before
+pytest on every matrix leg. Refactor conftest to attempt the real import and
+install/remove only its own fallback stub if that import fails.
+
+- [ ] **Step 3: Verify GREEN**
+
+Run the RED command, `tests/test_capture.py`, `tests/test_main_wiring.py`, and
+`tests/test_ops_polish_r9.py`, then `git diff --check`. Do not claim live device
+coverage.
+
+- [ ] **Step 4: Independent adversarial review**
+
+Reviewer must mutate every required API away, move the smoke after pytest,
+remove PortAudio, simulate a pre-existing third-party module, and test teardown
+ownership. Resolve confirmed findings before explicit-path staging.
+
+---
+
+### Task 3: Version and validate the system service (#419)
+
+**Files:**
+- Create: `deploy/vinyl-now-playing.service.in`
+- Create: `scripts/render_system_service.py`
+- Create: `tests/test_system_service.py`
+- Modify: `.github/workflows/tests.yml`
+- Modify: the same focused workflow-integrity test file selected in Task 2
+
+- [ ] **Step 1: Write RED renderer and invariant tests**
+
+Pin exact assertions for all preserved directives, `Type=simple`, service user,
+working directory, `DISPLAY`, `XAUTHORITY`, absolute venv Python/main paths, and
+`WantedBy=graphical.target`. Test safe substitution, rejection of relative or
+newline/whitespace-injection values, missing app/config, non-`0600` config,
+atomic output, byte-identical rerender, and unchanged config mode. Add workflow
+assertions requiring representative render plus `systemd-analyze verify` on
+Ubuntu.
+
+Run:
+
+```bash
+cd '/private/tmp/vnp-release-app-identity' && test "$(git branch --show-current)" = 'codex/r10-wave1-pi-preflight' && '/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m pytest -q tests/test_system_service.py tests/test_workflow_integrity_r10.py
+```
+
+Expected RED: template, renderer, and CI verification do not exist.
+
+- [ ] **Step 2: Implement template and minimal renderer**
+
+Use explicit placeholders for service user, absolute app directory, display,
+and absolute Xauthority. The CLI requires all four plus `--output`; it validates
+`<app-dir>/config.yaml` as `0600`, renders to a same-directory temporary file,
+fsyncs, then atomically replaces output. It never invokes sudo/systemctl and
+never changes config mode. CI creates a temporary representative app/config,
+renders, then runs `systemd-analyze verify`.
+
+- [ ] **Step 3: Verify GREEN and static unit semantics**
+
+Run the RED command and `git diff --check`. On Linux CI, require the real
+`systemd-analyze verify`; locally, unit tests must skip only the external binary
+check, never the directive contract.
+
+- [ ] **Step 4: Independent adversarial review**
+
+Reviewer must try template injection, relative paths, symlink/output races,
+unsafe config mode, partial writes, changed historical restart/time directives,
+and a renderer that mutates config. Resolve all confirmed findings.
+
+---
+
+### Task 4: Put an explicit safety gate around the Discogs write (#366)
+
+**Files:**
+- Modify: `scripts/discogs_live_check.py`
+- Modify: `tests/test_discogs_live_check.py`
+
+- [ ] **Step 1: Write RED tests**
+
+Test `--artist` and `--album` flow through every displayed/search operation.
+Test that `--test-write` aborts without calling `increment_play_count` on `n`,
+empty input, or EOF; accepts only an exact affirmative response; and that
+`--yes` bypasses the prompt only when both record arguments were explicitly
+provided. Test the prompt contains artist, album, release/instance IDs, and
+field name but no token. Preserve existing redaction and root-relative config
+tests.
+
+Run:
+
+```bash
+cd '/private/tmp/vnp-release-app-identity' && test "$(git branch --show-current)" = 'codex/r10-wave1-pi-preflight' && '/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m pytest -q tests/test_discogs_live_check.py
+```
+
+Expected RED: fixed constants and unconditional `--test-write` do not satisfy
+the selection/confirmation contract.
+
+- [ ] **Step 2: Implement selection and confirmation**
+
+Make artist/album explicit CLI inputs with current constants only for read-only
+compatibility. A write requires both inputs to have been supplied explicitly.
+Prompt immediately before the one writer call; accept only `yes`. `--yes` is
+the noninteractive equivalent and must remain visually loud in the summary.
+
+- [ ] **Step 3: Verify GREEN and no-write mutations**
+
+Run the focused suite and `git diff --check`. Reviewer must attempt absent
+arguments, EOF, whitespace/case variations, failed search, exception, and
+ambiguous response paths. No reviewer executes a live network call.
+
+---
+
+### Task 5: Reconcile deployment docs and the regression contract
+
+**Files:**
+- Modify: `docs/pi-setup-guide.md`
+- Modify: `docs/first-boot-checklist.md`
+- Modify: `docs/testing-guide.md`
+- Modify: `docs/decisions/remediation-guardrails.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Replace copy/paste drift with the versioned path**
+
+Document exact renderer usage for `/etc/systemd/system/vinyl-now-playing.service`,
+then `systemd-analyze verify`, `daemon-reload`, enable/start, and status. Preserve
+the system-service decision, #83/#201 rationale, time-sync waiter, and the
+image-specific Wayland/Xwayland warning. Remove any instruction suggesting a
+user-service migration as the Wave 1 fallback.
+
+- [ ] **Step 2: Add rollback and evidence forms**
+
+Document backup/restore of the last known-good rendered unit and venv/tag,
+`config.yaml` `0600` readback, UCA222 import/enumeration/hot-plug results,
+cold-boot/display/session/time-sync outcomes, and a redacted Discogs record
+before/after/HTTP result. Explicitly say CI does not close hardware gates.
+
+- [ ] **Step 3: Update durable status without premature closure**
+
+Update the guardrail and changelog with the implemented software controls.
+Leave #366 and Wave 1 hardware state pending until observed. Correct the stale
+`tests/conftest.py` reference to root `conftest.py`.
+
+- [ ] **Step 4: Independent documentation review**
+
+Review against live issues #418/#156/#419/#366 and closed #83/#201/#301.
+Search for contradictory service type, retry values, permission advice,
+hardware-success claims, unsafe write instructions, and stale file paths.
+
+---
+
+### Task 6: Integrated verification and adversarial release review
+
+**Files:** all intended Wave 1 files; no production edits by reviewer.
+
+- [ ] **Step 1: Run focused local verification**
+
+```bash
+cd '/private/tmp/vnp-release-app-identity' && test "$(git branch --show-current)" = 'codex/r10-wave1-pi-preflight' && '/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m py_compile src/config.py scripts/check_audio_backend.py scripts/render_system_service.py scripts/discogs_live_check.py && '/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m pytest -q tests/test_config.py tests/test_audio_backend_smoke.py tests/test_capture.py tests/test_main_wiring.py tests/test_ops_polish_r9.py tests/test_system_service.py tests/test_discogs_live_check.py tests/test_workflow_integrity_r10.py && git diff --check
+```
+
+- [ ] **Step 2: Run repository security/scope checks**
+
+Verify no secret/private-key material, no tracked `config.yaml`, no user-service
+artifact, no unintended files, no staged files, and an explicit intended diff.
+Run workflow lint using the repository's pinned/cached actionlint procedure.
+
+- [ ] **Step 3: Independent broad adversarial review**
+
+Review config TOCTOU/redaction, CI fake-package bypass, exact production API
+coverage, system-unit injection/partial writes/semantic drift, Discogs write
+bypass/ambiguous retries, docs/history conflicts, and test gaming. Fix through
+the owning task and repeat review until SPEC PASS / QUALITY PASS with zero open
+High/Critical or materially distinct non-gameable findings.
+
+---
+
+### Task 7: Merge software evidence, then execute the hardware gate
+
+**External objects:** GitHub pull request, issues #418/#156/#419/#366, milestone #52, target Raspberry Pi, live Discogs record.
+
+- [ ] **Step 1: Create the PR with explicit-path Git operations**
+
+Only if a Git mutation cannot be performed directly, the handoff begins with:
+
+```bash
+cd '/private/tmp/vnp-release-app-identity' && test "$(git branch --show-current)" = 'codex/r10-wave1-pi-preflight'
+```
+
+Then stage only named Wave 1 files, commit, and push. Never use `git add -A`.
+
+- [ ] **Step 2: Require exact-SHA supported CI**
+
+Require Python 3.11/3.12/3.13 tests, real sounddevice smoke on each leg,
+systemd verification, dependency audit, actionlint, and review. Merge only the
+reviewed exact SHA.
+
+- [ ] **Step 3: Close only software-complete issue contracts**
+
+Read back main and exact-SHA checks. #156 may close after its CI acceptance is
+proven. #418 and #419 remain open if their issue contracts still require Pi
+mode/cold-boot evidence. #366 remains open until the authorized write result.
+
+- [ ] **Step 4: Run the real Pi checklist**
+
+Record OS/Python versions, `stat` mode without content, real sounddevice import
+and required APIs, UCA222 enumeration/stream/hot-plug, selected DISPLAY/session
+auth, system-unit verification, offline/time-sync behavior, SIGTERM, and cold
+boot. Do not include credentials in evidence.
+
+- [ ] **Step 5: Obtain record-specific authorization and run #366 once**
+
+Lane supplies the exact artist/album in a non-default folder and approves that
+write. Record before/after value and outcome. On success, close #366; on 404,
+open/activate the folder-ID propagation task; on ambiguity, inspect before any
+retry.
+
+- [ ] **Step 6: Close Wave 1**
+
+Update the audit, guardrail, SDD record, issue comments, and milestone with
+exact merge SHA, run IDs, Pi image/Python, service evidence, config mode, and
+Discogs outcome. Close milestone #52 only when every exit gate is observed.
+

--- a/docs/superpowers/plans/2026-08-22-wave1-pi-preflight.md
+++ b/docs/superpowers/plans/2026-08-22-wave1-pi-preflight.md
@@ -144,7 +144,7 @@ ownership. Resolve confirmed findings before explicit-path staging.
 - Modify: `.github/workflows/tests.yml`
 - Modify: the same focused workflow-integrity test file selected in Task 2
 
-- [ ] **Step 1: Write RED renderer and invariant tests**
+- [x] **Step 1: Write RED renderer and invariant tests**
 
 Pin exact assertions for all preserved directives, `Type=simple`, service user,
 working directory, `DISPLAY`, `XAUTHORITY`, absolute venv Python/main paths, and
@@ -162,7 +162,7 @@ cd '/private/tmp/vnp-release-app-identity' && test "$(git branch --show-current)
 
 Expected RED: template, renderer, and CI verification do not exist.
 
-- [ ] **Step 2: Implement template and minimal renderer**
+- [x] **Step 2: Implement template and minimal renderer**
 
 Use explicit placeholders for service user, absolute app directory, display,
 and absolute Xauthority. The CLI requires all four plus `--output`; it validates
@@ -171,13 +171,13 @@ fsyncs, then atomically replaces output. It never invokes sudo/systemctl and
 never changes config mode. CI creates a temporary representative app/config,
 renders, then runs `systemd-analyze verify`.
 
-- [ ] **Step 3: Verify GREEN and static unit semantics**
+- [x] **Step 3: Verify GREEN and static unit semantics**
 
 Run the RED command and `git diff --check`. On Linux CI, require the real
 `systemd-analyze verify`; locally, unit tests must skip only the external binary
 check, never the directive contract.
 
-- [ ] **Step 4: Independent adversarial review**
+- [x] **Step 4: Independent adversarial review**
 
 Reviewer must try template injection, relative paths, symlink/output races,
 unsafe config mode, partial writes, changed historical restart/time directives,

--- a/docs/superpowers/plans/2026-08-22-wave1-pi-preflight.md
+++ b/docs/superpowers/plans/2026-08-22-wave1-pi-preflight.md
@@ -43,7 +43,7 @@
 - Modify: `src/config.py`
 - Modify: `tests/test_config.py`
 
-- [ ] **Step 1: Write focused RED tests**
+- [x] **Step 1: Write focused RED tests**
 
 Add a helper that writes valid YAML and explicitly chmods it `0600`. Add tests proving:
 
@@ -61,7 +61,7 @@ cd '/private/tmp/vnp-release-app-identity' && test "$(git branch --show-current)
 
 Expected RED: only the new permission-contract tests fail because no open-file mode check exists.
 
-- [ ] **Step 2: Implement the minimum open-file guard**
+- [x] **Step 2: Implement the minimum open-file guard**
 
 Inside the existing `with open(...) as f`, call a small private helper with
 `os.fstat(f.fileno())` before reading. On POSIX, evaluate `stat.S_IMODE` and
@@ -69,7 +69,7 @@ raise `ConfigError` when `mode & 0o077`. When mode semantics are unavailable,
 log one warning and continue. Preserve all existing `ConfigError` normalization;
 do not chmod or inspect ownership in this change.
 
-- [ ] **Step 3: Verify GREEN and regression scope**
+- [x] **Step 3: Verify GREEN and regression scope**
 
 Run the focused command above, then:
 
@@ -77,7 +77,7 @@ Run the focused command above, then:
 cd '/private/tmp/vnp-release-app-identity' && test "$(git branch --show-current)" = 'codex/r10-wave1-pi-preflight' && '/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m pytest -q tests/test_config.py tests/test_ops_polish_r9.py && git diff --check
 ```
 
-- [ ] **Step 4: Independent spec and quality review**
+- [x] **Step 4: Independent spec and quality review**
 
 Reviewer must attempt secret-bearing `0644`, parse-before-check, directory,
 missing-file, and unsupported-platform mutations. Resolve every confirmed
@@ -334,4 +334,3 @@ retry.
 Update the audit, guardrail, SDD record, issue comments, and milestone with
 exact merge SHA, run IDs, Pi image/Python, service evidence, config mode, and
 Discogs outcome. Close milestone #52 only when every exit gate is observed.
-

--- a/docs/superpowers/specs/2026-08-22-wave1-pi-preflight-design.md
+++ b/docs/superpowers/specs/2026-08-22-wave1-pi-preflight-design.md
@@ -126,4 +126,3 @@ diff/security scans. Hardware acceptance requires the real Pi checklist and
 non-secret evidence. The local macOS Python 3.9/sandbox suite is a recorded
 unsupported baseline (16 known failures); it cannot replace the supported CI
 matrix and does not block scoped RED/GREEN work.
-

--- a/docs/superpowers/specs/2026-08-22-wave1-pi-preflight-design.md
+++ b/docs/superpowers/specs/2026-08-22-wave1-pi-preflight-design.md
@@ -1,0 +1,129 @@
+# Wave 1 Pi Preflight Design
+
+**Status:** Approved for implementation; Pi-only acceptance remains pending
+**Date:** 2026-08-22
+**Issues:** #418, #156, #419, and carried hypothesis #366
+**Decision authority:** `docs/decisions/remediation-guardrails.md`
+
+## Outcome
+
+Wave 1 turns the current manual first-boot guidance into enforceable software
+boundaries without claiming that CI is a Raspberry Pi. Startup rejects an
+overexposed POSIX credential file before parsing it, CI imports the real
+`sounddevice` package and checks every production-used API before pytest can
+stub it, the repository owns a parameterized system-service artifact and an
+idempotent renderer, and the Discogs live-write probe requires an explicitly
+chosen record and confirmation.
+
+The wave is not complete until the target Pi proves the hardware/session gates:
+`config.yaml` is `0600`, the UCA222 opens and survives unplug/replug, the system
+service survives a cold boot into the selected display session, and the chosen
+custom-folder Discogs record either accepts the folder-0 write or supplies the
+404 evidence that activates the deferred folder-identity code change.
+
+`DESIGN.md` is not authority for this work. Current tested behavior, the live
+issue contracts, historical closure rationale, and the owner's ratified
+decisions control.
+
+## Decisions and invariants
+
+### Credential-file security (#418)
+
+- `load_config` opens the file and evaluates `os.fstat()` on that open file
+  before reading or parsing any YAML, avoiding a check/open race.
+- On POSIX, any group/other permission bit (`mode & 0o077`) raises
+  `ConfigError`. The diagnostic names the path and exact `chmod 600 <path>`
+  repair, but never includes file contents or credential values.
+- On a platform that cannot provide POSIX mode semantics, startup logs one
+  explicit warning and continues. The application does not silently chmod an
+  operator-owned file.
+- The checked-in example remains non-secret. The live `config.yaml` remains
+  ignored, untracked, unread by automation, and `0600`.
+
+### Real audio-backend CI boundary (#156)
+
+- Each supported Ubuntu matrix leg installs the PortAudio runtime before Python
+  dependencies.
+- A standalone pre-pytest command imports the installed `sounddevice` module
+  and requires callable `query_devices`, `InputStream`, `_terminate`, and
+  `_initialize`, the complete production API surface in `src/audio/capture.py`.
+- The ordinary unit suite remains hardware-free. Root `conftest.py` first tries
+  the real import and installs its centrally-owned stub only if import fails;
+  teardown removes only the stub it installed.
+- Import/API success is not evidence of USB enumeration, callback timing,
+  actual `InputStream` operation, or hot-plug recovery on the Pi.
+
+### Versioned system-service deployment (#419)
+
+- The supported architecture remains a **system service**. A user-service
+  migration is out of scope even if it would simplify a particular Wayland
+  session.
+- `deploy/vinyl-now-playing.service.in` is the single unit source. It is
+  parameterized for service user, absolute app directory, display, and absolute
+  Xauthority/session-auth path.
+- Rendering rejects unsafe values, requires the app directory and `config.yaml`
+  to exist, requires the config to be `0600`, writes atomically, and never
+  modifies config permissions. Re-rendering the same inputs is byte-identical.
+- The unit preserves the already-shipped behavior from #83 and #201:
+  `Wants=network-online.target`,
+  `After=network-online.target time-sync.target graphical.target`,
+  `StartLimitIntervalSec=300`, `StartLimitBurst=10`, `RestartSec=15`,
+  `RestartPreventExitStatus=78`, and `TimeoutStopSec=30`.
+- Linux CI renders a representative unit and runs `systemd-analyze verify`.
+  The selected Raspberry Pi OS image still determines the correct live
+  `DISPLAY`/Xauthority values, which must be recorded during bring-up.
+
+### Safe Discogs live probe (#366)
+
+- Read-only remains the default.
+- The test artist and album are command-line inputs rather than source edits.
+- A write requires `--test-write`, an explicit interactive confirmation that
+  names the selected record and field, or `--yes` for an already-authorized
+  noninteractive run. EOF, refusal, or a missing explicit record aborts before
+  constructing or invoking the writer operation.
+- The operator chooses a sacrificial or reversible record that is actually in a
+  non-default folder and records the non-secret before/after result.
+- A successful write closes #366 as a disproven hypothesis. A 404 activates a
+  separate folder-ID propagation change across reader, metadata, session, and
+  writer. Ambiguous write results are inspected before any retry.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    C["Open config"] --> M["Check open-file POSIX mode"]
+    M -->|"0600 / unsupported warned"| Y["Parse and validate YAML"]
+    M -->|"group/other bits"| E["Exit 78 with repair command"]
+    CI["Ubuntu matrix"] --> P["Install PortAudio"] --> S["Real sounddevice API smoke"] --> T["Hardware-free pytest"]
+    U["Versioned system-unit template"] --> R["Validated atomic render"] --> V["systemd-analyze verify"] --> H["Pi cold-boot proof"]
+    D["Named custom-folder record"] --> Q["Explicit write confirmation"] --> W["One observed Discogs write"]
+```
+
+## Failure and recovery behavior
+
+| Failure | Required behavior |
+|---|---|
+| POSIX config exposes any group/other bits | Fail before YAML parsing; print only path and `chmod 600` repair. |
+| POSIX mode cannot be evaluated | Warn once and continue to ordinary validation. |
+| Real `sounddevice` import or required API is missing | CI leg fails before pytest; Pi startup remains parked at exit 78. |
+| Unit input is unsafe or config is not `0600` | Renderer refuses to write the output unit. |
+| Render/install is interrupted | Atomic replacement leaves either the prior complete unit or the new complete unit. |
+| System service cannot open the live display | Preserve the system-service design; inspect and correct image-specific session auth, then rerun cold boot. |
+| Discogs write is declined/unconfirmed | No write occurs. |
+| Discogs write reports 404 | Preserve evidence, do not retry, and activate folder-ID propagation work. |
+| Discogs write outcome is ambiguous | Query current field state before any retry. |
+
+Rollback for the service is non-destructive: keep a copy of the last known-good
+rendered unit, point the app directory/venv back to the last known-good release,
+run `systemd-analyze verify`, then `daemon-reload` and restart. Never loosen
+`config.yaml` permissions as a recovery step.
+
+## Verification boundary
+
+Software acceptance requires focused tests, the full supported Python
+3.11/3.12/3.13 CI matrix, workflow lint, Linux unit verification, and clean
+diff/security scans. Hardware acceptance requires the real Pi checklist and
+non-secret evidence. The local macOS Python 3.9/sandbox suite is a recorded
+unsupported baseline (16 known failures); it cannot replace the supported CI
+matrix and does not block scoped RED/GREEN work.
+

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -40,13 +40,16 @@ is active.
 
 ### Discogs credentials (only for `scripts/discogs_live_check.py`)
 
+First copy the non-secret example, but do **not** enter credentials yet:
+
 ```bash
 cp config.example.yaml config.yaml
-# Edit config.yaml — fill in discogs.user_token and discogs.username
 ```
 
-On **POSIX** (macOS/Linux, including Raspberry Pi OS), restrict the file before
-entering credentials. The commands below print only mode/path, not its contents:
+Complete one platform security gate before entering credentials.
+
+On **POSIX** (macOS/Linux, including Raspberry Pi OS), restrict the copied file
+and read back its mode. These commands print only mode/path, not its contents:
 
 ```bash
 chmod 600 config.yaml
@@ -57,10 +60,23 @@ stat -f '%Lp %N' config.yaml
 ```
 
 The readback must report mode `600`. `load_config` rejects a POSIX file with any
-group/other permission bit. On Windows or another platform without POSIX mode
-semantics, startup emits its explicit warning and continues; use that platform's
-ACL controls to restrict the credential file, because `chmod`/POSIX `stat` are
-not a portable proof there.
+group/other permission bit.
+
+On **Windows or another platform without POSIX mode semantics**, do not use the
+POSIX commands above as proof. Before editing, use that platform's file-security
+or ACL controls to restrict `config.yaml` to the current account, then read the
+ACL back in the same security inspector (or its platform ACL command) and record
+that result and the warning acknowledgement before entering credentials.
+`load_config` will emit its explicit inability-to-verify-POSIX-permissions
+warning on the first run; the warning is expected but does not prove an ACL is
+safe.
+
+Only after the applicable gate's mode/ACL readback is satisfactory may you edit
+the file and enter `discogs.user_token` and `discogs.username`:
+
+```text
+# Edit config.yaml in your editor; do not paste credentials into a shell command.
+```
 
 **Getting your token:** Discogs → Settings → [Developers](https://www.discogs.com/settings/developers)
 → Generate new token.

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -789,8 +789,26 @@ python scripts/discogs_live_check.py \
 
 The prompt names the resolved artist, album, field, release ID, and instance ID;
 type the exact lowercase `yes` only after confirming it is the designated record.
-For an already-authorized noninteractive run, add `--yes` to that complete
-command—never run a bare `--test-write`.
+
+For an already-authorized noninteractive run, bind the owner's approval to the
+exact positive release and instance IDs already observed for that sacrificial
+record. Replace both quoted angle-bracket placeholders with those approved
+integer IDs:
+
+```bash
+python scripts/discogs_live_check.py \
+  --artist "Artist" --album "Album" \
+  --test-write --yes \
+  --release-id "<approved positive release ID>" \
+  --instance-id "<approved positive instance ID>"
+```
+
+Artist and album are search selectors; they do not authorize a noninteractive
+write by themselves. The script resolves the collection record again and aborts
+without writing if either resolved ID differs from the approved IDs. Treat any
+identity mismatch as a stop: do not retry, inspect the collection state, and
+obtain fresh owner approval before any later attempt. Never run a bare
+`--test-write`.
 
 Record the custom-folder name/ID, before value, after value, and HTTP/outcome
 without tokens. A success disproves the folder-identity hypothesis. On a `404`,

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -41,9 +41,15 @@ is active.
 ### Discogs credentials (only for `scripts/discogs_live_check.py`)
 
 ```bash
+cd /home/pi/vinyl-now-playing
 cp config.example.yaml config.yaml
+chmod 600 config.yaml
+stat -c '%a %n' config.yaml
 # Edit config.yaml — fill in discogs.user_token and discogs.username
 ```
+
+The mode readback must say `600 config.yaml` before entering credentials. It
+prints no secret content; `load_config` rejects a group/other-readable file.
 
 **Getting your token:** Discogs → Settings → [Developers](https://www.discogs.com/settings/developers)
 → Generate new token.
@@ -632,7 +638,7 @@ Key cases:
   block clear of the bottom meta/prev-next, and font floors + hierarchy at every
   size. (Backs CLAUDE.md's "resolution-independent" claim for the static layout;
   the renderer's runtime title push-down is content-dependent and remains a
-  hardware/visual check — see `docs/first-boot-checklist.md` §5.)
+  hardware/visual check — see `docs/first-boot-checklist.md` §6.)
 
 ### `test_cover_cache.py` — Cover fetch + disk cache (new in v1.5.1)
 
@@ -727,18 +733,31 @@ TEST 4: Collection custom fields
 | `✗` | Failed — API error or unexpected response |
 | `·` | Skipped — e.g. *Sister* not in your collection; collection-specific tests N/A |
 
-If *Sister* isn't in your collection, TEST 1 will show `·` and TEST 3 will use the
-release ID from TEST 2 instead. That's fine — the important thing is that your token
-is valid and the `Play Count` field is found.
+If *Sister* isn't in your collection, TEST 1 and TEST 3 are skipped; the script
+does not use the database-search result as a tracklist fallback. That is still a
+useful read-only credential check, but choose a record you own when you need the
+collection/field evidence.
 
 ### With the custom-folder write probe (modifies your Discogs collection)
 
 This is the pending #366 hardware/external-state gate. Select a sacrificial or
 reversible record that is actually filed in a non-default Discogs folder. First,
-run the explicit read-only lookup and record the non-secret release/instance IDs
-and the current Play Count field value. Then run exactly one confirmed write:
+run the explicit read-only lookup for that **same** record:
 
 ```bash
+cd /home/pi/vinyl-now-playing
+python scripts/discogs_live_check.py \
+  --artist "Artist" --album "Album"
+```
+
+In the Discogs collection UI, confirm that the resolved release/instance is the
+designated sacrificial record, and record its non-secret custom-folder **name and
+ID** plus the current Play Count field value. The script does not expose folder
+identity or the current field value for you. Only then run exactly one confirmed
+write against the same artist/album:
+
+```bash
+cd /home/pi/vinyl-now-playing
 python scripts/discogs_live_check.py \
   --artist "Artist" --album "Album" --test-write
 ```
@@ -748,11 +767,11 @@ type the exact lowercase `yes` only after confirming it is the designated record
 For an already-authorized noninteractive run, add `--yes` to that complete
 command—never run a bare `--test-write`.
 
-Record the before value, after value, and HTTP/outcome without tokens. A success
-disproves the folder-identity hypothesis. On a `404`, preserve the evidence and
-open the deferred folder-ID propagation change; do not retry. On a failed or
-ambiguous result, inspect the field state before any rerun because the write may
-already have applied.
+Record the custom-folder name/ID, before value, after value, and HTTP/outcome
+without tokens. A success disproves the folder-identity hypothesis. On a `404`,
+preserve the evidence and open the deferred folder-ID propagation change; do not
+retry. On a failed or ambiguous result, inspect the field state before any rerun
+because the write may already have applied.
 
 ---
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -63,7 +63,7 @@ The table groups related files; for the live, authoritative file list run
 | `test_silence.py`, `test_silence_liveness.py` | Silence detector state machine + the B-6 liveness tick |
 | `test_signal.py` | `Signal[T]` log-and-continue observer |
 | `test_chunking.py` | ChunkAssembler overlapping-window logic |
-| `test_capture.py` | AudioCapture device match, config guards, drop-oldest `_enqueue_block`, `stop()` (stubbed sounddevice) |
+| `test_capture.py` | AudioCapture device match, config guards, drop-oldest `_enqueue_block`, `stop()` (mocked capture surface; CI separately proves the installed backend) |
 | `test_player_state.py` | PlayerState transitions & change notifications |
 | `test_recognizer.py`, `_encode.py`, `_parse.py`, `_epoch.py`, `_progress.py` | Confirmation gate, `run()` loop, the encode/`_call_shazam`/`_parse` split, B-1 epoch + B-7 progress |
 | `test_track_commit_service.py` | `TrackCommitService.commit` — B-1 epoch guard, B-11 ordering, Last.fm scrobble branch (T-2) |
@@ -183,11 +183,15 @@ diagnostic aid, not a gate — the suite does not enforce a minimum percentage.
 
 Five GitHub Actions workflows live in `.github/workflows/`:
 
-- **`tests.yml`** — runs `pytest -q` on every `main` push and pull request across
-  Python 3.11, 3.12, and 3.13. It sets `SDL_VIDEODRIVER=dummy` /
-  `SDL_AUDIODRIVER=dummy` so pygame is headless, and `tests/conftest.py` stubs
-  `sounddevice` before any test module loads, so no PortAudio or display
-  hardware is needed on the runner.
+- **`tests.yml`** — runs on every `main` push and pull request across Python 3.11,
+  3.12, and 3.13. Each Ubuntu leg installs `libportaudio2`, runs
+  `python -I scripts/check_audio_backend.py` to authenticate the installed
+  `sounddevice` distribution and require the four production-used APIs, renders
+  the versioned system unit, and runs `/usr/bin/systemd-analyze verify` before
+  `pytest -q`. It sets `SDL_VIDEODRIVER=dummy` / `SDL_AUDIODRIVER=dummy` so
+  pygame is headless. Root `conftest.py` first retains a real `sounddevice`
+  import and installs its owned fallback stub only when import fails, keeping the
+  ordinary unit suite hardware-free.
 - **`sync-version-badge.yml`** — despite its historical filename, this is now a
   read-only version-metadata check on pull requests and `main`. It fails unless
   `VERSION`, the `CHANGELOG.md` release heading, and the README badge agree;
@@ -311,11 +315,12 @@ Key cases:
 
 ### `test_capture.py` — AudioCapture device matching & guards (new in v1.3.5)
 
-First-ever coverage for `capture.py`. The module imports `sounddevice` at the
-top level (which needs PortAudio at import time), so the suite plants a stub
-into `sys.modules["sounddevice"]` before importing — and every test patches
-`src.audio.capture.sd` explicitly, so the real module is never exercised even
-on machines where it is installed.
+`capture.py` imports `sounddevice` at the top level. Root `conftest.py` keeps a
+real installed import when available and installs a centrally owned fallback stub
+only when it is unavailable; each capture test still patches
+`src.audio.capture.sd` explicitly. CI separately authenticates the installed
+distribution and checks its production API surface before pytest, so the unit
+suite's mocks cannot mask a missing or incompatible package.
 
 Key cases:
 - Constructor reads the audio config; `overlap_seconds` defaults to 5
@@ -656,8 +661,10 @@ Key cases:
 
 ## Running the live Discogs integration test
 
-`scripts/discogs_live_check.py` (in `scripts/`, not in `tests/`) makes real network calls
-to the Discogs API. It uses Sonic Youth's *Sister* as the test album.
+`scripts/discogs_live_check.py` (in `scripts/`, not in `tests/`) makes real
+network calls to the Discogs API. Its default Sonic Youth *Sister* selection is
+read-only compatibility only; choose another record with `--artist` and `--album`
+rather than editing source constants.
 
 > **Requires `config.yaml`** with a valid `user_token` and `username`.
 
@@ -724,16 +731,28 @@ If *Sister* isn't in your collection, TEST 1 will show `·` and TEST 3 will use 
 release ID from TEST 2 instead. That's fine — the important thing is that your token
 is valid and the `Play Count` field is found.
 
-### With the write test (modifies your Discogs collection)
+### With the custom-folder write probe (modifies your Discogs collection)
+
+This is the pending #366 hardware/external-state gate. Select a sacrificial or
+reversible record that is actually filed in a non-default Discogs folder. First,
+run the explicit read-only lookup and record the non-secret release/instance IDs
+and the current Play Count field value. Then run exactly one confirmed write:
 
 ```bash
-python scripts/discogs_live_check.py --test-write
+python scripts/discogs_live_check.py \
+  --artist "Artist" --album "Album" --test-write
 ```
 
-This additionally tests `increment_play_count`. It will prompt for confirmation before
-making any changes. The field is a running counter — running this test will increment
-the Play Count by 1 on the test release. If you want to correct it afterward, adjust
-the value manually in your Discogs collection.
+The prompt names the resolved artist, album, field, release ID, and instance ID;
+type the exact lowercase `yes` only after confirming it is the designated record.
+For an already-authorized noninteractive run, add `--yes` to that complete
+command—never run a bare `--test-write`.
+
+Record the before value, after value, and HTTP/outcome without tokens. A success
+disproves the folder-identity hypothesis. On a `404`, preserve the evidence and
+open the deferred folder-ID propagation change; do not retry. On a failed or
+ambiguous result, inspect the field state before any rerun because the write may
+already have applied.
 
 ---
 
@@ -770,7 +789,7 @@ These components need the actual Pi + USB audio interface + display to test:
 - `src/audio/capture.py` — only the live `sd.InputStream` integration with
   the UCA222 now: the overlapping-window logic is covered by
   `tests/test_chunking.py`, and device matching / config guards by
-  `tests/test_capture.py` (stubbed sounddevice)
+  `tests/test_capture.py` (mocked capture surface)
 - `src/audio/recognizer.py` → `ShazamIOBackend.recognize()` — real Shazam API calls with real audio
 - `src/display/renderer.py` — pygame rendering on the HDMI display (the
   bounded caches and palette color math are covered hardware-free by
@@ -786,3 +805,9 @@ powers on — audio-device match, `silence_threshold_rms` tuning, the live cover
 fetch / S-7 IP-pinned-TLS smoke test, the recognition churn breadcrumb, the
 runtime title push-down, and full-pipeline + autostart checks — see
 **`docs/first-boot-checklist.md`**.
+
+CI proves the installed Linux package, its required Python APIs, and system-unit
+syntax. It does **not** prove UCA222 enumeration or stream operation, USB
+hot-plug recovery, Wayland/Xwayland authorization, cold-boot timing, SIGTERM
+shutdown, or a live Discogs custom-folder write; those remain first-boot evidence
+gates.

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -41,15 +41,26 @@ is active.
 ### Discogs credentials (only for `scripts/discogs_live_check.py`)
 
 ```bash
-cd /home/pi/vinyl-now-playing
 cp config.example.yaml config.yaml
-chmod 600 config.yaml
-stat -c '%a %n' config.yaml
 # Edit config.yaml — fill in discogs.user_token and discogs.username
 ```
 
-The mode readback must say `600 config.yaml` before entering credentials. It
-prints no secret content; `load_config` rejects a group/other-readable file.
+On **POSIX** (macOS/Linux, including Raspberry Pi OS), restrict the file before
+entering credentials. The commands below print only mode/path, not its contents:
+
+```bash
+chmod 600 config.yaml
+# Linux / Raspberry Pi OS:
+stat -c '%a %n' config.yaml
+# macOS:
+stat -f '%Lp %N' config.yaml
+```
+
+The readback must report mode `600`. `load_config` rejects a POSIX file with any
+group/other permission bit. On Windows or another platform without POSIX mode
+semantics, startup emits its explicit warning and continues; use that platform's
+ACL controls to restrict the credential file, because `chmod`/POSIX `stat` are
+not a portable proof there.
 
 **Getting your token:** Discogs → Settings → [Developers](https://www.discogs.com/settings/developers)
 → Generate new token.
@@ -745,7 +756,6 @@ reversible record that is actually filed in a non-default Discogs folder. First,
 run the explicit read-only lookup for that **same** record:
 
 ```bash
-cd /home/pi/vinyl-now-playing
 python scripts/discogs_live_check.py \
   --artist "Artist" --album "Album"
 ```
@@ -757,7 +767,6 @@ identity or the current field value for you. Only then run exactly one confirmed
 write against the same artist/album:
 
 ```bash
-cd /home/pi/vinyl-now-playing
 python scripts/discogs_live_check.py \
   --artist "Artist" --album "Album" --test-write
 ```

--- a/scripts/check_audio_backend.py
+++ b/scripts/check_audio_backend.py
@@ -1,5 +1,7 @@
 """Fail fast when the installed sounddevice backend cannot support production."""
 import importlib
+from importlib import metadata
+from pathlib import Path
 import sys
 
 
@@ -18,6 +20,45 @@ def validate_backend(module):
     )
 
 
+def _resolve_file(path):
+    """Resolve a readable file without letting provenance diagnostics raise."""
+    try:
+        return Path(path).resolve(strict=True)
+    except (OSError, TypeError, ValueError):
+        return None
+
+
+def validate_distribution_provenance(module, distribution_loader=metadata.distribution):
+    """Return a fail-closed reason unless ``module`` is from sounddevice's wheel."""
+    module_file = _resolve_file(getattr(module, "__file__", None))
+    if module_file is None:
+        return "imported module has no readable file origin"
+
+    try:
+        distribution = distribution_loader("sounddevice")
+    except metadata.PackageNotFoundError:
+        return "installed sounddevice distribution metadata is unavailable"
+    except Exception:
+        return "installed sounddevice distribution metadata could not be read"
+
+    try:
+        distribution_files = distribution.files
+        if not distribution_files:
+            return "installed sounddevice distribution file manifest is unavailable"
+        declared_files = {
+            path
+            for distribution_file in distribution_files
+            if (path := _resolve_file(distribution.locate_file(distribution_file)))
+            is not None
+        }
+    except Exception:
+        return "installed sounddevice distribution file manifest could not be read"
+    if module_file not in declared_files:
+        return "imported module is not declared by the installed distribution"
+
+    return None
+
+
 def main():
     """Import and validate sounddevice without touching an audio device."""
     try:
@@ -26,6 +67,16 @@ def main():
         print(
             "ERROR: unable to import the sounddevice audio backend "
             f"({type(error).__name__}). Install libportaudio2 and rerun this check.",
+            file=sys.stderr,
+        )
+        return 1
+
+    provenance_error = validate_distribution_provenance(backend)
+    if provenance_error:
+        print(
+            "ERROR: cannot verify sounddevice backend provenance: "
+            f"{provenance_error}. Remove local shadows and repair the installed "
+            "sounddevice package before rerunning this check.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/check_audio_backend.py
+++ b/scripts/check_audio_backend.py
@@ -1,0 +1,49 @@
+"""Fail fast when the installed sounddevice backend cannot support production."""
+import importlib
+import sys
+
+
+REQUIRED_APIS = (
+    "query_devices",
+    "InputStream",
+    "_terminate",
+    "_initialize",
+)
+
+
+def validate_backend(module):
+    """Return production-required sounddevice APIs that are absent or unusable."""
+    return tuple(
+        api for api in REQUIRED_APIS if not callable(getattr(module, api, None))
+    )
+
+
+def main():
+    """Import and validate sounddevice without touching an audio device."""
+    try:
+        backend = importlib.import_module("sounddevice")
+    except Exception as error:
+        print(
+            "ERROR: unable to import the sounddevice audio backend "
+            f"({type(error).__name__}). Install libportaudio2 and rerun this check.",
+            file=sys.stderr,
+        )
+        return 1
+
+    missing_apis = validate_backend(backend)
+    if missing_apis:
+        print(
+            "ERROR: installed sounddevice backend is missing required callable APIs: "
+            f"{', '.join(missing_apis)}. Pin or repair the sounddevice package before "
+            "running the application.",
+            file=sys.stderr,
+        )
+        return 1
+
+    version = getattr(backend, "__version__", "unknown")
+    print(f"sounddevice {version}: required audio backend APIs are available.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/discogs_live_check.py
+++ b/scripts/discogs_live_check.py
@@ -81,18 +81,20 @@ def info(msg): print(f"     {msg}")
 # Individual tests
 # ---------------------------------------------------------------------------
 
-def check_search_collection(client) -> Optional[dict]:
-    sep(f"1 · search_collection  —  {TEST_ARTIST} / {TEST_ALBUM}")
+def check_search_collection(
+    client, artist: str = TEST_ARTIST, album: str = TEST_ALBUM
+) -> Optional[dict]:
+    sep(f"1 · search_collection  —  {artist} / {album}")
     try:
-        result = client.search_collection(TEST_ARTIST, TEST_ALBUM)
+        result = client.search_collection(artist, album)
     except Exception as e:
         fail(f"Exception: {_redact(e)}")
         return None
 
     if result is None:
         fail("Not found in your collection.")
-        info(f"Is '{TEST_ALBUM}' by {TEST_ARTIST} in your Discogs?")
-        info("If so, try adjusting the artist/album strings at the top of this script.")
+        info(f"Is '{album}' by {artist} in your Discogs?")
+        info("If so, try adjusting --artist and --album and running the check again.")
         return None
 
     ok(f"Album:      {result['album']}")
@@ -112,10 +114,12 @@ def check_search_collection(client) -> Optional[dict]:
     return result
 
 
-def check_search_database(client):
-    sep(f"2 · search_database  —  {TEST_ARTIST} / {TEST_ALBUM}")
+def check_search_database(
+    client, artist: str = TEST_ARTIST, album: str = TEST_ALBUM
+):
+    sep(f"2 · search_database  —  {artist} / {album}")
     try:
-        result = client.search_database(TEST_ARTIST, TEST_ALBUM)
+        result = client.search_database(artist, album)
     except Exception as e:
         fail(f"Exception: {_redact(e)}")
         return
@@ -200,45 +204,94 @@ def check_collection_fields(client):
              "(optional; set it in config.yaml if you have that custom field).")
 
 
-def check_increment_play_count(client, collection_result: Optional[dict]):
+def check_increment_play_count(
+    client,
+    collection_result: Optional[dict],
+    artist: str = TEST_ARTIST,
+    album: str = TEST_ALBUM,
+    *,
+    confirmed: bool = False,
+    input_fn=None,
+) -> bool:
     sep("5 · increment_play_count  —  WRITE TEST")
     if collection_result is None:
         fail("Skipping — requires a successful search_collection result first.")
-        return
+        return False
 
     release_id  = collection_result["release_id"]
     instance_id = collection_result["instance_id"]
 
-    info(f"About to increment '{client.play_count_field_name}'")
-    info(f"Release {release_id}, instance {instance_id}")
+    field_name = client.play_count_field_name
+    if not confirmed:
+        if input_fn is None:
+            input_fn = input
+        prompt = (
+            "Authorize Discogs WRITE? Type exact lowercase 'yes' to continue, "
+            f"or anything else to decline. Artist: {artist}; Album: {album}; "
+            f"Field: {field_name}; Release ID: {release_id}; Instance ID: {instance_id}: "
+        )
+        try:
+            response = input_fn(prompt)
+        except (EOFError, KeyboardInterrupt):
+            response = ""
+        if response != "yes":
+            fail("Write declined; increment_play_count was not called.")
+            return False
 
+    # Keep this as the sole writer call, immediately after explicit authorization.
     try:
         success = client.increment_play_count(release_id, instance_id)
     except Exception as e:
         fail(f"Exception: {_redact(e)}")
-        return
+        return False
 
     if success:
         ok("Play Count incremented! Check your Discogs collection to confirm.")
         info("You can reset the value manually in Discogs if needed.")
     else:
         fail("Update failed — check the error logged above.")
+    return bool(success)
 
 
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
-def main():
+def _build_parser():
     parser = argparse.ArgumentParser(
         description="Live integration test for the vinyl-now-playing Discogs client."
+    )
+    parser.add_argument(
+        "--artist",
+        help=f"Artist to inspect (read-only default: {TEST_ARTIST!r}).",
+    )
+    parser.add_argument(
+        "--album",
+        help=f"Album to inspect (read-only default: {TEST_ALBUM!r}).",
     )
     parser.add_argument(
         "--test-write",
         action="store_true",
         help="Also run increment_play_count — WRITES to your Discogs collection.",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="With --test-write and explicit --artist/--album, bypass confirmation.",
+    )
+    return parser
+
+
+def main(argv=None, input_fn=None):
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.yes and not args.test_write:
+        parser.error("--yes requires --test-write")
+    if args.test_write and (args.artist is None or args.album is None):
+        parser.error("--test-write requires explicit --artist and --album")
+
+    artist = args.artist if args.artist is not None else TEST_ARTIST
+    album = args.album if args.album is not None else TEST_ALBUM
 
     print()
     print("  ╔══════════════════════════════════════════════════════╗")
@@ -281,15 +334,18 @@ def main():
     print()
     info(f"User:             {reader.username}")
     info(f"Play Count field: '{writer.play_count_field_name}'")
-    info(f"Test album:       {TEST_ARTIST} / {TEST_ALBUM}")
+    info(f"Test album:       {artist} / {album}")
     if args.test_write:
-        info("Mode:             READ + WRITE (--test-write)")
+        if args.yes:
+            info("Mode:             READ + WRITE (--test-write --yes; confirmation bypassed)")
+        else:
+            info("Mode:             READ + WRITE (--test-write; exact 'yes' required)")
     else:
         info("Mode:             read-only  (pass --test-write to also test the field update)")
 
     # Run tests
-    collection_result = check_search_collection(reader)
-    check_search_database(reader)
+    collection_result = check_search_collection(reader, artist, album)
+    check_search_database(reader, artist, album)
 
     if collection_result:
         check_get_tracklist(reader, collection_result["release_id"])
@@ -297,14 +353,23 @@ def main():
     check_collection_fields(writer)
 
     if args.test_write:
-        check_increment_play_count(writer, collection_result)
+        if not check_increment_play_count(
+            writer,
+            collection_result,
+            artist,
+            album,
+            confirmed=args.yes,
+            input_fn=input_fn,
+        ):
+            return 1
     else:
         sep("5 · increment_play_count  —  skipped (read-only mode)")
         info("Run with --test-write to also test the Play Count increment.")
 
     sep()
     print("  Done.\n")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/discogs_live_check.py
+++ b/scripts/discogs_live_check.py
@@ -247,10 +247,13 @@ def check_increment_play_count(
         f"Instance ID: {_redact(instance_id)}"
     )
     if confirmed:
-        if expected_release_id is None or expected_instance_id is None:
+        if not all(
+            type(value) is int and value > 0
+            for value in (expected_release_id, expected_instance_id)
+        ):
             fail(
                 "Noninteractive write declined — expected release and instance IDs "
-                "are both required."
+                "must both be positive integers."
             )
             return False
         if (

--- a/scripts/discogs_live_check.py
+++ b/scripts/discogs_live_check.py
@@ -6,8 +6,14 @@ All checks are read-only by default.
 
 Usage:
     python scripts/discogs_live_check.py                # read-only
-    python scripts/discogs_live_check.py --test-write   # also tests increment_play_count
-                                               # (WRITES to your Discogs collection)
+    python scripts/discogs_live_check.py --artist "Sonic Youth" --album "Sister" \
+        --test-write                                  # interactive WRITE test
+    python scripts/discogs_live_check.py --artist "Sonic Youth" --album "Sister" \
+        --test-write --yes                            # explicit noninteractive WRITE
+
+Any write test requires an explicitly selected artist and album. Use a designated
+sacrificial collection record and inspect its current field value before rerunning
+after an uncertain result.
 """
 
 import argparse
@@ -67,14 +73,15 @@ TEST_ALBUM = "Sister"
 def sep(title=""):
     width = 62
     if title:
+        title = _redact(title)
         print(f"\n{'─' * 3} {title} {'─' * max(1, width - len(title) - 5)}")
     else:
         print(f"\n{'─' * width}")
 
 
-def ok(msg):   print(f"  ✓  {msg}")
-def fail(msg): print(f"  ✗  {msg}")
-def info(msg): print(f"     {msg}")
+def ok(msg):   print(f"  ✓  {_redact(msg)}")
+def fail(msg): print(f"  ✗  {_redact(msg)}")
+def info(msg): print(f"     {_redact(msg)}")
 
 
 # ---------------------------------------------------------------------------
@@ -222,7 +229,13 @@ def check_increment_play_count(
     instance_id = collection_result["instance_id"]
 
     field_name = client.play_count_field_name
+    target = (
+        f"Artist: {_redact(artist)}; Album: {_redact(album)}; "
+        f"Field: {_redact(field_name)}; Release ID: {_redact(release_id)}; "
+        f"Instance ID: {_redact(instance_id)}"
+    )
     if not confirmed:
+        info(f"!!! WRITE TARGET — {target}")
         if input_fn is None:
             input_fn = input
         prompt = (
@@ -231,25 +244,33 @@ def check_increment_play_count(
             f"Field: {field_name}; Release ID: {release_id}; Instance ID: {instance_id}: "
         )
         try:
-            response = input_fn(prompt)
+            response = input_fn(_redact(prompt))
         except (EOFError, KeyboardInterrupt):
             response = ""
         if response != "yes":
             fail("Write declined; increment_play_count was not called.")
             return False
+    else:
+        info(f"!!! WRITE AUTHORIZED (--yes) — {target}")
 
     # Keep this as the sole writer call, immediately after explicit authorization.
     try:
         success = client.increment_play_count(release_id, instance_id)
     except Exception as e:
-        fail(f"Exception: {_redact(e)}")
+        fail(
+            f"Exception: {_redact(e)}. inspect the current Discogs field value "
+            "before rerunning; do not retry blindly because the remote state may be unknown."
+        )
         return False
 
     if success:
         ok("Play Count incremented! Check your Discogs collection to confirm.")
         info("You can reset the value manually in Discogs if needed.")
     else:
-        fail("Update failed — check the error logged above.")
+        fail(
+            "Update failed — inspect the current Discogs field value before rerunning; "
+            "do not retry blindly because the remote state may be unknown."
+        )
     return bool(success)
 
 
@@ -282,9 +303,21 @@ def _build_parser():
     return parser
 
 
+def _validate_target_value(parser, option: str, value: Optional[str]) -> None:
+    """Reject unsafe display/search targets without normalizing valid input."""
+    if value is None:
+        return
+    if not value.strip():
+        parser.error(f"{option} must contain a non-whitespace value")
+    if not value.isprintable():
+        parser.error(f"{option} must contain printable characters only")
+
+
 def main(argv=None, input_fn=None):
     parser = _build_parser()
     args = parser.parse_args(argv)
+    _validate_target_value(parser, "--artist", args.artist)
+    _validate_target_value(parser, "--album", args.album)
     if args.yes and not args.test_write:
         parser.error("--yes requires --test-write")
     if args.test_write and (args.artist is None or args.album is None):

--- a/scripts/discogs_live_check.py
+++ b/scripts/discogs_live_check.py
@@ -9,7 +9,8 @@ Usage:
     python scripts/discogs_live_check.py --artist "Sonic Youth" --album "Sister" \
         --test-write                                  # interactive WRITE test
     python scripts/discogs_live_check.py --artist "Sonic Youth" --album "Sister" \
-        --test-write --yes                            # explicit noninteractive WRITE
+        --test-write --yes --release-id 123 --instance-id 456
+                                                        # ID-bound noninteractive WRITE
 
 Any write test requires an explicitly selected artist and album. Use a designated
 sacrificial collection record and inspect its current field value before rerunning
@@ -218,6 +219,8 @@ def check_increment_play_count(
     album: str = TEST_ALBUM,
     *,
     confirmed: bool = False,
+    expected_release_id: Optional[int] = None,
+    expected_instance_id: Optional[int] = None,
     input_fn=None,
 ) -> bool:
     sep("5 · increment_play_count  —  WRITE TEST")
@@ -225,8 +228,17 @@ def check_increment_play_count(
         fail("Skipping — requires a successful search_collection result first.")
         return False
 
-    release_id  = collection_result["release_id"]
-    instance_id = collection_result["instance_id"]
+    release_id = collection_result.get("release_id")
+    instance_id = collection_result.get("instance_id")
+    if not all(
+        type(value) is int and value > 0
+        for value in (release_id, instance_id)
+    ):
+        fail(
+            "Write declined — resolved release and instance IDs must both be "
+            "positive integers."
+        )
+        return False
 
     field_name = client.play_count_field_name
     target = (
@@ -234,7 +246,24 @@ def check_increment_play_count(
         f"Field: {_redact(field_name)}; Release ID: {_redact(release_id)}; "
         f"Instance ID: {_redact(instance_id)}"
     )
-    if not confirmed:
+    if confirmed:
+        if expected_release_id is None or expected_instance_id is None:
+            fail(
+                "Noninteractive write declined — expected release and instance IDs "
+                "are both required."
+            )
+            return False
+        if (
+            release_id != expected_release_id
+            or instance_id != expected_instance_id
+        ):
+            fail(
+                "Noninteractive write declined — the resolved collection identity "
+                "does not match the expected release and instance IDs."
+            )
+            return False
+        info(f"!!! WRITE AUTHORIZED (--yes) — {target}")
+    else:
         info(f"!!! WRITE TARGET — {target}")
         if input_fn is None:
             input_fn = input
@@ -250,8 +279,6 @@ def check_increment_play_count(
         if response != "yes":
             fail("Write declined; increment_play_count was not called.")
             return False
-    else:
-        info(f"!!! WRITE AUTHORIZED (--yes) — {target}")
 
     # Keep this as the sole writer call, immediately after explicit authorization.
     try:
@@ -298,9 +325,33 @@ def _build_parser():
     parser.add_argument(
         "--yes",
         action="store_true",
-        help="With --test-write and explicit --artist/--album, bypass confirmation.",
+        help=(
+            "With --test-write, explicit artist/album, and matching release/instance "
+            "IDs, bypass confirmation."
+        ),
+    )
+    parser.add_argument(
+        "--release-id",
+        type=_positive_id,
+        help="Expected positive Discogs release ID (required with --yes).",
+    )
+    parser.add_argument(
+        "--instance-id",
+        type=_positive_id,
+        help="Expected positive collection instance ID (required with --yes).",
     )
     return parser
+
+
+def _positive_id(value: str) -> int:
+    """Return a positive integer ID for argparse."""
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive integer") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
 
 
 def _validate_target_value(parser, option: str, value: Optional[str]) -> None:
@@ -322,6 +373,10 @@ def main(argv=None, input_fn=None):
         parser.error("--yes requires --test-write")
     if args.test_write and (args.artist is None or args.album is None):
         parser.error("--test-write requires explicit --artist and --album")
+    if args.yes and (args.release_id is None or args.instance_id is None):
+        parser.error("--yes requires explicit --release-id and --instance-id")
+    if (args.release_id is not None or args.instance_id is not None) and not args.yes:
+        parser.error("--release-id and --instance-id require --yes")
 
     artist = args.artist if args.artist is not None else TEST_ARTIST
     album = args.album if args.album is not None else TEST_ALBUM
@@ -392,6 +447,8 @@ def main(argv=None, input_fn=None):
             artist,
             album,
             confirmed=args.yes,
+            expected_release_id=args.release_id,
+            expected_instance_id=args.instance_id,
             input_fn=input_fn,
         ):
             return 1

--- a/scripts/render_system_service.py
+++ b/scripts/render_system_service.py
@@ -21,6 +21,7 @@ _PLACEHOLDER_COUNTS = {
 }
 _SERVICE_USER = re.compile(r"[a-z_][a-z0-9_-]{0,31}\Z")
 _DISPLAY = re.compile(r":[0-9]+(?:\.[0-9]+)?\Z")
+_SAFE_ABSOLUTE_PATH = re.compile(r"/[A-Za-z0-9._/-]*\Z")
 
 
 class RenderError(ValueError):
@@ -38,10 +39,14 @@ def _safe_text(name: str, value: str | os.PathLike[str]) -> str:
 
 def _absolute_path(name: str, value: str | os.PathLike[str]) -> Path:
     text = _safe_text(name, value)
+    if not _SAFE_ABSOLUTE_PATH.fullmatch(text):
+        raise RenderError(f"{name} contains characters unsafe for a systemd unit")
+    if "//" in text:
+        raise RenderError(f"{name} must not contain noncanonical double slashes")
     path = Path(text)
     if not path.is_absolute():
         raise RenderError(f"{name} must be an absolute path")
-    if any(part in {".", ".."} for part in path.parts):
+    if any(part in {".", ".."} for part in text.split("/")[1:]):
         raise RenderError(f"{name} must not contain relative path components")
     return path
 
@@ -55,7 +60,26 @@ def _directory(path: Path, name: str) -> None:
         raise RenderError(f"{name} must be a real directory: {path}")
 
 
-def _validate_config(config_path: Path) -> None:
+def _reject_symlink_ancestors(path: Path, name: str) -> None:
+    """Reject every existing caller-controlled component, not only the leaf."""
+    current = Path(path.anchor)
+    for component in path.parts[1:]:
+        current /= component
+        try:
+            metadata = os.lstat(current)
+        except FileNotFoundError:
+            return
+        except OSError as error:
+            raise RenderError(f"cannot inspect {name}: {current}") from error
+        if stat.S_ISLNK(metadata.st_mode):
+            raise RenderError(f"{name} must not contain a symlink: {current}")
+
+
+def _same_file(left: os.stat_result, right: os.stat_result) -> bool:
+    return left.st_dev == right.st_dev and left.st_ino == right.st_ino
+
+
+def _validate_config(config_path: Path) -> os.stat_result:
     if os.name != "posix" or not hasattr(os, "O_NOFOLLOW"):
         raise RenderError("rendering requires POSIX O_NOFOLLOW support for config.yaml")
 
@@ -75,24 +99,39 @@ def _validate_config(config_path: Path) -> None:
         raise RenderError(f"config.yaml must be a regular file: {config_path}")
     if stat.S_IMODE(metadata.st_mode) != 0o600:
         raise RenderError(f"config.yaml must have mode 0600: {config_path}")
+    return metadata
 
 
-def _validate_output(output: Path, config_path: Path) -> None:
+def _template_metadata() -> os.stat_result:
+    _reject_symlink_ancestors(TEMPLATE, "template")
+    try:
+        metadata = os.lstat(TEMPLATE)
+    except OSError as error:
+        raise RenderError(f"cannot inspect system-service template: {TEMPLATE}") from error
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise RenderError(f"system-service template must be a regular file: {TEMPLATE}")
+    return metadata
+
+
+def _validate_output(
+    output: Path, config: os.stat_result, template: os.stat_result
+) -> os.stat_result | None:
     _directory(output.parent, "output parent")
-    if output == config_path:
-        raise RenderError("output must not replace config.yaml")
-    if output == TEMPLATE:
-        raise RenderError("output must not replace the unit template")
     try:
         metadata = os.lstat(output)
     except FileNotFoundError:
-        return
+        return None
     except OSError as error:
         raise RenderError(f"cannot inspect output: {output}") from error
     if stat.S_ISLNK(metadata.st_mode):
         raise RenderError(f"output must not be a symlink: {output}")
     if not stat.S_ISREG(metadata.st_mode):
         raise RenderError(f"output must be a regular file: {output}")
+    if _same_file(metadata, config):
+        raise RenderError("output must not refer to config.yaml")
+    if _same_file(metadata, template):
+        raise RenderError("output must not refer to the unit template")
+    return metadata
 
 
 def _render_template(values: Mapping[str, str]) -> bytes:
@@ -110,7 +149,13 @@ def _render_template(values: Mapping[str, str]) -> bytes:
     return template.encode("utf-8")
 
 
-def _existing_output_matches(output: Path, rendered: bytes) -> bool:
+def _existing_output_matches(
+    output: Path,
+    rendered: bytes,
+    expected: os.stat_result | None,
+    config: os.stat_result,
+    template: os.stat_result,
+) -> bool:
     flags = os.O_RDONLY
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
@@ -124,6 +169,14 @@ def _existing_output_matches(output: Path, rendered: bytes) -> bool:
         metadata = os.fstat(descriptor)
         if not stat.S_ISREG(metadata.st_mode):
             raise RenderError(f"output must be a regular file: {output}")
+        if _same_file(metadata, config):
+            raise RenderError("output must not refer to config.yaml")
+        if _same_file(metadata, template):
+            raise RenderError("output must not refer to the unit template")
+        if expected is not None and not _same_file(metadata, expected):
+            raise RenderError(f"output changed while it was being rendered: {output}")
+        if stat.S_IMODE(metadata.st_mode) != 0o644:
+            return False
         chunks = []
         while True:
             chunk = os.read(descriptor, 65_536)
@@ -135,21 +188,55 @@ def _existing_output_matches(output: Path, rendered: bytes) -> bool:
         os.close(descriptor)
 
 
-def _atomic_write(output: Path, rendered: bytes) -> None:
-    descriptor, temporary_name = tempfile.mkstemp(
-        prefix=f".{output.name}.", suffix=".tmp", dir=output.parent
-    )
-    temporary = Path(temporary_name)
+def _fsync_directory(directory: Path) -> None:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    descriptor = os.open(directory, flags)
     try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _atomic_write(output: Path, rendered: bytes) -> None:
+    descriptor: int | None = None
+    temporary: Path | None = None
+    write_error: OSError | None = None
+    try:
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{output.name}.", suffix=".tmp", dir=output.parent
+        )
+        temporary = Path(temporary_name)
         os.fchmod(descriptor, 0o644)
-        with os.fdopen(descriptor, "wb") as unit_file:
+        unit_file = os.fdopen(descriptor, "wb")
+        descriptor = None
+        with unit_file:
             unit_file.write(rendered)
             unit_file.flush()
             os.fsync(unit_file.fileno())
         os.replace(temporary, output)
+        _fsync_directory(output.parent)
+    except OSError as error:
+        write_error = error
+        raise RenderError(f"cannot atomically write output: {output}") from error
     finally:
-        if temporary.exists():
-            temporary.unlink()
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError as error:
+                if write_error is None:
+                    raise RenderError(f"cannot close temporary output: {output}") from error
+        if temporary is not None:
+            try:
+                os.unlink(temporary)
+            except FileNotFoundError:
+                pass
+            except OSError as error:
+                if write_error is None:
+                    raise RenderError(f"cannot remove temporary output: {output}") from error
 
 
 def render_system_service(
@@ -171,10 +258,14 @@ def render_system_service(
     xauthority = _absolute_path("xauthority", xauthority)
     output = _absolute_path("output", output)
 
+    _reject_symlink_ancestors(app_dir, "app-dir")
+    _reject_symlink_ancestors(xauthority, "xauthority")
+    _reject_symlink_ancestors(output, "output")
     _directory(app_dir, "app-dir")
     config_path = app_dir / "config.yaml"
-    _validate_config(config_path)
-    _validate_output(output, config_path)
+    config = _validate_config(config_path)
+    template = _template_metadata()
+    existing_output = _validate_output(output, config, template)
 
     rendered = _render_template(
         {
@@ -184,7 +275,7 @@ def render_system_service(
             "@XAUTHORITY@": str(xauthority),
         }
     )
-    if _existing_output_matches(output, rendered):
+    if _existing_output_matches(output, rendered, existing_output, config, template):
         return False
     _atomic_write(output, rendered)
     return True

--- a/scripts/render_system_service.py
+++ b/scripts/render_system_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import os
 from pathlib import Path
 import re
@@ -13,6 +14,8 @@ from typing import Mapping, Sequence
 
 
 TEMPLATE = Path(__file__).resolve().parent.parent / "deploy" / "vinyl-now-playing.service.in"
+# Intentional template edits must update this reviewed content-trust value.
+_TRUSTED_TEMPLATE_SHA256 = "717ed55031d2c02162522fade1332835d387cbafcb93c201829a1e6339e276cd"
 _PLACEHOLDER_COUNTS = {
     "@SERVICE_USER@": 1,
     "@APP_DIR@": 3,
@@ -203,8 +206,13 @@ def _render_template(
         or after_read.st_mtime_ns != expected.st_mtime_ns
     ):
         raise RenderError(f"system-service template changed while it was being read: {TEMPLATE}")
+    template_bytes = b"".join(chunks)
+    if hashlib.sha256(template_bytes).hexdigest() != _TRUSTED_TEMPLATE_SHA256:
+        raise RenderError(
+            f"system-service template does not match trusted template content: {TEMPLATE}"
+        )
     try:
-        template = b"".join(chunks).decode("utf-8")
+        template = template_bytes.decode("utf-8")
     except UnicodeDecodeError as error:
         raise RenderError(f"cannot decode system-service template as UTF-8: {TEMPLATE}") from error
 

--- a/scripts/render_system_service.py
+++ b/scripts/render_system_service.py
@@ -114,9 +114,17 @@ def _template_metadata() -> os.stat_result:
 
 
 def _validate_output(
-    output: Path, config: os.stat_result, template: os.stat_result
+    output: Path,
+    config_path: Path,
+    template_path: Path,
+    config: os.stat_result,
+    template: os.stat_result,
 ) -> os.stat_result | None:
     _directory(output.parent, "output parent")
+    if output == config_path:
+        raise RenderError("output must not refer to config.yaml")
+    if output == template_path:
+        raise RenderError("output must not refer to the unit template")
     try:
         metadata = os.lstat(output)
     except FileNotFoundError:
@@ -134,11 +142,69 @@ def _validate_output(
     return metadata
 
 
-def _render_template(values: Mapping[str, str]) -> bytes:
+def _open_template(
+    expected: os.stat_result, config: os.stat_result
+) -> tuple[int, os.stat_result]:
+    flags = os.O_RDONLY | os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
     try:
-        template = TEMPLATE.read_text(encoding="utf-8")
+        descriptor = os.open(TEMPLATE, flags)
+    except OSError as error:
+        raise RenderError(f"cannot safely open system-service template: {TEMPLATE}") from error
+    try:
+        metadata = os.fstat(descriptor)
+    except OSError as error:
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+        raise RenderError(f"cannot inspect system-service template: {TEMPLATE}") from error
+
+    if not stat.S_ISREG(metadata.st_mode):
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+        raise RenderError(f"system-service template must be a regular file: {TEMPLATE}")
+    if not _same_file(metadata, expected):
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+        raise RenderError(f"system-service template changed while it was being rendered: {TEMPLATE}")
+    if _same_file(metadata, config):
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+        raise RenderError("system-service template must not refer to config.yaml")
+    return descriptor, metadata
+
+
+def _render_template(
+    descriptor: int, expected: os.stat_result, values: Mapping[str, str]
+) -> bytes:
+    chunks = []
+    try:
+        while True:
+            chunk = os.read(descriptor, 65_536)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        after_read = os.fstat(descriptor)
     except OSError as error:
         raise RenderError(f"cannot read system-service template: {TEMPLATE}") from error
+    if (
+        not _same_file(after_read, expected)
+        or after_read.st_size != expected.st_size
+        or after_read.st_mtime_ns != expected.st_mtime_ns
+    ):
+        raise RenderError(f"system-service template changed while it was being read: {TEMPLATE}")
+    try:
+        template = b"".join(chunks).decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise RenderError(f"cannot decode system-service template as UTF-8: {TEMPLATE}") from error
 
     for placeholder, expected_count in _PLACEHOLDER_COUNTS.items():
         if template.count(placeholder) != expected_count:
@@ -165,6 +231,7 @@ def _existing_output_matches(
         return False
     except OSError as error:
         raise RenderError(f"cannot safely read output: {output}") from error
+    failure: BaseException | None = None
     try:
         metadata = os.fstat(descriptor)
         if not stat.S_ISREG(metadata.st_mode):
@@ -184,8 +251,18 @@ def _existing_output_matches(
                 break
             chunks.append(chunk)
         return b"".join(chunks) == rendered
+    except OSError as error:
+        failure = error
+        raise RenderError(f"cannot safely read output: {output}") from error
+    except RenderError as error:
+        failure = error
+        raise
     finally:
-        os.close(descriptor)
+        try:
+            os.close(descriptor)
+        except OSError as error:
+            if failure is None:
+                raise RenderError(f"cannot safely read output: {output}") from error
 
 
 def _fsync_directory(directory: Path) -> None:
@@ -264,17 +341,32 @@ def render_system_service(
     _directory(app_dir, "app-dir")
     config_path = app_dir / "config.yaml"
     config = _validate_config(config_path)
-    template = _template_metadata()
-    existing_output = _validate_output(output, config, template)
-
-    rendered = _render_template(
-        {
-            "@SERVICE_USER@": user,
-            "@APP_DIR@": str(app_dir),
-            "@DISPLAY@": display,
-            "@XAUTHORITY@": str(xauthority),
-        }
-    )
+    expected_template = _template_metadata()
+    template_descriptor, template = _open_template(expected_template, config)
+    template_error: BaseException | None = None
+    try:
+        existing_output = _validate_output(
+            output, config_path, TEMPLATE, config, template
+        )
+        rendered = _render_template(
+            template_descriptor,
+            template,
+            {
+                "@SERVICE_USER@": user,
+                "@APP_DIR@": str(app_dir),
+                "@DISPLAY@": display,
+                "@XAUTHORITY@": str(xauthority),
+            },
+        )
+    except BaseException as error:
+        template_error = error
+        raise
+    finally:
+        try:
+            os.close(template_descriptor)
+        except OSError as error:
+            if template_error is None:
+                raise RenderError(f"cannot close system-service template: {TEMPLATE}") from error
     if _existing_output_matches(output, rendered, existing_output, config, template):
         return False
     _atomic_write(output, rendered)

--- a/scripts/render_system_service.py
+++ b/scripts/render_system_service.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Render the supported vinyl-now-playing systemd unit without installing it."""
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import re
+import stat
+import sys
+import tempfile
+from typing import Mapping, Sequence
+
+
+TEMPLATE = Path(__file__).resolve().parent.parent / "deploy" / "vinyl-now-playing.service.in"
+_PLACEHOLDER_COUNTS = {
+    "@SERVICE_USER@": 1,
+    "@APP_DIR@": 3,
+    "@DISPLAY@": 1,
+    "@XAUTHORITY@": 1,
+}
+_SERVICE_USER = re.compile(r"[a-z_][a-z0-9_-]{0,31}\Z")
+_DISPLAY = re.compile(r":[0-9]+(?:\.[0-9]+)?\Z")
+
+
+class RenderError(ValueError):
+    """Raised when a service unit cannot be rendered safely."""
+
+
+def _safe_text(name: str, value: str | os.PathLike[str]) -> str:
+    text = os.fspath(value)
+    if not isinstance(text, str) or not text:
+        raise RenderError(f"{name} must be a non-empty string")
+    if any(character.isspace() or ord(character) < 32 or ord(character) == 127 for character in text):
+        raise RenderError(f"{name} must not contain whitespace or control characters")
+    return text
+
+
+def _absolute_path(name: str, value: str | os.PathLike[str]) -> Path:
+    text = _safe_text(name, value)
+    path = Path(text)
+    if not path.is_absolute():
+        raise RenderError(f"{name} must be an absolute path")
+    if any(part in {".", ".."} for part in path.parts):
+        raise RenderError(f"{name} must not contain relative path components")
+    return path
+
+
+def _directory(path: Path, name: str) -> None:
+    try:
+        metadata = os.lstat(path)
+    except OSError as error:
+        raise RenderError(f"{name} does not exist: {path}") from error
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+        raise RenderError(f"{name} must be a real directory: {path}")
+
+
+def _validate_config(config_path: Path) -> None:
+    if os.name != "posix" or not hasattr(os, "O_NOFOLLOW"):
+        raise RenderError("rendering requires POSIX O_NOFOLLOW support for config.yaml")
+
+    flags = os.O_RDONLY | os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    try:
+        descriptor = os.open(config_path, flags)
+    except OSError as error:
+        raise RenderError(f"cannot safely open config.yaml: {config_path}") from error
+    try:
+        metadata = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+
+    if not stat.S_ISREG(metadata.st_mode):
+        raise RenderError(f"config.yaml must be a regular file: {config_path}")
+    if stat.S_IMODE(metadata.st_mode) != 0o600:
+        raise RenderError(f"config.yaml must have mode 0600: {config_path}")
+
+
+def _validate_output(output: Path, config_path: Path) -> None:
+    _directory(output.parent, "output parent")
+    if output == config_path:
+        raise RenderError("output must not replace config.yaml")
+    if output == TEMPLATE:
+        raise RenderError("output must not replace the unit template")
+    try:
+        metadata = os.lstat(output)
+    except FileNotFoundError:
+        return
+    except OSError as error:
+        raise RenderError(f"cannot inspect output: {output}") from error
+    if stat.S_ISLNK(metadata.st_mode):
+        raise RenderError(f"output must not be a symlink: {output}")
+    if not stat.S_ISREG(metadata.st_mode):
+        raise RenderError(f"output must be a regular file: {output}")
+
+
+def _render_template(values: Mapping[str, str]) -> bytes:
+    try:
+        template = TEMPLATE.read_text(encoding="utf-8")
+    except OSError as error:
+        raise RenderError(f"cannot read system-service template: {TEMPLATE}") from error
+
+    for placeholder, expected_count in _PLACEHOLDER_COUNTS.items():
+        if template.count(placeholder) != expected_count:
+            raise RenderError(f"invalid system-service template placeholder: {placeholder}")
+        template = template.replace(placeholder, values[placeholder])
+    if "@" in template:
+        raise RenderError("system-service template contains an unknown placeholder")
+    return template.encode("utf-8")
+
+
+def _existing_output_matches(output: Path, rendered: bytes) -> bool:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(output, flags)
+    except FileNotFoundError:
+        return False
+    except OSError as error:
+        raise RenderError(f"cannot safely read output: {output}") from error
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise RenderError(f"output must be a regular file: {output}")
+        chunks = []
+        while True:
+            chunk = os.read(descriptor, 65_536)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        return b"".join(chunks) == rendered
+    finally:
+        os.close(descriptor)
+
+
+def _atomic_write(output: Path, rendered: bytes) -> None:
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{output.name}.", suffix=".tmp", dir=output.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, 0o644)
+        with os.fdopen(descriptor, "wb") as unit_file:
+            unit_file.write(rendered)
+            unit_file.flush()
+            os.fsync(unit_file.fileno())
+        os.replace(temporary, output)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def render_system_service(
+    *,
+    user: str,
+    app_dir: str | os.PathLike[str],
+    display: str,
+    xauthority: str | os.PathLike[str],
+    output: str | os.PathLike[str],
+) -> bool:
+    """Render a validated unit and return whether it replaced the output file."""
+    user = _safe_text("user", user)
+    if not _SERVICE_USER.fullmatch(user):
+        raise RenderError("user must be a safe system account name")
+    display = _safe_text("display", display)
+    if not _DISPLAY.fullmatch(display):
+        raise RenderError("display must be an X display such as :0")
+    app_dir = _absolute_path("app-dir", app_dir)
+    xauthority = _absolute_path("xauthority", xauthority)
+    output = _absolute_path("output", output)
+
+    _directory(app_dir, "app-dir")
+    config_path = app_dir / "config.yaml"
+    _validate_config(config_path)
+    _validate_output(output, config_path)
+
+    rendered = _render_template(
+        {
+            "@SERVICE_USER@": user,
+            "@APP_DIR@": str(app_dir),
+            "@DISPLAY@": display,
+            "@XAUTHORITY@": str(xauthority),
+        }
+    )
+    if _existing_output_matches(output, rendered):
+        return False
+    _atomic_write(output, rendered)
+    return True
+
+
+def _arguments(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--user", required=True, help="system account that runs the service")
+    parser.add_argument("--app-dir", required=True, help="absolute application directory")
+    parser.add_argument("--display", required=True, help="X display such as :0")
+    parser.add_argument("--xauthority", required=True, help="absolute Xauthority path")
+    parser.add_argument("--output", required=True, help="absolute rendered unit path")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _arguments(argv)
+    try:
+        changed = render_system_service(
+            user=arguments.user,
+            app_dir=arguments.app_dir,
+            display=arguments.display,
+            xauthority=arguments.xauthority,
+            output=arguments.output,
+        )
+    except RenderError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+    print("rendered system service" if changed else "system service already current")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_system_service.py
+++ b/scripts/render_system_service.py
@@ -6,9 +6,9 @@ import argparse
 import os
 from pathlib import Path
 import re
+import secrets
 import stat
 import sys
-import tempfile
 from typing import Mapping, Sequence
 
 
@@ -115,18 +115,20 @@ def _template_metadata() -> os.stat_result:
 
 def _validate_output(
     output: Path,
+    output_parent_descriptor: int,
     config_path: Path,
     template_path: Path,
     config: os.stat_result,
     template: os.stat_result,
 ) -> os.stat_result | None:
-    _directory(output.parent, "output parent")
     if output == config_path:
         raise RenderError("output must not refer to config.yaml")
     if output == template_path:
         raise RenderError("output must not refer to the unit template")
     try:
-        metadata = os.lstat(output)
+        metadata = os.stat(
+            output.name, dir_fd=output_parent_descriptor, follow_symlinks=False
+        )
     except FileNotFoundError:
         return None
     except OSError as error:
@@ -217,6 +219,7 @@ def _render_template(
 
 def _existing_output_matches(
     output: Path,
+    output_parent_descriptor: int,
     rendered: bytes,
     expected: os.stat_result | None,
     config: os.stat_result,
@@ -226,7 +229,7 @@ def _existing_output_matches(
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
     try:
-        descriptor = os.open(output, flags)
+        descriptor = os.open(output.name, flags, dir_fd=output_parent_descriptor)
     except FileNotFoundError:
         return False
     except OSError as error:
@@ -265,28 +268,77 @@ def _existing_output_matches(
                 raise RenderError(f"cannot safely read output: {output}") from error
 
 
-def _fsync_directory(directory: Path) -> None:
-    flags = os.O_RDONLY
-    if hasattr(os, "O_DIRECTORY"):
-        flags |= os.O_DIRECTORY
+def _open_output_parent(output: Path) -> tuple[int, os.stat_result]:
+    if os.name != "posix" or not hasattr(os, "O_NOFOLLOW") or not hasattr(os, "O_DIRECTORY"):
+        raise RenderError("rendering requires POSIX directory-descriptor support")
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
     if hasattr(os, "O_CLOEXEC"):
         flags |= os.O_CLOEXEC
-    descriptor = os.open(directory, flags)
-    try:
-        os.fsync(descriptor)
-    finally:
-        os.close(descriptor)
-
-
-def _atomic_write(output: Path, rendered: bytes) -> None:
     descriptor: int | None = None
-    temporary: Path | None = None
-    write_error: OSError | None = None
     try:
-        descriptor, temporary_name = tempfile.mkstemp(
-            prefix=f".{output.name}.", suffix=".tmp", dir=output.parent
+        descriptor = os.open(output.parent, flags)
+        metadata = os.fstat(descriptor)
+    except OSError as error:
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+        raise RenderError(f"cannot safely open output parent: {output.parent}") from error
+    if not stat.S_ISDIR(metadata.st_mode):
+        os.close(descriptor)
+        raise RenderError(f"output parent must be a real directory: {output.parent}")
+    try:
+        path_metadata = os.lstat(output.parent)
+    except OSError as error:
+        os.close(descriptor)
+        raise RenderError(f"cannot inspect output parent: {output.parent}") from error
+    if stat.S_ISLNK(path_metadata.st_mode) or not _same_file(path_metadata, metadata):
+        os.close(descriptor)
+        raise RenderError(f"output parent changed while it was being opened: {output.parent}")
+    return descriptor, metadata
+
+
+def _verify_output_parent(output: Path, expected: os.stat_result) -> None:
+    try:
+        metadata = os.lstat(output.parent)
+    except OSError as error:
+        raise RenderError(f"output parent changed while rendering: {output.parent}") from error
+    if (
+        stat.S_ISLNK(metadata.st_mode)
+        or not stat.S_ISDIR(metadata.st_mode)
+        or not _same_file(metadata, expected)
+    ):
+        raise RenderError(f"output parent changed while rendering: {output.parent}")
+
+
+def _temporary_output_name(output: Path, output_parent_descriptor: int) -> tuple[int, str]:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    for _attempt in range(128):
+        name = f".{output.name}.{secrets.token_hex(8)}.tmp"
+        try:
+            descriptor = os.open(name, flags, 0o600, dir_fd=output_parent_descriptor)
+        except FileExistsError:
+            continue
+        return descriptor, name
+    raise RenderError(f"cannot create unique temporary output: {output}")
+
+
+def _atomic_write(
+    output: Path,
+    rendered: bytes,
+    output_parent_descriptor: int,
+    output_parent: os.stat_result,
+) -> None:
+    descriptor: int | None = None
+    temporary_name: str | None = None
+    write_error: BaseException | None = None
+    try:
+        descriptor, temporary_name = _temporary_output_name(
+            output, output_parent_descriptor
         )
-        temporary = Path(temporary_name)
         os.fchmod(descriptor, 0o644)
         unit_file = os.fdopen(descriptor, "wb")
         descriptor = None
@@ -294,8 +346,18 @@ def _atomic_write(output: Path, rendered: bytes) -> None:
             unit_file.write(rendered)
             unit_file.flush()
             os.fsync(unit_file.fileno())
-        os.replace(temporary, output)
-        _fsync_directory(output.parent)
+        _verify_output_parent(output, output_parent)
+        os.replace(
+            temporary_name,
+            output.name,
+            src_dir_fd=output_parent_descriptor,
+            dst_dir_fd=output_parent_descriptor,
+        )
+        os.fsync(output_parent_descriptor)
+        _verify_output_parent(output, output_parent)
+    except RenderError as error:
+        write_error = error
+        raise
     except OSError as error:
         write_error = error
         raise RenderError(f"cannot atomically write output: {output}") from error
@@ -306,9 +368,9 @@ def _atomic_write(output: Path, rendered: bytes) -> None:
             except OSError as error:
                 if write_error is None:
                     raise RenderError(f"cannot close temporary output: {output}") from error
-        if temporary is not None:
+        if temporary_name is not None:
             try:
-                os.unlink(temporary)
+                os.unlink(temporary_name, dir_fd=output_parent_descriptor)
             except FileNotFoundError:
                 pass
             except OSError as error:
@@ -343,10 +405,17 @@ def render_system_service(
     config = _validate_config(config_path)
     expected_template = _template_metadata()
     template_descriptor, template = _open_template(expected_template, config)
+    output_parent_descriptor: int | None = None
     template_error: BaseException | None = None
     try:
+        output_parent_descriptor, output_parent = _open_output_parent(output)
         existing_output = _validate_output(
-            output, config_path, TEMPLATE, config, template
+            output,
+            output_parent_descriptor,
+            config_path,
+            TEMPLATE,
+            config,
+            template,
         )
         rendered = _render_template(
             template_descriptor,
@@ -358,19 +427,38 @@ def render_system_service(
                 "@XAUTHORITY@": str(xauthority),
             },
         )
+        if _existing_output_matches(
+            output,
+            output_parent_descriptor,
+            rendered,
+            existing_output,
+            config,
+            template,
+        ):
+            _verify_output_parent(output, output_parent)
+            return False
+        _atomic_write(
+            output,
+            rendered,
+            output_parent_descriptor,
+            output_parent,
+        )
+        return True
     except BaseException as error:
         template_error = error
         raise
     finally:
+        if output_parent_descriptor is not None:
+            try:
+                os.close(output_parent_descriptor)
+            except OSError as error:
+                if template_error is None:
+                    raise RenderError(f"cannot close output parent: {output.parent}") from error
         try:
             os.close(template_descriptor)
         except OSError as error:
             if template_error is None:
                 raise RenderError(f"cannot close system-service template: {TEMPLATE}") from error
-    if _existing_output_matches(output, rendered, existing_output, config, template):
-        return False
-    _atomic_write(output, rendered)
-    return True
 
 
 def _arguments(argv: Sequence[str] | None = None) -> argparse.Namespace:

--- a/src/config.py
+++ b/src/config.py
@@ -56,6 +56,8 @@ def _config_file_mode(file_obj):
     unsupported/unknown result: callers warn and continue on platforms where
     POSIX mode semantics are unavailable.
     """
+    if os.name != "posix":
+        return None
     try:
         file_stat = os.fstat(file_obj.fileno())
         if not stat.S_ISREG(file_stat.st_mode):

--- a/src/config.py
+++ b/src/config.py
@@ -27,7 +27,9 @@ documented in CODE_REVIEW_2026-06-17.md (finding A-2).
 """
 
 from dataclasses import dataclass
+import os
 from pathlib import Path
+import stat
 from typing import Optional
 
 import difflib
@@ -44,6 +46,23 @@ class ConfigError(Exception):
     The message is human-facing and may span multiple lines (one bullet per
     problem); ``main.py`` logs it and exits non-zero at startup.
     """
+
+
+def _config_file_mode(file_obj):
+    """Return the mode of an opened regular config file, or ``None``.
+
+    The descriptor is inspected rather than the path so the permission decision
+    applies to the exact file that will be parsed.  ``None`` is deliberately an
+    unsupported/unknown result: callers warn and continue on platforms where
+    POSIX mode semantics are unavailable.
+    """
+    try:
+        file_stat = os.fstat(file_obj.fileno())
+        if not stat.S_ISREG(file_stat.st_mode):
+            return None
+        return stat.S_IMODE(file_stat.st_mode)
+    except (AttributeError, OSError, TypeError, ValueError):
+        return None
 
 
 # Sentinel marking a field that has no default — it MUST be present in the
@@ -511,6 +530,17 @@ def load_config(path: str = "config.yaml") -> AppConfig:
         )
     try:
         with open(p, encoding="utf-8") as f:
+            mode = _config_file_mode(f)
+            if mode is None:
+                log.warning(
+                    "Could not verify POSIX permissions for %s; continuing",
+                    path,
+                )
+            elif mode & 0o077:
+                raise ConfigError(
+                    f"{path} permissions are too permissive (mode {mode:04o}); "
+                    f"run chmod 600 {path}"
+                )
             raw = yaml.safe_load(f)
     except yaml.YAMLError as e:
         raise ConfigError(f"{path} is not valid YAML: {e}")

--- a/tests/test_audio_backend_smoke.py
+++ b/tests/test_audio_backend_smoke.py
@@ -1,6 +1,10 @@
 """Unit checks for the CI sounddevice import boundary (#156)."""
 import importlib.util
+import os
 from pathlib import Path
+import shutil
+import subprocess
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -57,6 +61,84 @@ def test_main_redacts_import_error_and_gives_portaudio_remediation(monkeypatch, 
     assert "sounddevice" in output
     assert "libportaudio2" in output
     assert "token=not-for-output" not in output
+
+
+class _Distribution:
+    def __init__(self, root, files):
+        self.root = root
+        self.files = files
+
+    def locate_file(self, path):
+        return self.root / path
+
+
+def test_distribution_provenance_accepts_a_declared_sounddevice_module(tmp_path):
+    backend = _backend_module()
+    module_file = tmp_path / "sounddevice.py"
+    module_file.touch()
+    module = SimpleNamespace(__file__=str(module_file))
+    distribution = _Distribution(tmp_path, (Path("sounddevice.py"),))
+
+    assert backend.validate_distribution_provenance(
+        module, distribution_loader=lambda _name: distribution
+    ) is None
+
+
+def test_distribution_provenance_rejects_a_same_name_shadow_module(tmp_path):
+    backend = _backend_module()
+    installed_root = tmp_path / "installed"
+    installed_root.mkdir()
+    installed_file = installed_root / "sounddevice.py"
+    installed_file.touch()
+    shadow_file = tmp_path / "scripts" / "sounddevice.py"
+    shadow_file.parent.mkdir()
+    shadow_file.touch()
+    module = SimpleNamespace(__file__=str(shadow_file))
+    distribution = _Distribution(installed_root, (Path("sounddevice.py"),))
+
+    assert backend.validate_distribution_provenance(
+        module, distribution_loader=lambda _name: distribution
+    ) == "imported module is not declared by the installed distribution"
+
+
+def test_distribution_provenance_fails_closed_when_metadata_is_unreadable(tmp_path):
+    backend = _backend_module()
+    module_file = tmp_path / "sounddevice.py"
+    module_file.touch()
+    module = SimpleNamespace(__file__=str(module_file))
+
+    assert backend.validate_distribution_provenance(
+        module, distribution_loader=lambda _name: SimpleNamespace(files=None)
+    ) == "installed sounddevice distribution file manifest is unavailable"
+
+
+def test_cli_rejects_a_same_name_module_shadowing_from_its_script_directory(tmp_path):
+    script_dir = tmp_path / "scripts"
+    script_dir.mkdir()
+    shadow_script = script_dir / "check_audio_backend.py"
+    shutil.copyfile(SCRIPT, shadow_script)
+    (script_dir / "sounddevice.py").write_text(
+        "__version__ = 'fake-shadow'\n"
+        "def query_devices(): pass\n"
+        "def InputStream(): pass\n"
+        "def _terminate(): pass\n"
+        "def _initialize(): pass\n"
+    )
+    environment = os.environ.copy()
+    environment.pop("PYTHONPATH", None)
+
+    result = subprocess.run(
+        [sys.executable, str(shadow_script)],
+        cwd=tmp_path,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "provenance" in result.stderr
+    assert "fake-shadow" not in result.stdout + result.stderr
 
 
 def test_successful_import_is_retained_without_a_conftest_owned_stub():

--- a/tests/test_audio_backend_smoke.py
+++ b/tests/test_audio_backend_smoke.py
@@ -1,0 +1,118 @@
+"""Unit checks for the CI sounddevice import boundary (#156)."""
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "check_audio_backend.py"
+REQUIRED_APIS = (
+    "query_devices",
+    "InputStream",
+    "_terminate",
+    "_initialize",
+)
+
+
+def _backend_module():
+    assert SCRIPT.exists(), "CI audio backend smoke script is missing"
+    spec = importlib.util.spec_from_file_location("check_audio_backend", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _complete_backend():
+    return SimpleNamespace(**{name: lambda: None for name in REQUIRED_APIS})
+
+
+def test_validate_backend_accepts_all_production_sounddevice_apis():
+    backend = _backend_module()
+
+    assert backend.validate_backend(_complete_backend()) == ()
+
+
+@pytest.mark.parametrize("missing_api", REQUIRED_APIS)
+def test_validate_backend_reports_each_missing_or_noncallable_api(missing_api):
+    backend = _backend_module()
+    module = _complete_backend()
+    setattr(module, missing_api, None)
+
+    assert backend.validate_backend(module) == (missing_api,)
+
+
+def test_main_redacts_import_error_and_gives_portaudio_remediation(monkeypatch, capsys):
+    backend = _backend_module()
+
+    def raise_import_error(_name):
+        raise ImportError("token=not-for-output")
+
+    monkeypatch.setattr(backend.importlib, "import_module", raise_import_error)
+
+    assert backend.main() == 1
+    output = capsys.readouterr().err
+    assert "sounddevice" in output
+    assert "libportaudio2" in output
+    assert "token=not-for-output" not in output
+
+
+def test_successful_import_is_retained_without_a_conftest_owned_stub():
+    import conftest
+
+    external_module = SimpleNamespace(__name__="sounddevice")
+    modules = {"sounddevice": external_module}
+
+    module, owned_stub = conftest._load_sounddevice_or_install_stub(
+        importer=lambda _name: external_module,
+        modules=modules,
+    )
+
+    assert module is external_module
+    assert owned_stub is None
+    assert modules["sounddevice"] is external_module
+
+    conftest._remove_owned_sounddevice_stub(modules, owned_stub)
+
+    assert modules["sounddevice"] is external_module
+
+
+def test_import_failure_installs_and_removes_only_the_conftest_owned_stub():
+    import conftest
+
+    def raise_missing_backend(_name):
+        raise OSError("PortAudio unavailable")
+
+    modules = {}
+    module, owned_stub = conftest._load_sounddevice_or_install_stub(
+        importer=raise_missing_backend,
+        modules=modules,
+    )
+
+    assert module is owned_stub
+    assert modules["sounddevice"] is owned_stub
+
+    conftest._remove_owned_sounddevice_stub(modules, owned_stub)
+
+    assert "sounddevice" not in modules
+
+
+def test_conftest_teardown_does_not_remove_a_third_party_replacement():
+    import conftest
+
+    def raise_missing_backend(_name):
+        raise OSError("PortAudio unavailable")
+
+    modules = {}
+    _module, owned_stub = conftest._load_sounddevice_or_install_stub(
+        importer=raise_missing_backend,
+        modules=modules,
+    )
+    third_party_module = SimpleNamespace(__name__="sounddevice")
+    modules["sounddevice"] = third_party_module
+
+    conftest._remove_owned_sounddevice_stub(modules, owned_stub)
+
+    assert modules["sounddevice"] is third_party_module

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -323,6 +323,18 @@ def test_load_config_unsupported_permission_check_warns_and_continues(
     assert str(p) in warnings[0].message
 
 
+def test_load_config_non_posix_warns_and_continues(tmp_path, monkeypatch, caplog):
+    p = _write_valid_config(tmp_path / "config.yaml", mode=0o644)
+    fake_os = type("FakeOS", (), {"name": "nt", "fstat": staticmethod(os.fstat)})
+    monkeypatch.setattr("src.config.os", fake_os)
+    with caplog.at_level("WARNING", logger="src.config"):
+        cfg = load_config(str(p))
+    assert cfg.discogs.username == "me"
+    warnings = [record for record in caplog.records if record.levelname == "WARNING"]
+    assert len(warnings) == 1
+    assert str(p) in warnings[0].message
+
+
 def test_load_config_empty_file_raises_config_error(tmp_path):
     p = tmp_path / "empty.yaml"
     p.write_text("")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,7 @@ which use tmp_path.
 """
 import os
 import textwrap
+from unittest.mock import Mock
 
 import pytest
 
@@ -252,9 +253,80 @@ def test_load_config_missing_file_raises_config_error(tmp_path):
     assert "not found" in str(exc.value)
 
 
+def _write_valid_config(path, *, token="tok", mode=0o600):
+    """Write a valid config fixture with an explicit private-file mode."""
+    raw = _valid_raw()
+    raw["discogs"]["user_token"] = token
+    path.write_text(textwrap.dedent(f"""
+        audio:
+          device_name: USB Audio Codec
+          sample_rate: 44100
+          chunk_seconds: 15
+          silence_threshold_rms: 0.01
+          session_end_silence_seconds: 45
+        discogs:
+          user_token: {raw["discogs"]["user_token"]}
+          username: me
+          play_count_field_name: Play Count
+        display:
+          width: 1024
+          height: 600
+        recognition:
+          poll_interval_seconds: 30
+        lastfm:
+          scrobble_enabled: false
+    """).strip() + "\n")
+    os.chmod(path, mode)
+    return path
+
+
+def test_load_config_private_file_parses_normally(tmp_path):
+    p = _write_valid_config(tmp_path / "config.yaml")
+    cfg = load_config(str(p))
+    assert cfg.discogs.username == "me"
+
+
+@pytest.mark.parametrize("mode", [0o640, 0o604, 0o644])
+def test_load_config_rejects_group_or_other_permissions_without_leaking_secret(
+    tmp_path, mode
+):
+    sentinel = "SUPER_SECRET_CONFIG_SENTINEL"
+    p = _write_valid_config(tmp_path / "config.yaml", token=sentinel, mode=mode)
+    with pytest.raises(ConfigError) as exc:
+        load_config(str(p))
+    msg = str(exc.value)
+    assert str(p) in msg
+    assert f"chmod 600 {p}" in msg
+    assert sentinel not in msg
+
+
+def test_load_config_checks_open_descriptor_before_yaml_parser(tmp_path, monkeypatch):
+    p = _write_valid_config(tmp_path / "config.yaml", mode=0o644)
+    parser = Mock(side_effect=AssertionError("parser must not run"))
+    monkeypatch.setattr("src.config.yaml.safe_load", parser)
+    with pytest.raises(ConfigError) as exc:
+        load_config(str(p))
+    assert "chmod 600" in str(exc.value)
+    parser.assert_not_called()
+
+
+def test_load_config_unsupported_permission_check_warns_and_continues(
+    tmp_path, monkeypatch, caplog
+):
+    p = _write_valid_config(tmp_path / "config.yaml")
+    monkeypatch.setattr("src.config._config_file_mode", lambda _file: None)
+    with caplog.at_level("WARNING", logger="src.config"):
+        cfg = load_config(str(p))
+    assert cfg.discogs.username == "me"
+    warnings = [record for record in caplog.records if record.levelname == "WARNING"]
+    assert len(warnings) == 1
+    assert str(p) in warnings[0].message
+
+
 def test_load_config_empty_file_raises_config_error(tmp_path):
     p = tmp_path / "empty.yaml"
     p.write_text("")
+    os.chmod(p, 0o600)
     with pytest.raises(ConfigError) as exc:
         load_config(str(p))
     assert "empty" in str(exc.value)
@@ -280,6 +352,7 @@ def test_load_config_invalid_utf8_raises_config_error(tmp_path):
     must become a ConfigError."""
     p = tmp_path / "config.yaml"
     p.write_bytes(b"\xff\xfe not valid utf-8 \x80\x81")
+    os.chmod(p, 0o600)
     with pytest.raises(ConfigError) as exc:
         load_config(str(p))
     assert "UTF-8" in str(exc.value)
@@ -351,6 +424,7 @@ def test_load_config_reads_and_validates(tmp_path):
         recognition:
           poll_interval_seconds: 20
     """))
+    os.chmod(p, 0o600)
     cfg = load_config(str(p))
     assert cfg.display.width == 800
     assert cfg.recognition.poll_interval_seconds == 20
@@ -360,6 +434,7 @@ def test_load_config_reads_and_validates(tmp_path):
 def test_load_config_invalid_yaml_raises_config_error(tmp_path):
     p = tmp_path / "bad.yaml"
     p.write_text("audio: [unclosed\n")
+    os.chmod(p, 0o600)
     with pytest.raises(ConfigError):
         load_config(str(p))
 

--- a/tests/test_deployment_integrity_r10.py
+++ b/tests/test_deployment_integrity_r10.py
@@ -1,24 +1,24 @@
 """Deployment-facing CI contracts introduced in Wave 1."""
 from pathlib import Path
 
+import pytest
 import yaml
 
 
 REPO = Path(__file__).resolve().parent.parent
 TESTS_WORKFLOW = REPO / ".github" / "workflows" / "tests.yml"
+PORTAUDIO_RUN = "sudo apt-get update\nsudo apt-get install --yes libportaudio2\n"
 
 
-def _tests_job():
-    return yaml.safe_load(TESTS_WORKFLOW.read_text())["jobs"]["test"]
+def _tests_job(workflow_path=TESTS_WORKFLOW):
+    return yaml.safe_load(workflow_path.read_text())["jobs"]["test"]
 
 
 def _step_index(steps, name):
     return next(index for index, step in enumerate(steps) if step.get("name") == name)
 
 
-def test_ci_installs_portaudio_and_smokes_the_real_backend_before_pytest():
-    """#156: every supported CI leg proves the installed backend before stubbing."""
-    job = _tests_job()
+def _assert_audio_boundary_contract(job):
     steps = job["steps"]
     portaudio_index = _step_index(steps, "Install PortAudio")
     dependencies_index = _step_index(steps, "Install dependencies")
@@ -26,7 +26,55 @@ def test_ci_installs_portaudio_and_smokes_the_real_backend_before_pytest():
     pytest_index = _step_index(steps, "Run tests")
 
     assert job["strategy"]["matrix"]["python-version"] == ["3.11", "3.12", "3.13"]
-    assert "sudo apt-get install --yes libportaudio2" in steps[portaudio_index]["run"]
-    assert steps[smoke_index]["run"] == "python scripts/check_audio_backend.py"
+    assert "if" not in job
+    assert "continue-on-error" not in job
+    assert steps[portaudio_index]["run"] == PORTAUDIO_RUN
+    assert steps[smoke_index]["run"] == "python -I scripts/check_audio_backend.py"
     assert steps[pytest_index]["run"] == "pytest -q"
+    for index in (portaudio_index, smoke_index, pytest_index):
+        assert "if" not in steps[index]
+        assert "continue-on-error" not in steps[index]
     assert portaudio_index < dependencies_index < smoke_index < pytest_index
+
+
+def test_ci_installs_portaudio_and_smokes_the_real_backend_before_pytest():
+    """#156: every supported CI leg proves the installed backend before stubbing."""
+    _assert_audio_boundary_contract(_tests_job())
+
+
+@pytest.mark.parametrize(
+    ("step_name", "field", "value"),
+    (
+        ("Install PortAudio", "if", "matrix.python-version != '3.13'"),
+        ("Smoke-test audio backend", "if", "matrix.python-version != '3.13'"),
+        ("Run tests", "if", "matrix.python-version != '3.13'"),
+        ("Install PortAudio", "continue-on-error", True),
+        ("Smoke-test audio backend", "continue-on-error", True),
+        ("Run tests", "continue-on-error", True),
+    ),
+)
+def test_audio_boundary_contract_rejects_per_leg_bypass_mutations(
+    tmp_path, step_name, field, value
+):
+    """Mutate a disposable workflow file to prove every required step fails closed."""
+    workflow = yaml.safe_load(TESTS_WORKFLOW.read_text())
+    steps = workflow["jobs"]["test"]["steps"]
+    steps[_step_index(steps, step_name)][field] = value
+    mutated_workflow = tmp_path / "tests.yml"
+    mutated_workflow.write_text(yaml.safe_dump(workflow))
+
+    with pytest.raises(AssertionError):
+        _assert_audio_boundary_contract(_tests_job(mutated_workflow))
+
+
+def test_audio_boundary_contract_rejects_nonblocking_portaudio_install(tmp_path):
+    """The exact command blocks a shell-level `|| true` bypass as well."""
+    workflow = yaml.safe_load(TESTS_WORKFLOW.read_text())
+    steps = workflow["jobs"]["test"]["steps"]
+    portaudio_step = steps[_step_index(steps, "Install PortAudio")]
+    portaudio_step["run"] += " || true"
+    mutated_workflow = tmp_path / "tests.yml"
+    mutated_workflow.write_text(yaml.safe_dump(workflow))
+
+    with pytest.raises(AssertionError):
+        _assert_audio_boundary_contract(_tests_job(mutated_workflow))

--- a/tests/test_deployment_integrity_r10.py
+++ b/tests/test_deployment_integrity_r10.py
@@ -1,0 +1,32 @@
+"""Deployment-facing CI contracts introduced in Wave 1."""
+from pathlib import Path
+
+import yaml
+
+
+REPO = Path(__file__).resolve().parent.parent
+TESTS_WORKFLOW = REPO / ".github" / "workflows" / "tests.yml"
+
+
+def _tests_job():
+    return yaml.safe_load(TESTS_WORKFLOW.read_text())["jobs"]["test"]
+
+
+def _step_index(steps, name):
+    return next(index for index, step in enumerate(steps) if step.get("name") == name)
+
+
+def test_ci_installs_portaudio_and_smokes_the_real_backend_before_pytest():
+    """#156: every supported CI leg proves the installed backend before stubbing."""
+    job = _tests_job()
+    steps = job["steps"]
+    portaudio_index = _step_index(steps, "Install PortAudio")
+    dependencies_index = _step_index(steps, "Install dependencies")
+    smoke_index = _step_index(steps, "Smoke-test audio backend")
+    pytest_index = _step_index(steps, "Run tests")
+
+    assert job["strategy"]["matrix"]["python-version"] == ["3.11", "3.12", "3.13"]
+    assert "sudo apt-get install --yes libportaudio2" in steps[portaudio_index]["run"]
+    assert steps[smoke_index]["run"] == "python scripts/check_audio_backend.py"
+    assert steps[pytest_index]["run"] == "pytest -q"
+    assert portaudio_index < dependencies_index < smoke_index < pytest_index

--- a/tests/test_deployment_integrity_r10.py
+++ b/tests/test_deployment_integrity_r10.py
@@ -30,7 +30,7 @@ touch "$app_dir/config.yaml" "$app_dir/main.py" "$tmp_dir/Xauthority"
 chmod 600 "$app_dir/config.yaml"
 ln -s "$(command -v python)" "$app_dir/venv/bin/python3"
 python -I scripts/render_system_service.py --user root --app-dir "$app_dir" --display :0 --xauthority "$tmp_dir/Xauthority" --output "$tmp_dir/vinyl-now-playing.service"
-systemd-analyze verify "$tmp_dir/vinyl-now-playing.service"
+/usr/bin/systemd-analyze verify "$tmp_dir/vinyl-now-playing.service"
 """,
 }
 
@@ -108,6 +108,21 @@ def test_system_service_contract_rejects_ci_bypass_mutations(tmp_path, field, va
 
     with pytest.raises(AssertionError):
         _assert_system_service_contract(_workflow(mutated_workflow))
+
+
+def test_system_service_contract_keeps_using_the_os_parser_if_path_is_shadowed(tmp_path):
+    """A prior PATH mutation cannot replace the absolute Ubuntu parser binary."""
+    workflow = yaml.safe_load(TESTS_WORKFLOW.read_text())
+    steps = workflow["jobs"]["test"]["steps"]
+    service_index = _step_index(steps, "Render and verify system service")
+    steps.insert(
+        service_index,
+        {"name": "Shadow PATH", "run": "echo /tmp/fake-bin >> \"$GITHUB_PATH\""},
+    )
+    mutated_workflow = tmp_path / "tests.yml"
+    mutated_workflow.write_text(yaml.safe_dump(workflow))
+
+    _assert_system_service_contract(_workflow(mutated_workflow))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_deployment_integrity_r10.py
+++ b/tests/test_deployment_integrity_r10.py
@@ -8,38 +8,57 @@ import yaml
 REPO = Path(__file__).resolve().parent.parent
 TESTS_WORKFLOW = REPO / ".github" / "workflows" / "tests.yml"
 PORTAUDIO_RUN = "sudo apt-get update\nsudo apt-get install --yes libportaudio2\n"
+EXPECTED_STRATEGY = {
+    "fail-fast": False,
+    "matrix": {"python-version": ["3.11", "3.12", "3.13"]},
+}
+EXPECTED_CRITICAL_STEPS = {
+    "Install PortAudio": {"name": "Install PortAudio", "run": PORTAUDIO_RUN},
+    "Smoke-test audio backend": {
+        "name": "Smoke-test audio backend",
+        "run": "python -I scripts/check_audio_backend.py",
+    },
+    "Run tests": {"name": "Run tests", "run": "pytest -q"},
+}
+
+
+def _workflow(workflow_path=TESTS_WORKFLOW):
+    return yaml.safe_load(workflow_path.read_text())
 
 
 def _tests_job(workflow_path=TESTS_WORKFLOW):
-    return yaml.safe_load(workflow_path.read_text())["jobs"]["test"]
+    return _workflow(workflow_path)["jobs"]["test"]
 
 
 def _step_index(steps, name):
     return next(index for index, step in enumerate(steps) if step.get("name") == name)
 
 
-def _assert_audio_boundary_contract(job):
+def _named_steps(steps, name):
+    return [step for step in steps if step.get("name") == name]
+
+
+def _assert_audio_boundary_contract(workflow):
+    job = workflow["jobs"]["test"]
     steps = job["steps"]
     portaudio_index = _step_index(steps, "Install PortAudio")
     dependencies_index = _step_index(steps, "Install dependencies")
     smoke_index = _step_index(steps, "Smoke-test audio backend")
     pytest_index = _step_index(steps, "Run tests")
 
-    assert job["strategy"]["matrix"]["python-version"] == ["3.11", "3.12", "3.13"]
+    assert "defaults" not in workflow
+    assert job["strategy"] == EXPECTED_STRATEGY
+    assert "defaults" not in job
     assert "if" not in job
     assert "continue-on-error" not in job
-    assert steps[portaudio_index]["run"] == PORTAUDIO_RUN
-    assert steps[smoke_index]["run"] == "python -I scripts/check_audio_backend.py"
-    assert steps[pytest_index]["run"] == "pytest -q"
-    for index in (portaudio_index, smoke_index, pytest_index):
-        assert "if" not in steps[index]
-        assert "continue-on-error" not in steps[index]
+    for name, expected_step in EXPECTED_CRITICAL_STEPS.items():
+        assert _named_steps(steps, name) == [expected_step]
     assert portaudio_index < dependencies_index < smoke_index < pytest_index
 
 
 def test_ci_installs_portaudio_and_smokes_the_real_backend_before_pytest():
     """#156: every supported CI leg proves the installed backend before stubbing."""
-    _assert_audio_boundary_contract(_tests_job())
+    _assert_audio_boundary_contract(_workflow())
 
 
 @pytest.mark.parametrize(
@@ -64,7 +83,7 @@ def test_audio_boundary_contract_rejects_per_leg_bypass_mutations(
     mutated_workflow.write_text(yaml.safe_dump(workflow))
 
     with pytest.raises(AssertionError):
-        _assert_audio_boundary_contract(_tests_job(mutated_workflow))
+        _assert_audio_boundary_contract(_workflow(mutated_workflow))
 
 
 def test_audio_boundary_contract_rejects_nonblocking_portaudio_install(tmp_path):
@@ -77,4 +96,52 @@ def test_audio_boundary_contract_rejects_nonblocking_portaudio_install(tmp_path)
     mutated_workflow.write_text(yaml.safe_dump(workflow))
 
     with pytest.raises(AssertionError):
-        _assert_audio_boundary_contract(_tests_job(mutated_workflow))
+        _assert_audio_boundary_contract(_workflow(mutated_workflow))
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    (
+        lambda workflow: workflow.__setitem__(
+            "defaults", {"run": {"shell": "bash -c 'source {0} || true'"}}
+        ),
+        lambda workflow: workflow["jobs"]["test"].__setitem__(
+            "defaults", {"run": {"shell": "bash -c 'source {0} || true'"}}
+        ),
+        lambda workflow: workflow["jobs"]["test"]["strategy"]["matrix"].__setitem__(
+            "exclude", [{"python-version": "3.13"}]
+        ),
+        lambda workflow: workflow["jobs"]["test"]["strategy"]["matrix"].__setitem__(
+            "include", [{"python-version": "3.14"}]
+        ),
+        lambda workflow: workflow["jobs"]["test"]["steps"][_step_index(
+            workflow["jobs"]["test"]["steps"], "Install PortAudio"
+        )].__setitem__("shell", "bash -c 'source {0} || true'"),
+        lambda workflow: workflow["jobs"]["test"]["steps"][_step_index(
+            workflow["jobs"]["test"]["steps"], "Smoke-test audio backend"
+        )].__setitem__("shell", "bash -c 'source {0} || true'"),
+        lambda workflow: workflow["jobs"]["test"]["steps"][_step_index(
+            workflow["jobs"]["test"]["steps"], "Run tests"
+        )].__setitem__("shell", "bash -c 'source {0} || true'"),
+    ),
+    ids=(
+        "workflow-default-shell",
+        "job-default-shell",
+        "matrix-exclude",
+        "matrix-include",
+        "portaudio-step-shell",
+        "smoke-step-shell",
+        "pytest-step-shell",
+    ),
+)
+def test_audio_boundary_contract_rejects_effective_semantics_bypasses(
+    tmp_path, mutation
+):
+    """Disposable mutations prove defaults and matrix overlays cannot bypass CI."""
+    workflow = yaml.safe_load(TESTS_WORKFLOW.read_text())
+    mutation(workflow)
+    mutated_workflow = tmp_path / "tests.yml"
+    mutated_workflow.write_text(yaml.safe_dump(workflow))
+
+    with pytest.raises(AssertionError):
+        _assert_audio_boundary_contract(_workflow(mutated_workflow))

--- a/tests/test_deployment_integrity_r10.py
+++ b/tests/test_deployment_integrity_r10.py
@@ -20,6 +20,19 @@ EXPECTED_CRITICAL_STEPS = {
     },
     "Run tests": {"name": "Run tests", "run": "pytest -q"},
 }
+EXPECTED_SERVICE_STEP = {
+    "name": "Render and verify system service",
+    "run": """set -euo pipefail
+tmp_dir="$(mktemp -d)"
+app_dir="$tmp_dir/app"
+mkdir -p "$app_dir/venv/bin"
+touch "$app_dir/config.yaml" "$app_dir/main.py" "$tmp_dir/Xauthority"
+chmod 600 "$app_dir/config.yaml"
+ln -s "$(command -v python)" "$app_dir/venv/bin/python3"
+python -I scripts/render_system_service.py --user root --app-dir "$app_dir" --display :0 --xauthority "$tmp_dir/Xauthority" --output "$tmp_dir/vinyl-now-playing.service"
+systemd-analyze verify "$tmp_dir/vinyl-now-playing.service"
+""",
+}
 
 
 def _workflow(workflow_path=TESTS_WORKFLOW):
@@ -56,9 +69,45 @@ def _assert_audio_boundary_contract(workflow):
     assert portaudio_index < dependencies_index < smoke_index < pytest_index
 
 
+def _assert_system_service_contract(workflow):
+    """#419: every supported Linux leg parses a rendered representative unit."""
+    job = workflow["jobs"]["test"]
+    steps = job["steps"]
+    service_index = _step_index(steps, "Render and verify system service")
+    smoke_index = _step_index(steps, "Smoke-test audio backend")
+    pytest_index = _step_index(steps, "Run tests")
+
+    assert _named_steps(steps, "Render and verify system service") == [
+        EXPECTED_SERVICE_STEP
+    ]
+    assert "if" not in steps[service_index]
+    assert "continue-on-error" not in steps[service_index]
+    assert smoke_index < service_index < pytest_index
+
+
 def test_ci_installs_portaudio_and_smokes_the_real_backend_before_pytest():
     """#156: every supported CI leg proves the installed backend before stubbing."""
     _assert_audio_boundary_contract(_workflow())
+
+
+def test_ci_renders_and_verifies_the_versioned_system_service_before_pytest():
+    _assert_system_service_contract(_workflow())
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (("if", "matrix.python-version != '3.13'"), ("continue-on-error", True)),
+)
+def test_system_service_contract_rejects_ci_bypass_mutations(tmp_path, field, value):
+    """Disposable mutations prove service verification cannot go nonblocking."""
+    workflow = yaml.safe_load(TESTS_WORKFLOW.read_text())
+    steps = workflow["jobs"]["test"]["steps"]
+    steps[_step_index(steps, "Render and verify system service")][field] = value
+    mutated_workflow = tmp_path / "tests.yml"
+    mutated_workflow.write_text(yaml.safe_dump(workflow))
+
+    with pytest.raises(AssertionError):
+        _assert_system_service_contract(_workflow(mutated_workflow))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_discogs_live_check.py
+++ b/tests/test_discogs_live_check.py
@@ -248,3 +248,98 @@ def test_yes_bypasses_prompt_only_for_explicit_write_selection(monkeypatch):
     assert args.yes is True
     assert args.artist == "Artist"
     assert args.album == "Album"
+
+
+@pytest.mark.parametrize("bad_value", ["", "   ", "\t\t", "Artist\x1b[2J", "Album\x00"])
+def test_main_rejects_blank_or_control_target_values_before_config(monkeypatch, bad_value):
+    monkeypatch.setattr(
+        "src.config.load_config",
+        lambda _path: pytest.fail("invalid target reached config loading"),
+    )
+    with pytest.raises(SystemExit) as ei:
+        dlc.main(["--artist", bad_value, "--album", "Album"])
+    assert ei.value.code == 2
+
+    with pytest.raises(SystemExit) as ei:
+        dlc.main(["--artist", "Artist", "--album", bad_value])
+    assert ei.value.code == 2
+
+
+def test_target_validation_allows_internal_spaces_without_changing_search_values():
+    client = MagicMock()
+    client.search_collection.return_value = None
+    artist = "The  Artist"
+    album = "An Album  With Spaces"
+    dlc.check_search_collection(client, artist, album)
+    client.search_collection.assert_called_once_with(artist, album)
+
+
+def test_write_target_and_prompt_redact_token_shaped_values(capsys):
+    client = MagicMock()
+    client.play_count_field_name = "Play Count token=FIELD_SECRET"
+    client.increment_play_count.return_value = True
+    result = {"release_id": 123, "instance_id": 456}
+    prompts = []
+
+    assert dlc.check_increment_play_count(
+        client,
+        result,
+        "Artist token=ARTIST_SECRET",
+        "Album token=ALBUM_SECRET",
+        input_fn=prompts.append,
+    ) is False
+    # append returns None, which is intentionally a non-affirmative response.
+    client.increment_play_count.assert_not_called()
+    output = capsys.readouterr().out
+    assert "ARTIST_SECRET" not in output
+    assert "ALBUM_SECRET" not in output
+    assert "FIELD_SECRET" not in output
+    assert prompts and "ARTIST_SECRET" not in prompts[0]
+    assert "ALBUM_SECRET" not in prompts[0]
+    assert "FIELD_SECRET" not in prompts[0]
+
+
+def test_yes_emits_resolved_target_immediately_before_single_write(capsys):
+    client = MagicMock()
+    client.play_count_field_name = "Play Count"
+    client.increment_play_count.return_value = True
+    result = {"release_id": 123, "instance_id": 456}
+
+    assert dlc.check_increment_play_count(
+        client,
+        result,
+        "Selected Artist",
+        "Selected Album",
+        confirmed=True,
+    ) is True
+    client.increment_play_count.assert_called_once_with(123, 456)
+    output = capsys.readouterr().out
+    assert "WRITE AUTHORIZED (--yes)" in output
+    assert "Selected Artist" in output
+    assert "Selected Album" in output
+    assert "Play Count" in output
+    assert "Release ID: 123" in output
+    assert "Instance ID: 456" in output
+
+
+@pytest.mark.parametrize("outcome", [False, RuntimeError("transport uncertain")])
+def test_failed_write_warns_inspect_before_rerun_and_never_retries(capsys, outcome):
+    client = MagicMock()
+    client.play_count_field_name = "Play Count"
+    if isinstance(outcome, Exception):
+        client.increment_play_count.side_effect = outcome
+    else:
+        client.increment_play_count.return_value = outcome
+    result = {"release_id": 123, "instance_id": 456}
+
+    assert dlc.check_increment_play_count(
+        client,
+        result,
+        "Artist",
+        "Album",
+        confirmed=True,
+    ) is False
+    client.increment_play_count.assert_called_once_with(123, 456)
+    output = capsys.readouterr().out
+    assert "inspect the current Discogs field value before rerunning" in output
+    assert "do not retry blindly" in output

--- a/tests/test_discogs_live_check.py
+++ b/tests/test_discogs_live_check.py
@@ -145,3 +145,106 @@ def test_main_loads_config_from_repo_root_not_cwd(monkeypatch, tmp_path):
 
     expected = str(Path(dlc.__file__).resolve().parent.parent / "config.yaml")
     assert captured["path"] == expected
+
+
+# ---------------------------------------------------------------------------
+# #366 — explicit record selection and write authorization
+# ---------------------------------------------------------------------------
+
+def test_search_operations_use_selected_artist_and_album(capsys):
+    client = MagicMock()
+    client.search_collection.return_value = None
+    client.search_database.return_value = None
+
+    dlc.check_search_collection(client, "Selected Artist", "Selected Album")
+    dlc.check_search_database(client, "Selected Artist", "Selected Album")
+
+    client.search_collection.assert_called_once_with("Selected Artist", "Selected Album")
+    client.search_database.assert_called_once_with("Selected Artist", "Selected Album")
+    out = capsys.readouterr().out
+    assert "Selected Artist / Selected Album" in out
+
+
+@pytest.mark.parametrize("response", ["n", "", " yes", "yes ", "YES", "Yes"])
+def test_write_requires_exact_yes(response, capsys):
+    client = MagicMock()
+    result = {"release_id": 123, "instance_id": 456}
+
+    accepted = dlc.check_increment_play_count(
+        client,
+        result,
+        "Selected Artist",
+        "Selected Album",
+        input_fn=lambda _prompt: response,
+    )
+
+    assert accepted is False
+    client.increment_play_count.assert_not_called()
+    assert "Write declined" in capsys.readouterr().out
+
+
+def test_write_declines_on_eof(capsys):
+    client = MagicMock()
+    result = {"release_id": 123, "instance_id": 456}
+
+    def eof(_prompt):
+        raise EOFError
+
+    accepted = dlc.check_increment_play_count(
+        client,
+        result,
+        "Selected Artist",
+        "Selected Album",
+        input_fn=eof,
+    )
+
+    assert accepted is False
+    client.increment_play_count.assert_not_called()
+    assert "Write declined" in capsys.readouterr().out
+
+
+def test_write_prompt_contains_selection_and_ids_but_not_token(capsys):
+    client = MagicMock()
+    client.play_count_field_name = "Play Count"
+    client.increment_play_count.return_value = True
+    result = {"release_id": 123, "instance_id": 456}
+    prompts = []
+
+    def authorize(prompt):
+        prompts.append(prompt)
+        return "yes"
+
+    assert dlc.check_increment_play_count(
+        client,
+        result,
+        "Selected Artist",
+        "Selected Album",
+        input_fn=authorize,
+    ) is True
+    client.increment_play_count.assert_called_once_with(123, 456)
+    assert len(prompts) == 1
+    prompt = prompts[0]
+    assert "Selected Artist" in prompt
+    assert "Selected Album" in prompt
+    assert "Play Count" in prompt
+    assert "123" in prompt and "456" in prompt
+    assert "token" not in prompt.lower()
+    capsys.readouterr()
+
+
+def test_yes_bypasses_prompt_only_for_explicit_write_selection(monkeypatch):
+    with pytest.raises(SystemExit) as ei:
+        dlc.main(["--yes"])
+    assert ei.value.code == 2
+
+    with pytest.raises(SystemExit) as ei:
+        dlc.main(["--test-write", "--artist", "Artist"])
+    assert ei.value.code == 2
+
+    parser = dlc._build_parser()
+    args = parser.parse_args([
+        "--test-write", "--yes", "--artist", "Artist", "--album", "Album"
+    ])
+    assert args.yes is True
+    assert args.artist == "Artist"
+    assert args.album == "Album"

--- a/tests/test_discogs_live_check.py
+++ b/tests/test_discogs_live_check.py
@@ -531,6 +531,41 @@ def test_confirmed_write_fails_closed_without_complete_expected_identity(
     assert "expected release and instance IDs" in capsys.readouterr().out
 
 
+@pytest.mark.parametrize(
+    ("resolved", "expected_release_id", "expected_instance_id"),
+    [
+        ({"release_id": 1, "instance_id": 456}, True, 456),
+        ({"release_id": 1, "instance_id": 456}, 1.0, 456),
+        ({"release_id": 1, "instance_id": 456}, "1", 456),
+        ({"release_id": 1, "instance_id": 456}, 0, 456),
+        ({"release_id": 1, "instance_id": 456}, -1, 456),
+        ({"release_id": 123, "instance_id": 1}, 123, True),
+        ({"release_id": 123, "instance_id": 1}, 123, 1.0),
+        ({"release_id": 123, "instance_id": 1}, 123, "1"),
+        ({"release_id": 123, "instance_id": 1}, 123, 0),
+        ({"release_id": 123, "instance_id": 1}, 123, -1),
+    ],
+)
+def test_confirmed_write_rejects_non_positive_or_non_integer_expected_ids(
+    capsys, resolved, expected_release_id, expected_instance_id
+):
+    client = MagicMock()
+    client.play_count_field_name = "Play Count"
+
+    assert dlc.check_increment_play_count(
+        client,
+        resolved,
+        "Artist",
+        "Album",
+        confirmed=True,
+        expected_release_id=expected_release_id,
+        expected_instance_id=expected_instance_id,
+        input_fn=lambda _prompt: pytest.fail("invalid --yes identity must not prompt"),
+    ) is False
+    client.increment_play_count.assert_not_called()
+    assert "positive integers" in capsys.readouterr().out
+
+
 @pytest.mark.parametrize("outcome", [False, RuntimeError("transport uncertain")])
 def test_failed_write_warns_inspect_before_rerun_and_never_retries(capsys, outcome):
     client = MagicMock()

--- a/tests/test_discogs_live_check.py
+++ b/tests/test_discogs_live_check.py
@@ -9,6 +9,7 @@ import importlib.util
 import logging
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -232,7 +233,7 @@ def test_write_prompt_contains_selection_and_ids_but_not_token(capsys):
     capsys.readouterr()
 
 
-def test_yes_bypasses_prompt_only_for_explicit_write_selection(monkeypatch):
+def test_yes_requires_explicit_write_selection_and_expected_ids(monkeypatch):
     with pytest.raises(SystemExit) as ei:
         dlc.main(["--yes"])
     assert ei.value.code == 2
@@ -241,13 +242,115 @@ def test_yes_bypasses_prompt_only_for_explicit_write_selection(monkeypatch):
         dlc.main(["--test-write", "--artist", "Artist"])
     assert ei.value.code == 2
 
+
+@pytest.mark.parametrize(
+    "id_args",
+    [
+        [],
+        ["--release-id", "123"],
+        ["--instance-id", "456"],
+    ],
+)
+def test_yes_rejects_missing_one_or_both_expected_ids_before_config(
+    monkeypatch, id_args
+):
+    monkeypatch.setattr(
+        "src.config.load_config",
+        lambda _path: pytest.fail("incomplete authorization reached config loading"),
+    )
+    with pytest.raises(SystemExit) as ei:
+        dlc.main([
+            "--test-write", "--yes", "--artist", "Artist", "--album", "Album",
+            *id_args,
+        ])
+    assert ei.value.code == 2
+
+
+@pytest.mark.parametrize(
+    ("option", "value"),
+    [
+        ("--release-id", "0"),
+        ("--release-id", "-1"),
+        ("--release-id", "not-an-id"),
+        ("--instance-id", "0"),
+        ("--instance-id", "-1"),
+        ("--instance-id", "not-an-id"),
+    ],
+)
+def test_expected_ids_must_be_positive_integers_before_config(
+    monkeypatch, option, value
+):
+    monkeypatch.setattr(
+        "src.config.load_config",
+        lambda _path: pytest.fail("invalid authorization reached config loading"),
+    )
+    args = [
+        "--test-write", "--yes", "--artist", "Artist", "--album", "Album",
+        "--release-id", "123", "--instance-id", "456",
+    ]
+    args[args.index(option) + 1] = value
+    with pytest.raises(SystemExit) as ei:
+        dlc.main(args)
+    assert ei.value.code == 2
+
+
+def test_yes_parser_accepts_complete_id_bound_authorization():
     parser = dlc._build_parser()
     args = parser.parse_args([
-        "--test-write", "--yes", "--artist", "Artist", "--album", "Album"
+        "--test-write", "--yes", "--artist", "Artist", "--album", "Album",
+        "--release-id", "123", "--instance-id", "456",
     ])
     assert args.yes is True
     assert args.artist == "Artist"
     assert args.album == "Album"
+    assert args.release_id == 123
+    assert args.instance_id == 456
+
+
+def test_parser_help_describes_id_bound_yes_without_error():
+    help_text = " ".join(dlc._build_parser().format_help().split())
+    assert "--release-id" in help_text
+    assert "--instance-id" in help_text
+    assert "required with --yes" in help_text
+
+
+def test_main_forwards_expected_ids_and_aborts_on_later_resolution_drift(
+    monkeypatch
+):
+    reader = MagicMock()
+    reader.username = "dummy-user"
+    writer = MagicMock()
+    writer.play_count_field_name = "Play Count"
+    config = SimpleNamespace(discogs=SimpleNamespace(user_token="dummy-token"))
+
+    monkeypatch.setattr("src.config.load_config", lambda _path: config)
+    monkeypatch.setattr("src.metadata.discogs.DiscogsHttp", lambda _token: object())
+    monkeypatch.setattr("src.metadata.discogs.DiscogsReader", lambda _http, _cfg: reader)
+    monkeypatch.setattr(
+        "src.metadata.discogs.DiscogsCollectionWriter", lambda _http, _cfg: writer
+    )
+    monkeypatch.setattr(
+        dlc,
+        "check_search_collection",
+        lambda _reader, _artist, _album: {"release_id": 123, "instance_id": 999},
+    )
+    monkeypatch.setattr(dlc, "check_search_database", lambda *_args: None)
+    monkeypatch.setattr(dlc, "check_get_tracklist", lambda *_args: None)
+    monkeypatch.setattr(dlc, "check_collection_fields", lambda *_args: None)
+
+    def unexpected_prompt(_prompt):
+        pytest.fail("valid --yes invocation must never prompt")
+
+    result = dlc.main(
+        [
+            "--test-write", "--yes", "--artist", "Artist", "--album", "Album",
+            "--release-id", "123", "--instance-id", "456",
+        ],
+        input_fn=unexpected_prompt,
+    )
+
+    assert result == 1
+    writer.increment_play_count.assert_not_called()
 
 
 @pytest.mark.parametrize("bad_value", ["", "   ", "\t\t", "Artist\x1b[2J", "Album\x00"])
@@ -299,11 +402,14 @@ def test_write_target_and_prompt_redact_token_shaped_values(capsys):
     assert "FIELD_SECRET" not in prompts[0]
 
 
-def test_yes_emits_resolved_target_immediately_before_single_write(capsys):
+def test_yes_writes_once_without_prompt_when_resolved_ids_match(capsys):
     client = MagicMock()
     client.play_count_field_name = "Play Count"
     client.increment_play_count.return_value = True
     result = {"release_id": 123, "instance_id": 456}
+
+    def unexpected_prompt(_prompt):
+        pytest.fail("valid --yes authorization must not prompt")
 
     assert dlc.check_increment_play_count(
         client,
@@ -311,6 +417,9 @@ def test_yes_emits_resolved_target_immediately_before_single_write(capsys):
         "Selected Artist",
         "Selected Album",
         confirmed=True,
+        expected_release_id=123,
+        expected_instance_id=456,
+        input_fn=unexpected_prompt,
     ) is True
     client.increment_play_count.assert_called_once_with(123, 456)
     output = capsys.readouterr().out
@@ -320,6 +429,106 @@ def test_yes_emits_resolved_target_immediately_before_single_write(capsys):
     assert "Play Count" in output
     assert "Release ID: 123" in output
     assert "Instance ID: 456" in output
+
+
+@pytest.mark.parametrize(
+    ("resolved", "expected_release_id", "expected_instance_id"),
+    [
+        ({"release_id": 999, "instance_id": 456}, 123, 456),
+        ({"release_id": 123, "instance_id": 999}, 123, 456),
+    ],
+)
+def test_yes_aborts_without_prompt_or_write_when_later_resolution_drifts(
+    capsys, resolved, expected_release_id, expected_instance_id
+):
+    client = MagicMock()
+    client.play_count_field_name = "Play Count"
+
+    def unexpected_prompt(_prompt):
+        pytest.fail("--yes drift handling must not fall back to a prompt")
+
+    assert dlc.check_increment_play_count(
+        client,
+        resolved,
+        "Same Artist",
+        "Same Album",
+        confirmed=True,
+        expected_release_id=expected_release_id,
+        expected_instance_id=expected_instance_id,
+        input_fn=unexpected_prompt,
+    ) is False
+    client.increment_play_count.assert_not_called()
+    assert "does not match" in capsys.readouterr().out
+
+
+def test_yes_does_not_treat_same_artist_album_as_unique_collection_identity(capsys):
+    client = MagicMock()
+    client.play_count_field_name = "Play Count"
+    approved_copy = {"release_id": 123, "instance_id": 456}
+    duplicate_copy_resolved_later = {"release_id": 123, "instance_id": 789}
+
+    assert dlc.check_increment_play_count(
+        client,
+        duplicate_copy_resolved_later,
+        "Duplicate Artist",
+        "Duplicate Album",
+        confirmed=True,
+        expected_release_id=approved_copy["release_id"],
+        expected_instance_id=approved_copy["instance_id"],
+    ) is False
+    client.increment_play_count.assert_not_called()
+    assert "does not match" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "resolved",
+    [
+        {"release_id": 0, "instance_id": 456},
+        {"release_id": -1, "instance_id": 456},
+        {"release_id": "123", "instance_id": 456},
+        {"release_id": 123, "instance_id": 0},
+        {"release_id": 123, "instance_id": -1},
+        {"release_id": 123, "instance_id": "456"},
+    ],
+)
+def test_write_rejects_non_positive_or_non_integer_resolved_ids(
+    capsys, resolved
+):
+    client = MagicMock()
+    client.play_count_field_name = "Play Count"
+
+    assert dlc.check_increment_play_count(
+        client,
+        resolved,
+        "Artist",
+        "Album",
+        input_fn=lambda _prompt: "yes",
+    ) is False
+    client.increment_play_count.assert_not_called()
+    assert "positive integer" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("expected_release_id", "expected_instance_id"),
+    [(None, None), (123, None), (None, 456)],
+)
+def test_confirmed_write_fails_closed_without_complete_expected_identity(
+    capsys, expected_release_id, expected_instance_id
+):
+    client = MagicMock()
+    client.play_count_field_name = "Play Count"
+
+    assert dlc.check_increment_play_count(
+        client,
+        {"release_id": 123, "instance_id": 456},
+        "Artist",
+        "Album",
+        confirmed=True,
+        expected_release_id=expected_release_id,
+        expected_instance_id=expected_instance_id,
+    ) is False
+    client.increment_play_count.assert_not_called()
+    assert "expected release and instance IDs" in capsys.readouterr().out
 
 
 @pytest.mark.parametrize("outcome", [False, RuntimeError("transport uncertain")])
@@ -338,6 +547,8 @@ def test_failed_write_warns_inspect_before_rerun_and_never_retries(capsys, outco
         "Artist",
         "Album",
         confirmed=True,
+        expected_release_id=123,
+        expected_instance_id=456,
     ) is False
     client.increment_play_count.assert_called_once_with(123, 456)
     output = capsys.readouterr().out

--- a/tests/test_system_service.py
+++ b/tests/test_system_service.py
@@ -5,6 +5,7 @@ import importlib.util
 import os
 from pathlib import Path
 import shutil
+import stat
 import subprocess
 import sys
 
@@ -455,6 +456,48 @@ def test_renderer_rejects_symlinks_in_existing_path_ancestors(tmp_path, kind):
     assert not output.exists()
 
 
+def test_renderer_detects_output_parent_swap_without_publishing_outside_pinned_directory(
+    tmp_path, monkeypatch
+):
+    """A post-validation parent swap cannot redirect publication onto protected files."""
+    app_dir = _make_app(tmp_path)
+    config = app_dir / "config.yaml"
+    config_before = config.read_bytes()
+    config_mode_before = stat.S_IMODE(config.stat().st_mode)
+    renderer = _load_renderer_module()
+    template = tmp_path / "template.service.in"
+    template.write_bytes(renderer.TEMPLATE.read_bytes())
+    monkeypatch.setattr(renderer, "TEMPLATE", template)
+    template_before = template.read_bytes()
+    output_parent = tmp_path / "output"
+    output_parent.mkdir()
+    pinned_parent = tmp_path / "pinned-output"
+    output = output_parent / "config.yaml"
+    original_matches = renderer._existing_output_matches
+    swapped = False
+
+    def swap_parent_after_validation(*args, **kwargs):
+        nonlocal swapped
+        matches = original_matches(*args, **kwargs)
+        output_parent.rename(pinned_parent)
+        output_parent.symlink_to(app_dir, target_is_directory=True)
+        swapped = True
+        return matches
+
+    monkeypatch.setattr(renderer, "_existing_output_matches", swap_parent_after_validation)
+
+    with pytest.raises(renderer.RenderError, match="output parent changed"):
+        _render_direct(renderer, app_dir, output)
+
+    assert swapped
+    assert output_parent.is_symlink()
+    assert config.read_bytes() == config_before
+    assert stat.S_IMODE(config.stat().st_mode) == config_mode_before == 0o600
+    assert template.read_bytes() == template_before
+    assert not pinned_parent.joinpath(output.name).exists()
+    assert not list(pinned_parent.glob(f".{output.name}.*.tmp"))
+
+
 def test_renderer_rerender_is_byte_and_inode_identical_for_identical_inputs(tmp_path):
     """A no-op re-render avoids unnecessary service-file churn."""
     app_dir = _make_app(tmp_path)
@@ -498,7 +541,7 @@ def test_renderer_leaves_the_previous_complete_output_on_atomic_replace_failure(
     output.write_bytes(previous)
     renderer = _load_renderer_module()
 
-    def fail_replace(source, destination):
+    def fail_replace(source, destination, **_kwargs):
         raise OSError("simulated replace interruption")
 
     monkeypatch.setattr(renderer.os, "replace", fail_replace)
@@ -541,7 +584,9 @@ def test_renderer_cli_normalizes_atomic_write_failures_without_a_traceback(
     monkeypatch.setattr(
         renderer.os,
         "replace",
-        lambda *_args: (_ for _ in ()).throw(PermissionError("simulated denied write")),
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            PermissionError("simulated denied write")
+        ),
     )
 
     exit_code = renderer.main(_arguments(app_dir, output))
@@ -567,10 +612,10 @@ def test_renderer_cli_normalizes_existing_output_io_failures_without_a_traceback
     original_close = renderer.os.close
     output_descriptor = None
 
-    def remember_output_descriptor(path, flags, mode=0o777):
+    def remember_output_descriptor(path, flags, mode=0o777, **kwargs):
         nonlocal output_descriptor
-        descriptor = original_open(path, flags, mode)
-        if Path(path) == output:
+        descriptor = original_open(path, flags, mode, **kwargs)
+        if path == output.name and kwargs.get("dir_fd") is not None:
             output_descriptor = descriptor
         return descriptor
 

--- a/tests/test_system_service.py
+++ b/tests/test_system_service.py
@@ -284,6 +284,135 @@ def test_renderer_rejects_an_existing_output_hardlink_before_reading_it(
     assert target.read_bytes() == original
 
 
+def _template_with_secret_marker(marker: str) -> str:
+    return SCRIPT.parent.parent.joinpath("deploy", "vinyl-now-playing.service.in").read_text() + marker
+
+
+@pytest.mark.parametrize("swap_kind", ("regular", "config-symlink"))
+def test_renderer_rejects_template_swaps_before_the_template_descriptor_is_read(
+    tmp_path, monkeypatch, swap_kind
+):
+    """A post-check template swap cannot publish attacker or config bytes."""
+    app_dir = _make_app(tmp_path)
+    config = app_dir / "config.yaml"
+    config.write_text(_template_with_secret_marker("\n# config-secret-marker\n"))
+    os.chmod(config, 0o600)
+    renderer = _load_renderer_module()
+    template = tmp_path / "template.service.in"
+    template.write_text(_template_with_secret_marker("\n# trusted-template\n"))
+    output = tmp_path / "vinyl-now-playing.service"
+    monkeypatch.setattr(renderer, "TEMPLATE", template)
+    original_open = renderer.os.open
+    swapped = False
+
+    def swap_before_template_open(path, flags, mode=0o777):
+        nonlocal swapped
+        if Path(path) == template and not swapped:
+            swapped = True
+            template.unlink()
+            if swap_kind == "regular":
+                template.write_text(_template_with_secret_marker("\n# raced-template\n"))
+            else:
+                template.symlink_to(config)
+        return original_open(path, flags, mode)
+
+    monkeypatch.setattr(renderer.os, "open", swap_before_template_open)
+
+    with pytest.raises(renderer.RenderError):
+        _render_direct(renderer, app_dir, output)
+
+    assert swapped
+    assert not output.exists()
+    assert config.read_text().endswith("# config-secret-marker\n")
+    assert config.stat().st_mode & 0o777 == 0o600
+
+
+def test_renderer_rejects_a_template_that_is_already_a_hardlink_to_config(tmp_path, monkeypatch):
+    """The template descriptor itself can never be the private config inode."""
+    app_dir = _make_app(tmp_path)
+    config = app_dir / "config.yaml"
+    config.write_text(_template_with_secret_marker("\n# config-secret-marker\n"))
+    os.chmod(config, 0o600)
+    renderer = _load_renderer_module()
+    template = tmp_path / "template.service.in"
+    os.link(config, template)
+    output = tmp_path / "vinyl-now-playing.service"
+    monkeypatch.setattr(renderer, "TEMPLATE", template)
+
+    with pytest.raises(renderer.RenderError):
+        _render_direct(renderer, app_dir, output)
+
+    assert not output.exists()
+    assert config.read_text().endswith("# config-secret-marker\n")
+    assert config.stat().st_mode & 0o777 == 0o600
+
+
+@pytest.mark.parametrize("target_name", ("config", "template"))
+def test_renderer_rejects_canonical_output_collisions_after_identity_races(
+    tmp_path, monkeypatch, target_name
+):
+    """A path-string collision remains forbidden if the target inode changes."""
+    app_dir = _make_app(tmp_path)
+    config = app_dir / "config.yaml"
+    renderer = _load_renderer_module()
+    template = tmp_path / "template.service.in"
+    template.write_text(_template_with_secret_marker("\n# trusted-template\n"))
+    monkeypatch.setattr(renderer, "TEMPLATE", template)
+    output = config if target_name == "config" else template
+    replacement = _template_with_secret_marker("\n# replacement-must-not-be-overwritten\n").encode()
+    original_template_metadata = renderer._template_metadata
+
+    def replace_target_after_first_identity_check():
+        metadata = original_template_metadata()
+        output.unlink()
+        output.write_bytes(replacement)
+        os.chmod(output, 0o600)
+        return metadata
+
+    monkeypatch.setattr(renderer, "_template_metadata", replace_target_after_first_identity_check)
+
+    with pytest.raises(renderer.RenderError):
+        _render_direct(renderer, app_dir, output)
+
+    assert output.read_bytes() == replacement
+
+
+def test_renderer_reads_the_template_only_from_its_verified_descriptor(tmp_path, monkeypatch):
+    """A path-level `read_text()` call would reintroduce the template TOCTOU gap."""
+    app_dir = _make_app(tmp_path)
+    output = tmp_path / "vinyl-now-playing.service"
+    renderer = _load_renderer_module()
+
+    monkeypatch.setattr(
+        renderer.Path,
+        "read_text",
+        lambda *_args, **_kwargs: pytest.fail("renderer reopened the template by path"),
+    )
+
+    assert _render_direct(renderer, app_dir, output) is True
+    assert output.exists()
+
+
+def test_renderer_cli_normalizes_invalid_template_utf8_without_a_traceback(
+    tmp_path, monkeypatch, capsys
+):
+    """A corrupted checked-in unit template gives operators one concise error."""
+    app_dir = _make_app(tmp_path)
+    output = tmp_path / "vinyl-now-playing.service"
+    renderer = _load_renderer_module()
+    template = tmp_path / "template.service.in"
+    template.write_bytes(b"\xff\xfe")
+    monkeypatch.setattr(renderer, "TEMPLATE", template)
+
+    exit_code = renderer.main(_arguments(app_dir, output))
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert captured.err.startswith("error: cannot decode system-service template")
+    assert "Traceback" not in captured.err
+    assert not output.exists()
+
+
 @pytest.mark.parametrize("unsafe", ("%n", "$HOME", "'", '\"', "\\\\", "@", ";", "&", "|"))
 def test_renderer_rejects_systemd_metacharacters_in_unit_bound_paths(tmp_path, unsafe):
     """Unit substitutions stay literal rather than invoking systemd expansion rules."""
@@ -422,6 +551,58 @@ def test_renderer_cli_normalizes_atomic_write_failures_without_a_traceback(
     assert captured.err.startswith("error: cannot atomically write output")
     assert "Traceback" not in captured.err
     assert not output.exists()
+
+
+@pytest.mark.parametrize("failure", ("read", "close"))
+def test_renderer_cli_normalizes_existing_output_io_failures_without_a_traceback(
+    tmp_path, monkeypatch, capsys, failure
+):
+    """A verification read failure cannot escape the renderer's CLI boundary."""
+    app_dir = _make_app(tmp_path)
+    output = tmp_path / "vinyl-now-playing.service"
+    renderer = _load_renderer_module()
+    _render_direct(renderer, app_dir, output)
+
+    original_open = renderer.os.open
+    original_close = renderer.os.close
+    output_descriptor = None
+
+    def remember_output_descriptor(path, flags, mode=0o777):
+        nonlocal output_descriptor
+        descriptor = original_open(path, flags, mode)
+        if Path(path) == output:
+            output_descriptor = descriptor
+        return descriptor
+
+    monkeypatch.setattr(renderer.os, "open", remember_output_descriptor)
+
+    if failure == "read":
+        original_read = renderer.os.read
+
+        def fail_output_read(descriptor, *args):
+            if descriptor == output_descriptor:
+                raise OSError("simulated read failure")
+            return original_read(descriptor, *args)
+
+        monkeypatch.setattr(
+            renderer.os,
+            "read",
+            fail_output_read,
+        )
+    else:
+        def fail_output_close(descriptor):
+            if descriptor == output_descriptor:
+                raise OSError("simulated close failure")
+            return original_close(descriptor)
+
+        monkeypatch.setattr(renderer.os, "close", fail_output_close)
+
+    exit_code = renderer.main(_arguments(app_dir, output))
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert captured.err.startswith("error: cannot safely read output")
+    assert "Traceback" not in captured.err
 
 
 def test_renderer_refuses_to_replace_an_output_symlink(tmp_path):

--- a/tests/test_system_service.py
+++ b/tests/test_system_service.py
@@ -1,0 +1,294 @@
+"""Contracts for the versioned system-service renderer (#419)."""
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "render_system_service.py"
+PYTHON = sys.executable
+
+
+def _make_app(tmp_path: Path) -> Path:
+    app_dir = tmp_path / "vinyl-now-playing"
+    app_dir.mkdir()
+    config = app_dir / "config.yaml"
+    config.write_text("discogs:\n  token: secret-not-for-output\n")
+    os.chmod(config, 0o600)
+    return app_dir
+
+
+def _arguments(base_app_dir: Path, base_output: Path, **overrides: str) -> list[str]:
+    values = {
+        "user": "pi",
+        "app_dir": str(base_app_dir),
+        "display": ":0",
+        "xauthority": "/home/pi/.Xauthority",
+        "output": str(base_output),
+    }
+    values.update(overrides)
+    return [
+        "--user",
+        values["user"],
+        "--app-dir",
+        values["app_dir"],
+        "--display",
+        values["display"],
+        "--xauthority",
+        values["xauthority"],
+        "--output",
+        values["output"],
+    ]
+
+
+def _run_renderer(
+    base_app_dir: Path, base_output: Path, **overrides: str
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [PYTHON, str(SCRIPT), *_arguments(base_app_dir, base_output, **overrides)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _load_renderer_module():
+    spec = importlib.util.spec_from_file_location("render_system_service", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _render_direct(
+    renderer, base_app_dir: Path | str, base_output: Path | str, **overrides: str
+):
+    values = {
+        "user": "pi",
+        "app_dir": base_app_dir,
+        "display": ":0",
+        "xauthority": "/home/pi/.Xauthority",
+        "output": base_output,
+    }
+    values.update(overrides)
+    return renderer.render_system_service(**values)
+
+
+def test_renderer_emits_the_supported_system_unit_without_reading_or_chmodding_config(
+    tmp_path,
+):
+    """Changing any required unit directive makes the rendered deployment unsafe."""
+    app_dir = _make_app(tmp_path)
+    config = app_dir / "config.yaml"
+    output = tmp_path / "vinyl-now-playing.service"
+    mode_before = config.stat().st_mode & 0o777
+
+    completed = _run_renderer(app_dir, output)
+
+    assert completed.returncode == 0, completed.stderr
+    assert config.stat().st_mode & 0o777 == mode_before == 0o600
+    assert "secret-not-for-output" not in output.read_text()
+    assert output.read_text() == """[Unit]
+Description=vinyl-now-playing
+Wants=network-online.target
+After=network-online.target time-sync.target graphical.target
+StartLimitIntervalSec=300
+StartLimitBurst=10
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory={app_dir}
+Environment=\"DISPLAY=:0\"
+Environment=\"XAUTHORITY=/home/pi/.Xauthority\"
+ExecStart={app_dir}/venv/bin/python3 {app_dir}/main.py
+Restart=on-failure
+RestartPreventExitStatus=78
+RestartSec=15
+TimeoutStopSec=30
+
+[Install]
+WantedBy=graphical.target
+""".format(app_dir=app_dir)
+    assert output.stat().st_mode & 0o777 == 0o644
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("user", "pi\nExecStart=/tmp/evil"),
+        ("user", "pi user"),
+        ("app_dir", "relative/app"),
+        ("app_dir", "{app_dir}\t"),
+        ("display", ":0\nEnvironment=EVIL=yes"),
+        ("display", ":0 display"),
+        ("xauthority", "relative/.Xauthority"),
+        ("xauthority", "/home/pi/.Xauthority\r"),
+        ("output", "relative.service"),
+        ("output", "{output}\nother.service"),
+    ),
+)
+def test_renderer_rejects_relative_control_and_whitespace_injection_values(
+    tmp_path, field, value
+):
+    """An unsafe substitution must not create a second systemd directive."""
+    app_dir = _make_app(tmp_path)
+    output = tmp_path / "vinyl-now-playing.service"
+    value = value.format(app_dir=app_dir, output=output)
+    renderer = _load_renderer_module()
+
+    with pytest.raises(renderer.RenderError):
+        _render_direct(renderer, app_dir, output, **{field: value})
+
+    assert not output.exists()
+
+
+def test_renderer_requires_an_existing_application_directory(tmp_path):
+    """A typo in the deployment path must fail before any unit is written."""
+    missing_app = tmp_path / "missing"
+    output = tmp_path / "vinyl-now-playing.service"
+    renderer = _load_renderer_module()
+
+    with pytest.raises(renderer.RenderError):
+        _render_direct(renderer, missing_app, output)
+
+    assert not output.exists()
+
+
+def test_renderer_requires_a_config_file(tmp_path):
+    """A runnable-looking unit without the operator config must not be emitted."""
+    app_dir = tmp_path / "vinyl-now-playing"
+    app_dir.mkdir()
+    output = tmp_path / "vinyl-now-playing.service"
+    renderer = _load_renderer_module()
+
+    with pytest.raises(renderer.RenderError):
+        _render_direct(renderer, app_dir, output)
+
+    assert not output.exists()
+
+
+@pytest.mark.parametrize("mode", (0o640, 0o644, 0o660, 0o700))
+def test_renderer_rejects_any_config_mode_other_than_0600(tmp_path, mode):
+    """Loosening or over-restricting the operator credential file blocks deploy."""
+    app_dir = _make_app(tmp_path)
+    os.chmod(app_dir / "config.yaml", mode)
+    output = tmp_path / "vinyl-now-playing.service"
+    renderer = _load_renderer_module()
+
+    with pytest.raises(renderer.RenderError):
+        _render_direct(renderer, app_dir, output)
+
+    assert not output.exists()
+    assert app_dir.joinpath("config.yaml").stat().st_mode & 0o777 == mode
+
+
+def test_renderer_rejects_a_symlinked_config_descriptor(tmp_path):
+    """A path swap cannot make the renderer validate one config and deploy another."""
+    app_dir = _make_app(tmp_path)
+    real_config = app_dir / "real-config.yaml"
+    real_config.write_text("safe: true\n")
+    os.chmod(real_config, 0o600)
+    config = app_dir / "config.yaml"
+    config.unlink()
+    config.symlink_to(real_config)
+    output = tmp_path / "vinyl-now-playing.service"
+    renderer = _load_renderer_module()
+
+    with pytest.raises(renderer.RenderError):
+        _render_direct(renderer, app_dir, output)
+
+    assert not output.exists()
+
+
+def test_renderer_rerender_is_byte_and_inode_identical_for_identical_inputs(tmp_path):
+    """A no-op re-render avoids unnecessary service-file churn."""
+    app_dir = _make_app(tmp_path)
+    output = tmp_path / "vinyl-now-playing.service"
+    first = _run_renderer(app_dir, output)
+    before = output.stat()
+
+    second = _run_renderer(app_dir, output)
+    after = output.stat()
+
+    assert first.returncode == second.returncode == 0
+    assert after.st_ino == before.st_ino
+    assert after.st_mtime_ns == before.st_mtime_ns
+
+
+def test_renderer_leaves_the_previous_complete_output_on_atomic_replace_failure(
+    tmp_path, monkeypatch
+):
+    """An interrupted install may retain the old unit but must never truncate it."""
+    app_dir = _make_app(tmp_path)
+    output = tmp_path / "vinyl-now-playing.service"
+    previous = b"[Unit]\nDescription=previous-complete-unit\n"
+    output.write_bytes(previous)
+    renderer = _load_renderer_module()
+
+    def fail_replace(source, destination):
+        raise OSError("simulated replace interruption")
+
+    monkeypatch.setattr(renderer.os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="simulated replace interruption"):
+        renderer.render_system_service(
+            user="pi",
+            app_dir=app_dir,
+            display=":0",
+            xauthority=Path("/home/pi/.Xauthority"),
+            output=output,
+        )
+
+    assert output.read_bytes() == previous
+    assert not list(tmp_path.glob(".vinyl-now-playing.service.*.tmp"))
+
+
+def test_renderer_refuses_to_replace_an_output_symlink(tmp_path):
+    """The explicit output path cannot be used to replace a symlinked target."""
+    app_dir = _make_app(tmp_path)
+    protected = tmp_path / "protected.service"
+    protected.write_text("do-not-replace\n")
+    output = tmp_path / "vinyl-now-playing.service"
+    output.symlink_to(protected)
+    renderer = _load_renderer_module()
+
+    with pytest.raises(renderer.RenderError):
+        _render_direct(renderer, app_dir, output)
+
+    assert protected.read_text() == "do-not-replace\n"
+    assert output.is_symlink()
+
+
+@pytest.mark.skipif(
+    shutil.which("systemd-analyze") is None,
+    reason="systemd-analyze is required only for Linux system-unit parsing",
+)
+def test_rendered_unit_passes_systemd_analyze_verify_when_available(tmp_path):
+    """The real parser, not source text, accepts the representative unit."""
+    app_dir = _make_app(tmp_path)
+    python_path = app_dir / "venv" / "bin" / "python3"
+    python_path.parent.mkdir(parents=True)
+    python_path.symlink_to(Path(sys.executable))
+    (app_dir / "main.py").write_text("print('representative app')\n")
+    xauthority = tmp_path / "Xauthority"
+    xauthority.write_text("")
+    output = tmp_path / "vinyl-now-playing.service"
+
+    completed = _run_renderer(app_dir, output, xauthority=str(xauthority))
+    verified = subprocess.run(
+        ["systemd-analyze", "verify", str(output)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert verified.returncode == 0, verified.stderr

--- a/tests/test_system_service.py
+++ b/tests/test_system_service.py
@@ -1,6 +1,7 @@
 """Contracts for the versioned system-service renderer (#419)."""
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import os
 from pathlib import Path
@@ -66,6 +67,16 @@ def _load_renderer_module():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def _trust_test_template(renderer, monkeypatch, template: Path) -> None:
+    """Bind a disposable fixture to the renderer's explicit template trust contract."""
+    monkeypatch.setattr(renderer, "TEMPLATE", template)
+    monkeypatch.setattr(
+        renderer,
+        "_TRUSTED_TEMPLATE_SHA256",
+        hashlib.sha256(template.read_bytes()).hexdigest(),
+    )
 
 
 def _render_direct(
@@ -248,7 +259,7 @@ ExecStart=@APP_DIR@/venv/bin/python3 @APP_DIR@/main.py
 """
     )
     original = template.read_bytes()
-    monkeypatch.setattr(renderer, "TEMPLATE", template)
+    _trust_test_template(renderer, monkeypatch, template)
     monkeypatch.setattr(
         renderer.os,
         "read",
@@ -302,11 +313,11 @@ def test_renderer_rejects_template_swaps_before_the_template_descriptor_is_read(
     template = tmp_path / "template.service.in"
     template.write_text(_template_with_secret_marker("\n# trusted-template\n"))
     output = tmp_path / "vinyl-now-playing.service"
-    monkeypatch.setattr(renderer, "TEMPLATE", template)
+    _trust_test_template(renderer, monkeypatch, template)
     original_open = renderer.os.open
     swapped = False
 
-    def swap_before_template_open(path, flags, mode=0o777):
+    def swap_before_template_open(path, flags, mode=0o777, **kwargs):
         nonlocal swapped
         if Path(path) == template and not swapped:
             swapped = True
@@ -315,7 +326,7 @@ def test_renderer_rejects_template_swaps_before_the_template_descriptor_is_read(
                 template.write_text(_template_with_secret_marker("\n# raced-template\n"))
             else:
                 template.symlink_to(config)
-        return original_open(path, flags, mode)
+        return original_open(path, flags, mode, **kwargs)
 
     monkeypatch.setattr(renderer.os, "open", swap_before_template_open)
 
@@ -394,6 +405,45 @@ def test_renderer_reads_the_template_only_from_its_verified_descriptor(tmp_path,
     assert output.exists()
 
 
+def test_renderer_rejects_changed_template_bytes_when_checked_metadata_is_identical(
+    tmp_path,
+):
+    """Content trust must not depend on inode, size, or timestamp uniqueness."""
+    renderer = _load_renderer_module()
+    trusted = renderer.TEMPLATE.read_bytes()
+    raced = trusted.replace(
+        b"Description=vinyl-now-playing",
+        b"Description=vinyl-now-pLaying",
+    )
+    assert raced != trusted
+    assert len(raced) == len(trusted)
+    template = tmp_path / "template.service.in"
+    template.write_bytes(trusted)
+    descriptor = os.open(template, os.O_RDONLY)
+    expected = os.fstat(descriptor)
+    try:
+        template.write_bytes(raced)
+        os.utime(
+            template,
+            ns=(expected.st_atime_ns, expected.st_mtime_ns),
+        )
+        os.lseek(descriptor, 0, os.SEEK_SET)
+
+        with pytest.raises(renderer.RenderError, match="trusted template content"):
+            renderer._render_template(
+                descriptor,
+                expected,
+                {
+                    "@SERVICE_USER@": "pi",
+                    "@APP_DIR@": "/opt/vinyl-now-playing",
+                    "@DISPLAY@": ":0",
+                    "@XAUTHORITY@": "/home/pi/.Xauthority",
+                },
+            )
+    finally:
+        os.close(descriptor)
+
+
 def test_renderer_cli_normalizes_invalid_template_utf8_without_a_traceback(
     tmp_path, monkeypatch, capsys
 ):
@@ -403,7 +453,7 @@ def test_renderer_cli_normalizes_invalid_template_utf8_without_a_traceback(
     renderer = _load_renderer_module()
     template = tmp_path / "template.service.in"
     template.write_bytes(b"\xff\xfe")
-    monkeypatch.setattr(renderer, "TEMPLATE", template)
+    _trust_test_template(renderer, monkeypatch, template)
 
     exit_code = renderer.main(_arguments(app_dir, output))
     captured = capsys.readouterr()

--- a/tests/test_system_service.py
+++ b/tests/test_system_service.py
@@ -30,7 +30,7 @@ def _arguments(base_app_dir: Path, base_output: Path, **overrides: str) -> list[
         "user": "pi",
         "app_dir": str(base_app_dir),
         "display": ":0",
-        "xauthority": "/home/pi/.Xauthority",
+        "xauthority": str(base_output.parent / "Xauthority"),
         "output": str(base_output),
     }
     values.update(overrides)
@@ -74,7 +74,7 @@ def _render_direct(
         "user": "pi",
         "app_dir": base_app_dir,
         "display": ":0",
-        "xauthority": "/home/pi/.Xauthority",
+        "xauthority": str(Path(base_output).parent / "Xauthority"),
         "output": base_output,
     }
     values.update(overrides)
@@ -107,7 +107,7 @@ Type=simple
 User=pi
 WorkingDirectory={app_dir}
 Environment=\"DISPLAY=:0\"
-Environment=\"XAUTHORITY=/home/pi/.Xauthority\"
+Environment=\"XAUTHORITY={xauthority}\"
 ExecStart={app_dir}/venv/bin/python3 {app_dir}/main.py
 Restart=on-failure
 RestartPreventExitStatus=78
@@ -116,7 +116,7 @@ TimeoutStopSec=30
 
 [Install]
 WantedBy=graphical.target
-""".format(app_dir=app_dir)
+""".format(app_dir=app_dir, xauthority=output.parent / "Xauthority")
     assert output.stat().st_mode & 0o777 == 0o644
 
 
@@ -208,6 +208,124 @@ def test_renderer_rejects_a_symlinked_config_descriptor(tmp_path):
     assert not output.exists()
 
 
+def test_renderer_rejects_a_double_slash_alias_to_config_before_reading_it(
+    tmp_path, monkeypatch
+):
+    """A lexical `//` alias cannot replace or expose the credential file."""
+    app_dir = _make_app(tmp_path)
+    config = app_dir / "config.yaml"
+    original = config.read_bytes()
+    original_mode = config.stat().st_mode & 0o777
+    output = "//" + str(config).lstrip("/")
+    renderer = _load_renderer_module()
+
+    monkeypatch.setattr(
+        renderer.os,
+        "read",
+        lambda *_args: pytest.fail("renderer read the config through an output alias"),
+    )
+    with pytest.raises(renderer.RenderError):
+        _render_direct(renderer, app_dir, output)
+
+    assert config.read_bytes() == original
+    assert config.stat().st_mode & 0o777 == original_mode == 0o600
+
+
+def test_renderer_rejects_a_double_slash_alias_to_its_template(tmp_path, monkeypatch):
+    """A noncanonical template path cannot be atomically replaced as output."""
+    app_dir = _make_app(tmp_path)
+    renderer = _load_renderer_module()
+    template = tmp_path / "template.service.in"
+    template.write_text(
+        """[Unit]
+Description=vinyl-now-playing
+User=@SERVICE_USER@
+WorkingDirectory=@APP_DIR@
+Environment=\"DISPLAY=@DISPLAY@\"
+Environment=\"XAUTHORITY=@XAUTHORITY@\"
+ExecStart=@APP_DIR@/venv/bin/python3 @APP_DIR@/main.py
+"""
+    )
+    original = template.read_bytes()
+    monkeypatch.setattr(renderer, "TEMPLATE", template)
+    monkeypatch.setattr(
+        renderer.os,
+        "read",
+        lambda *_args: pytest.fail("renderer read the template through an output alias"),
+    )
+
+    with pytest.raises(renderer.RenderError):
+        _render_direct(renderer, app_dir, "//" + str(template).lstrip("/"))
+
+    assert template.read_bytes() == original
+
+
+@pytest.mark.parametrize("target_name", ("config", "template"))
+def test_renderer_rejects_an_existing_output_hardlink_before_reading_it(
+    tmp_path, monkeypatch, target_name
+):
+    """A hardlink cannot turn the output read into a credential/template read."""
+    app_dir = _make_app(tmp_path)
+    config = app_dir / "config.yaml"
+    renderer = _load_renderer_module()
+    target = config if target_name == "config" else renderer.TEMPLATE
+    output = tmp_path / "vinyl-now-playing.service"
+    os.link(target, output)
+    original = target.read_bytes()
+
+    monkeypatch.setattr(
+        renderer.os,
+        "read",
+        lambda *_args: pytest.fail("renderer read an identity-colliding output"),
+    )
+    with pytest.raises(renderer.RenderError):
+        _render_direct(renderer, app_dir, output)
+
+    assert target.read_bytes() == original
+
+
+@pytest.mark.parametrize("unsafe", ("%n", "$HOME", "'", '\"', "\\\\", "@", ";", "&", "|"))
+def test_renderer_rejects_systemd_metacharacters_in_unit_bound_paths(tmp_path, unsafe):
+    """Unit substitutions stay literal rather than invoking systemd expansion rules."""
+    app_dir = _make_app(tmp_path)
+    output = tmp_path / "vinyl-now-playing.service"
+    xauthority = tmp_path / f"Xauthority{unsafe}"
+    xauthority.write_text("")
+    renderer = _load_renderer_module()
+
+    with pytest.raises(renderer.RenderError):
+        _render_direct(renderer, app_dir, output, xauthority=str(xauthority))
+
+    assert not output.exists()
+
+
+@pytest.mark.parametrize("kind", ("app", "output-parent", "xauthority-parent"))
+def test_renderer_rejects_symlinks_in_existing_path_ancestors(tmp_path, kind):
+    """Every existing caller-controlled path component is stable at render time."""
+    real_root = tmp_path / "real-root"
+    real_root.mkdir()
+    alias_root = tmp_path / "alias-root"
+    alias_root.symlink_to(real_root, target_is_directory=True)
+    app_dir = _make_app(tmp_path)
+    output = tmp_path / "vinyl-now-playing.service"
+    xauthority = tmp_path / "Xauthority"
+    xauthority.write_text("")
+    renderer = _load_renderer_module()
+
+    if kind == "app":
+        real_app = _make_app(real_root)
+        app_dir = alias_root / real_app.name
+    elif kind == "output-parent":
+        output = alias_root / "vinyl-now-playing.service"
+    else:
+        xauthority = alias_root / "Xauthority"
+
+    with pytest.raises(renderer.RenderError):
+        _render_direct(renderer, app_dir, output, xauthority=str(xauthority))
+
+    assert not output.exists()
+
+
 def test_renderer_rerender_is_byte_and_inode_identical_for_identical_inputs(tmp_path):
     """A no-op re-render avoids unnecessary service-file churn."""
     app_dir = _make_app(tmp_path)
@@ -221,6 +339,24 @@ def test_renderer_rerender_is_byte_and_inode_identical_for_identical_inputs(tmp_
     assert first.returncode == second.returncode == 0
     assert after.st_ino == before.st_ino
     assert after.st_mtime_ns == before.st_mtime_ns
+
+
+@pytest.mark.parametrize("mode", (0o600, 0o666, 0o777))
+def test_renderer_atomically_replaces_equal_content_with_an_unsafe_mode(tmp_path, mode):
+    """Content alone is not current when the deployment artifact is writable."""
+    app_dir = _make_app(tmp_path)
+    output = tmp_path / "vinyl-now-playing.service"
+    renderer = _load_renderer_module()
+    _render_direct(renderer, app_dir, output)
+    before = output.stat()
+    os.chmod(output, mode)
+
+    changed = _render_direct(renderer, app_dir, output)
+    after = output.stat()
+
+    assert changed is True
+    assert after.st_mode & 0o777 == 0o644
+    assert after.st_ino != before.st_ino
 
 
 def test_renderer_leaves_the_previous_complete_output_on_atomic_replace_failure(
@@ -238,17 +374,54 @@ def test_renderer_leaves_the_previous_complete_output_on_atomic_replace_failure(
 
     monkeypatch.setattr(renderer.os, "replace", fail_replace)
 
-    with pytest.raises(OSError, match="simulated replace interruption"):
+    with pytest.raises(renderer.RenderError, match="cannot atomically write output"):
         renderer.render_system_service(
             user="pi",
             app_dir=app_dir,
             display=":0",
-            xauthority=Path("/home/pi/.Xauthority"),
+            xauthority=tmp_path / "Xauthority",
             output=output,
         )
 
     assert output.read_bytes() == previous
     assert not list(tmp_path.glob(".vinyl-now-playing.service.*.tmp"))
+
+
+def test_renderer_fsyncs_the_containing_directory_after_atomic_replace(tmp_path, monkeypatch):
+    """Power loss after rename cannot discard the otherwise-complete unit entry."""
+    app_dir = _make_app(tmp_path)
+    output = tmp_path / "vinyl-now-playing.service"
+    renderer = _load_renderer_module()
+    fsync_calls = []
+
+    monkeypatch.setattr(renderer.os, "fsync", lambda descriptor: fsync_calls.append(descriptor))
+
+    _render_direct(renderer, app_dir, output)
+
+    assert len(fsync_calls) == 2
+
+
+def test_renderer_cli_normalizes_atomic_write_failures_without_a_traceback(
+    tmp_path, monkeypatch, capsys
+):
+    """Operators get one concise actionable failure if a write cannot complete."""
+    app_dir = _make_app(tmp_path)
+    output = tmp_path / "vinyl-now-playing.service"
+    renderer = _load_renderer_module()
+
+    monkeypatch.setattr(
+        renderer.os,
+        "replace",
+        lambda *_args: (_ for _ in ()).throw(PermissionError("simulated denied write")),
+    )
+
+    exit_code = renderer.main(_arguments(app_dir, output))
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert captured.err.startswith("error: cannot atomically write output")
+    assert "Traceback" not in captured.err
+    assert not output.exists()
 
 
 def test_renderer_refuses_to_replace_an_output_symlink(tmp_path):


### PR DESCRIPTION
## Summary

- enforce `0600` credential-file permissions before parsing on POSIX, with an explicit non-POSIX warning path
- verify the installed `sounddevice` distribution and exact production APIs on every supported CI matrix leg
- replace hand-maintained systemd guidance with a validated, atomic system-service renderer and Linux verification
- make the Discogs live-write probe explicit, ID-bound, redacted, single-attempt, and fail-closed
- reconcile Pi setup, rollback, first-boot evidence, testing, architecture, changelog, and remediation guardrails

## Verification

- focused integrated contract: 305 passed, 1 expected macOS systemd skip, 1 known local LibreSSL warning
- independent final review: SPEC PASS / QUALITY PASS, zero open findings
- cached/pinned actionlint 1.7.12: all workflows clean
- range diff, scope, secret-material, tracked-config, and user-service scans: clean
- unsupported local macOS/Python 3.9 full comparison: 1668 passed, 1 skipped, 15 known environment-only failures, 3 known warnings

## Required merge gates

- exact-SHA Python 3.11/3.12/3.13 tests
- installed `sounddevice` smoke on every matrix leg
- Ubuntu `systemd-analyze verify`
- dependency/security workflow and actionlint

## Deferred evidence gates

- #418 remains open until Pi mode readback is recorded
- #419 remains open until real Pi cold-boot/session/time-sync/service evidence is recorded
- #366 remains open until Lane selects a non-default-folder sacrificial record, approves its exact release/instance IDs, and the one live write is observed
- #156 is closure-ready only after this PR's exact-SHA supported CI succeeds

Implements the software portion of milestone #52 without claiming the pending hardware or external-write outcomes.
