### PR TITLE
fix: recover Discogs metadata identity safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Versions follow [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.PATCH`.
 
 ## [Unreleased]
 
+### Metadata safety
+
+- **Long-uptime Discogs ownership recovery is now bounded and identity-safe
+  (#420, #421).** A failed collection refresh can still show database metadata
+  without caching an unproven downgrade; a strictly proven removed collection
+  instance may be replaced for one Play Count attempt only when the same release
+  has exactly one validated new instance. Ambiguous, paginated, malformed, or
+  duplicate-copy responses make no replacement write. This behavior is covered
+  with mocked transport seams; it does not claim a live Discogs write
+  validation.
+
 ### Security and deployment controls
 
 - **Wave 1 software preflight controls are implemented (#418, #156, #419).**

--- a/docs/decisions/remediation-guardrails.md
+++ b/docs/decisions/remediation-guardrails.md
@@ -160,7 +160,8 @@ The first controlled App-backed publication is immutable Latest Release `v1.5.35
   the tracker; malformed, partial, multi-page, non-200, or ambiguous responses
   are `ABORT`, never permission to recover. One session may recover only the
   same release and exactly one new observed instance. Multiple/zero candidates
-  never select a target and leave the album key uncached.
+  never select a target and leave only a stale or absent album key uncached; a
+  newer nonmatching cache entry is preserved.
 - **Wave 2 — preserved boundaries:** ordinary positive collection cache entries
   remain immortal and the collection index remains process-local and memory-only
   (#169). The narrow pre-plan recovery does not reopen #186's read-once,

--- a/docs/decisions/remediation-guardrails.md
+++ b/docs/decisions/remediation-guardrails.md
@@ -145,7 +145,27 @@ The first controlled App-backed publication is immutable Latest Release `v1.5.35
 - Wave 1 software controls are implemented; #418/#419 Pi evidence, #156's real
   InputStream/hot-plug recovery, and #366's real custom-folder result remain
   pending. The system-service decision is preserved throughout.
-- Wave 2 preserves immortal positive collection reads during normal operation; only a definitive missing-instance write may invalidate, refresh, and permit one identity-safe retry.
+- **Wave 2 — metadata recovery (#420/#421):** collection refreshes expose
+  explicit `OWNED`, `CLEAN_NO_MATCH`, and `COOLDOWN_SKIPPED` states. A database
+  downgrade is cacheable only after owned or completed-clean ownership evidence;
+  a skip following a failed or unknown refresh remains displayable but uncached.
+  Collection-index promotion requires a complete, internally consistent page
+  walk. Failed/incomplete walks retain the last complete snapshot under #242 and
+  use their own bounded build-failure backoff; they neither create clean-negative
+  truth nor reset the #191 speculative-refresh cooldown.
+- **Wave 2 — write identity:** only a validated collection-items-by-release
+  response whose pagination proves page 1 of exactly 1 page may prove an
+  expected instance missing.
+  The writer carries its immutable, unique positive observed-instance tuple to
+  the tracker; malformed, partial, multi-page, non-200, or ambiguous responses
+  are `ABORT`, never permission to recover. One session may recover only the
+  same release and exactly one new observed instance. Multiple/zero candidates
+  never select a target and leave the album key uncached.
+- **Wave 2 — preserved boundaries:** ordinary positive collection cache entries
+  remain immortal and the collection index remains process-local and memory-only
+  (#169). The narrow pre-plan recovery does not reopen #186's read-once,
+  absolute-set writes or #229's bounded rate-limit behavior; after a safe
+  replacement META-7 retains its independent one-shot Last Played behavior.
 - Wave 3 preserves recognition freshness, confirmation timestamps, epoch gates, and spin deduplication while isolating Last.fm latency.
 - Wave 4 keeps floor-based dependency manifests and Python 3.11 compatibility; it does not introduce a platform-specific lockfile implicitly.
 - Wave 5 begins with design-source reconciliation and owner-visible render approval; it cannot use outdated `DESIGN.md` alone as evidence that production is defective.

--- a/docs/superpowers/plans/2026-08-22-wave2-metadata-recovery.md
+++ b/docs/superpowers/plans/2026-08-22-wave2-metadata-recovery.md
@@ -639,7 +639,7 @@ git commit -m 'feat: retry one credit on safe Discogs replacement'
 - Modify: `docs/superpowers/specs/2026-08-22-wave2-metadata-recovery-design.md` only if implementation review resolves a documented interface detail
 - Modify: `docs/superpowers/plans/2026-08-22-wave2-metadata-recovery.md` checkboxes/status only after fresh evidence
 
-- [ ] **Step 1: Add the cross-layer acceptance matrix**
+- [x] **Step 1: Add the cross-layer acceptance matrix**
 
 Use real resolver/tracker orchestration with mocked HTTP/reader/writer seams. Add:
 
@@ -649,7 +649,7 @@ Use real resolver/tracker orchestration with mocked HTTP/reader/writer seams. Ad
 
 The first test records two displayed database results, zero cache entries, and no second page walk. The second begins with cached `(release=999, instance=77)`, gets a strict MISSING result carrying `(88,)`, rebuilds the same release, reads 88 once, and posts one absolute target. The duplicate test carries `(88, 89)`, clears only stale state, performs no field POST, and leaves the key uncached for the next play.
 
-- [ ] **Step 2: Run the integrated Wave 2 suite**
+- [x] **Step 2: Run the integrated Wave 2 suite**
 
 ```bash
 cd '/private/tmp/vnp-wave2-metadata-recovery'
@@ -657,7 +657,7 @@ cd '/private/tmp/vnp-wave2-metadata-recovery'
 git diff --check
 ```
 
-- [ ] **Step 3: Update durable decisions and changelog**
+- [x] **Step 3: Update durable decisions and changelog**
 
 In the Wave 2 guardrail section record:
 
@@ -671,7 +671,7 @@ In the Wave 2 guardrail section record:
 
 In `CHANGELOG.md` under Unreleased, describe user-visible long-uptime ownership recovery and safe replacement crediting without claiming live Discogs validation.
 
-- [ ] **Step 4: Independent documentation/spec review and commit**
+- [x] **Step 4: Independent documentation/spec review and commit**
 
 Review current implementation, issue contracts, and historical #191/#242/#169/#186/#229/META-7 behavior. Reject any claim that ambiguous or multi-page absence is definitive or that positive entries now expire.
 

--- a/docs/superpowers/plans/2026-08-22-wave2-metadata-recovery.md
+++ b/docs/superpowers/plans/2026-08-22-wave2-metadata-recovery.md
@@ -1,0 +1,731 @@
+# Wave 2 Metadata Recovery and Cache Coherence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Apply superpowers:test-driven-development to every behavior change and superpowers:verification-before-completion before any pass claim. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep Discogs cache state truthful after failed/cooldown-skipped refreshes and safely recover one completed-play credit when a formerly valid collection instance has definitively been replaced.
+
+**Architecture:** Reader-owned explicit refresh outcomes distinguish owned, clean-no-match, and cooldown-skip states while strict pagination and a separate failed-build backoff preserve both truth and request bounds. A strictly validated writer read carries snapshot-safe replacement-instance evidence through a narrow tracker callback to a serialized resolver recovery path; only the same release with exactly one proven new instance can receive one replacement credit attempt.
+
+**Tech Stack:** Python 3.11–3.13, asyncio, dataclasses/enums, pytest/pytest-asyncio, Discogs REST API through the existing `DiscogsHttp` transport.
+
+**Spec:** `docs/superpowers/specs/2026-08-22-wave2-metadata-recovery-design.md`
+
+## Global Constraints
+
+- Work only in `/private/tmp/vnp-wave2-metadata-recovery` on branch `codex/r10-wave2-metadata-recovery`, based on merged Wave 1 `origin/main` SHA `7915dcacea00dea7846b3d0dfa4b915ec6f74dbe` plus the approved design commits.
+- `DESIGN.md` is noncanonical. Owner decisions, `docs/decisions/remediation-guardrails.md`, live issues #420/#421, ratified production/tests, and closure rationale control.
+- Implement #420 completely and review it before starting #421.
+- Preserve the #191 15-minute speculative cooldown, stamp-before-I/O behavior, and request-rate protection. Recovery does not consume, reset, or extend that cooldown.
+- Preserve #242 swap-on-success. Never promote or cache a partial collection index as complete ownership truth.
+- Preserve immortal positive collection entries on ordinary reads. Only a definitive writer observation may invalidate the exact stale entry.
+- Preserve #186 read-once/absolute-set behavior and #229 bounded rate-limit handling. Identity recovery occurs before an old absolute target exists and has one budget.
+- Preserve META-7 Last Played independence once a safe identity exists; Last Played remains one attempt.
+- Do not persist the collection index or instance IDs, add a positive TTL, add background synchronization, or perform a live Discogs write.
+- Never use `git add -A`; stage only files named by the active task.
+- Use the canonical clone's development interpreter only as `/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python`. It is Python 3.9 and is a fast local signal only; final acceptance requires GitHub Python 3.11/3.12/3.13.
+- The pre-change focused Wave 2 baseline is 201 passing tests. Record every RED failure and fresh GREEN result in the task report.
+
+## File and interface map
+
+| Task | Files owned | Interface produced |
+|---|---|---|
+| 1 | `src/metadata/discogs/outcomes.py`, `reader.py`, `resolver.py`, #420 cache/index tests | `CollectionRefreshResult` makes ownership/cacheability explicit; strict index builds back off without partial promotion. |
+| 2 | `outcomes.py`, `writer.py`, `listen_tracker.py`, writer/tracker tests | `PlayCountReadResult` distinguishes ready, definitive missing with observed IDs, and ordinary abort without changing write safety. |
+| 3 | `models.py`, `resolver.py`, `reader.py`, resolver/model tests | Latched `album_resolve_key`, one resolver reader gate, `recover_collection_instance(...)`, and same-release/singleton cache recovery. |
+| 4 | `listen_tracker.py`, `main.py`, tracker/idempotency/concurrency/wiring tests | One pre-plan recovery attempt, recovered write identity, preserved META-7, and composition-root injection. |
+| 5 | dedicated acceptance matrix plus durable docs | Cross-layer #420/#421 reproductions, regression contract, changelog, and issue-ready evidence. |
+| 6 | all Wave 2 files | Fresh integrated/full verification, adversarial review, supported CI, and GitHub closeout. |
+
+---
+
+### Task 1: Make refresh and index truth explicit (#420)
+
+**Files:**
+- Create: `src/metadata/discogs/outcomes.py`
+- Modify: `src/metadata/discogs/reader.py` around `_get_collection_index` and `refresh_index_and_research`
+- Modify: `src/metadata/resolver.py` around `resolve`
+- Modify: `tests/test_cache_expiry.py`
+- Modify: `tests/test_resolver_error_no_cache.py`
+- Modify: `tests/test_discogs_collection_index.py`
+- Modify: `tests/test_resolver.py` only where refresh mocks require the new type
+- Modify: `tests/test_reader_efficiency_w6.py`
+
+**Interfaces:**
+- Produces: `CollectionRefreshState`, `CollectionRefreshResult`, strict complete-index replacement, build-failure backoff, and explicit resolver cache branching.
+- Preserves: `DiscogsReader.search_collection(...) -> Optional[dict]`, collection index TTL, global speculative cooldown, and ordinary positive cache behavior.
+
+- [ ] **Step 1: Write RED tests for the tri-state refresh contract**
+
+In `tests/test_cache_expiry.py`, migrate `_page()` to return complete pagination:
+
+```python
+def _page(releases, page=1, pages=1, per_page=100, items=None):
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {
+        "releases": releases,
+        "pagination": {
+            "page": page,
+            "pages": pages,
+            "per_page": per_page,
+            "items": len(releases) if items is None else items,
+        },
+    }
+    return resp
+```
+
+Add tests named:
+
+- `test_refresh_returns_owned_after_complete_rebuild`
+- `test_refresh_returns_clean_no_match_after_complete_rebuild`
+- `test_refresh_returns_cooldown_skipped_after_successful_rebuild`
+- `test_failed_refresh_marks_cooldown_provenance_unknown`
+- `test_cooldown_skip_after_failed_refresh_does_not_repage`
+- `test_resolver_caches_database_after_clean_no_match`
+- `test_resolver_caches_database_on_cooldown_after_proven_success`
+- `test_resolver_does_not_cache_database_on_cooldown_after_failed_refresh`
+
+Assert explicit state and provenance, not truthiness:
+
+```python
+assert outcome.state is CollectionRefreshState.COOLDOWN_SKIPPED
+assert outcome.cooldown_follows_successful_rebuild is False
+assert len(resolver._album_cache) == 0
+```
+
+- [ ] **Step 2: Add the executed #420 failure-then-skip RED reproduction**
+
+In `tests/test_resolver_error_no_cache.py`, run two resolves through one reader state. The first forced refresh raises after stamping its attempt; the second resolve occurs inside the cooldown and returns `COOLDOWN_SKIPPED` with unsuccessful provenance. Both return database metadata for display and both leave `_album_cache` empty. Assert the second resolve adds no collection-page request.
+
+Run:
+
+```bash
+cd '/private/tmp/vnp-wave2-metadata-recovery'
+'/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m pytest -q tests/test_cache_expiry.py tests/test_resolver_error_no_cache.py
+```
+
+Expected RED: current `None` return has no state/provenance, and the second resolve stores one database downgrade.
+
+- [ ] **Step 3: Rewrite the conflicting STAB-4 test RED-first**
+
+Replace `test_stab4_paging_stops_at_absolute_cap_with_partial_index` in `tests/test_discogs_collection_index.py`. The old test deliberately requires caching partial truth and conflicts with the approved Wave 2 contract. Add:
+
+- `test_page_cap_rejects_partial_index_and_preserves_prior_complete_snapshot`
+- `test_page_cap_without_prior_snapshot_leaves_index_unavailable`
+- `test_failed_build_backoff_prevents_second_page_walk_with_prior_snapshot`
+- `test_failed_build_backoff_prevents_second_page_walk_without_snapshot`
+- `test_build_backoff_serves_positive_from_prior_snapshot`
+- `test_build_backoff_miss_is_unknown_not_clean`
+- `test_build_backoff_refusal_does_not_change_speculative_cooldown_state`
+- `test_successful_complete_rebuild_clears_failure_backoff`
+- parameterized `test_incomplete_pagination_never_promotes_candidate_index`
+
+The parameter matrix covers missing pagination, wrong page, changing page count, inconsistent `items`, invalid `per_page`, malformed release/instance IDs, premature empty page, and advertised pages beyond the cap. A second lookup inside backoff must not add an HTTP request.
+
+Expected RED: current code caches the capped partial index and immediately retries other failed builds.
+
+- [ ] **Step 4: Add the explicit refresh types**
+
+Create `src/metadata/discogs/outcomes.py` with:
+
+```python
+from dataclasses import dataclass
+from enum import Enum, auto
+from types import MappingProxyType
+from typing import Any, Mapping, Optional
+
+
+class CollectionRefreshState(Enum):
+    OWNED = auto()
+    CLEAN_NO_MATCH = auto()
+    COOLDOWN_SKIPPED = auto()
+
+
+@dataclass(frozen=True)
+class CollectionRefreshResult:
+    state: CollectionRefreshState
+    result: Optional[Mapping[str, Any]] = None
+    cooldown_follows_successful_rebuild: bool = False
+
+    def __post_init__(self):
+        if (self.state is CollectionRefreshState.OWNED) != (self.result is not None):
+            raise ValueError("OWNED requires a result; other states forbid one")
+        if (self.state is not CollectionRefreshState.COOLDOWN_SKIPPED
+                and self.cooldown_follows_successful_rebuild):
+            raise ValueError("cooldown provenance is valid only for a skipped refresh")
+        if self.result is not None:
+            object.__setattr__(self, "result", MappingProxyType(dict(self.result)))
+```
+
+The frozen envelope and defensive read-only mapping make state/provenance and
+the top-level payload immutable. Nested enrichment lists retain their existing
+copy-on-`TrackMetadata` boundary. The resolver converts the mapping to its own
+`dict` before cache storage. Do not add later-task types yet.
+
+- [ ] **Step 5: Implement strict index replacement and build backoff**
+
+In `reader.py`, add a separate 15-minute `_COLLECTION_BUILD_FAILURE_BACKOFF_SECONDS` and monotonic failure stamp. Extract one strict builder that constructs a candidate locally and assigns `_collection_index`/`_collection_index_built_at` only after every advertised page validates and completes.
+
+The validator must require exact positive integers (`type(value) is int`, excluding booleans) for page counts, release IDs, and instance IDs; stable `pages`, `per_page`, and total `items` across the walk; current `pagination.page`; and completion below `_MAX_COLLECTION_PAGES`. Count raw release rows separately from collapsed index keys: every nonfinal page contains exactly `per_page` rows, the final page contains at most `per_page`, and the accumulated raw row count equals `items`. Duplicate copies of one release remain valid rows even though the ordinary index retains one entry. On any failure:
+
+```python
+self._last_collection_build_failure_at = time.monotonic()
+# keep the prior complete self._collection_index and built_at unchanged
+raise CollectionIndexIncomplete("collection pagination was incomplete")
+```
+
+Add a private frozen access envelope:
+
+```python
+@dataclass(frozen=True)
+class _CollectionIndexView:
+    index: dict
+    misses_are_authoritative: bool
+```
+
+`_get_collection_index()` returns an authoritative view for an injected/fresh
+or newly completed index. During build backoff it returns a prior complete
+snapshot with `misses_are_authoritative=False`; with no prior snapshot it raises
+unknown immediately. `search_collection()` may return a positive match from a
+stale view, but after both matching strategies miss it raises
+`CollectionOwnershipUnknown` when the view is non-authoritative. This explicit
+signal prevents a stale miss from becoming clean `None`. Successful completion
+clears the failure stamp.
+
+Migrate successful page fixtures in both `tests/test_discogs_collection_index.py`
+and `tests/test_reader_efficiency_w6.py` to complete pagination metadata. Add a
+multi-page duplicate-release fixture proving raw `items` equals accumulated
+rows while `len(index)` is smaller because duplicate releases collapse.
+
+- [ ] **Step 6: Implement refresh outcome and provenance**
+
+Keep `_last_index_refresh_at` and add `_last_speculative_refresh_succeeded`. At the start of a real speculative attempt, stamp time and set success false. After a strict full rebuild completes, set it true and return:
+
+```python
+if match is not None:
+    return CollectionRefreshResult(CollectionRefreshState.OWNED, result=match)
+return CollectionRefreshResult(CollectionRefreshState.CLEAN_NO_MATCH)
+```
+
+Inside the existing cooldown, return `COOLDOWN_SKIPPED` with the stored provenance and do no I/O. A build-backoff refusal raises as unknown without altering the speculative timestamp. Preserve the old index/built-at on every exception.
+
+- [ ] **Step 7: Branch explicitly in the resolver**
+
+Replace `if upgraded:` with a state switch. `OWNED` stores the positive result. `CLEAN_NO_MATCH` keeps `discogs_completed=True`. `COOLDOWN_SKIPPED` keeps it true only when `cooldown_follows_successful_rebuild` is true; otherwise set it false so the display may use database metadata but `_album_cache` stays empty. Exceptions retain the existing no-cache behavior and error taxonomy.
+
+Migrate every #420 fixture returning bare `None` to an explicit clean or skipped result; do not let a default `MagicMock` accidentally exercise the owned branch.
+
+- [ ] **Step 8: Verify #420 GREEN and preserved behavior**
+
+Run:
+
+```bash
+cd '/private/tmp/vnp-wave2-metadata-recovery'
+'/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m pytest -q tests/test_cache_expiry.py tests/test_resolver_error_no_cache.py tests/test_discogs_collection_index.py tests/test_resolver.py tests/test_reader_efficiency_w6.py
+git diff --check
+```
+
+Require all new tests plus `test_collection_cache_never_expires`, swap-on-success, cooldown request-count, and reader-efficiency tests to pass.
+
+- [ ] **Step 9: Independent #420 review and commit**
+
+Reviewer attacks: a failed refresh followed by another album; missing/malformed pagination; page-cap retry loops; cooldown reset on error; stale index loss; `bool` IDs; and ordinary positive-cache expiry. Resolve findings, rerun Step 8, then commit only Task 1 files:
+
+```bash
+cd '/private/tmp/vnp-wave2-metadata-recovery'
+git add src/metadata/discogs/outcomes.py src/metadata/discogs/reader.py src/metadata/resolver.py tests/test_cache_expiry.py tests/test_resolver_error_no_cache.py tests/test_discogs_collection_index.py tests/test_resolver.py tests/test_reader_efficiency_w6.py
+git commit -m 'fix: keep Discogs refresh cache state truthful'
+```
+
+---
+
+### Task 2: Expose definitive missing-instance evidence at the writer boundary (#421)
+
+**Files:**
+- Modify: `src/metadata/discogs/outcomes.py`
+- Modify: `src/metadata/discogs/writer.py`
+- Modify: `src/tracking/listen_tracker.py` only to consume typed ready/abort results safely before recovery exists
+- Modify: `tests/test_discogs_client.py`
+- Modify: `tests/test_discogs_client_robustness.py`
+- Modify: `tests/test_credit_idempotent_186.py`
+- Modify: `tests/test_listen_tracker.py` fixtures for typed reads
+
+**Interfaces:**
+- Produces: `PlayCountReadState` and immutable `PlayCountReadResult`; definitive missing carries `observed_instance_ids: tuple[int, ...]`.
+- Preserves: `increment_play_count(...) -> bool`, absolute `set_play_count`, current retry-on-429 behavior, and no write on every ambiguous read.
+
+- [ ] **Step 1: Write typed-read RED tests**
+
+In `tests/test_discogs_client.py`, add a helper whose complete single-page body includes `pagination.page/pages/items/per_page`, each item's `instance_id`, `folder_id`, and `basic_information.id` equal to the requested release.
+
+Add:
+
+- `test_read_play_count_returns_ready_with_integer_count`
+- `test_read_play_count_returns_ready_for_confirmed_blank`
+- `test_read_play_count_definitively_missing_only_from_valid_complete_single_page`
+- `test_read_play_count_definitively_missing_with_empty_observed_tuple`
+- `test_found_expected_instance_is_ready_not_missing`
+- `test_noninteger_count_is_abort_not_missing`
+- parameterized `test_missing_instance_evidence_remains_abort`
+
+The abort matrix includes missing pagination, `pages > 1`, inconsistent item count, invalid/too-small `per_page`, duplicate instance IDs, malformed IDs including booleans, wrong release IDs, malformed JSON, every non-200 including 404, and transport exceptions. Assert only definitive missing exposes the exact sorted/response-order validated tuple, and ambiguous results expose no IDs.
+
+Run:
+
+```bash
+cd '/private/tmp/vnp-wave2-metadata-recovery'
+'/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m pytest -q tests/test_discogs_client.py
+```
+
+Expected RED: `read_play_count` returns tuple/`None` and cannot distinguish validated absence.
+
+- [ ] **Step 2: Add the writer result types**
+
+Extend `outcomes.py`:
+
+```python
+class PlayCountReadState(Enum):
+    READY = auto()
+    DEFINITIVE_INSTANCE_MISSING = auto()
+    ABORT = auto()
+
+
+@dataclass(frozen=True)
+class PlayCountReadResult:
+    state: PlayCountReadState
+    field_id: Optional[int] = None
+    current_count: Optional[int] = None
+    observed_instance_ids: tuple[int, ...] = ()
+
+    def __post_init__(self):
+        ready = self.state is PlayCountReadState.READY
+        missing = self.state is PlayCountReadState.DEFINITIVE_INSTANCE_MISSING
+        if ready:
+            if type(self.field_id) is not int or self.field_id <= 0:
+                raise ValueError("READY requires a positive integer field ID")
+            if type(self.current_count) is not int or self.current_count < 0:
+                raise ValueError("READY requires a nonnegative integer count")
+            if self.observed_instance_ids:
+                raise ValueError("READY cannot carry replacement instances")
+        elif self.field_id is not None or self.current_count is not None:
+            raise ValueError("non-READY results cannot carry field/count data")
+        if missing:
+            if (len(set(self.observed_instance_ids)) != len(self.observed_instance_ids)
+                    or any(type(value) is not int or value <= 0
+                           for value in self.observed_instance_ids)):
+                raise ValueError("MISSING instances must be unique positive integers")
+        elif self.observed_instance_ids:
+            raise ValueError("only MISSING can carry replacement instances")
+```
+
+ABORT has no payload by construction. A MISSING result may carry an empty tuple
+when a complete validated response proves the release currently has zero
+instances; state, not tuple truthiness, distinguishes it from ABORT.
+
+- [ ] **Step 3: Implement snapshot-safe writer classification**
+
+Refactor the private read helper to return a private structured classification. If the expected instance is found, return its field value through the existing confirmed-blank/noninteger rules; a found target does not require absence proof. Only when the target is absent, validate the entire one-page response exactly as the spec requires. Return definitive missing with all observed IDs only after that validation; otherwise ABORT.
+
+Do not treat HTTP 404 as definitive. Do not follow `pages > 1`. Do not log response bodies or note values. `read_play_count` converts the private classification into `PlayCountReadResult`.
+
+- [ ] **Step 4: Preserve convenience and tracker behavior during migration**
+
+Update `increment_play_count` to act only on READY. In `ListenTracker`, adapt the current credit attempt to read `state.field_id/current_count`; ABORT remains retryable as before. Define the terminal signal exactly:
+
+```python
+class _DefinitiveMissingInstance(Exception):
+    def __init__(self, result: PlayCountReadResult):
+        super().__init__("collection instance is definitively missing")
+        self.result = result
+```
+
+When the stale read returns MISSING, `_credit_attempt` raises this signal.
+`_finalize_write_with_retry` adds `except _DefinitiveMissingInstance: raise`
+before its broad `except Exception`, so it performs no retry or backoff.
+`_credit_completed_album` catches it outside the helper; until Task 4 adds
+recovery, it records Play Count failure and suppresses Last Played because the
+target is known stale. ABORT remains normally retryable and retains META-7.
+Task 4 reuses the exception's carried result to invoke recovery.
+
+Update `make_writer_mock()` in `tests/test_listen_tracker.py` to return `PlayCountReadResult(PlayCountReadState.READY, 3, 0)` while preserving its existing `increment_play_count` delegation assertions. Add a Task 2 test proving MISSING performs exactly one old-instance GET, zero field POSTs, zero Last Played calls, and no retry sleep.
+
+- [ ] **Step 5: Verify writer GREEN and #186 preservation**
+
+Run:
+
+```bash
+cd '/private/tmp/vnp-wave2-metadata-recovery'
+'/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m pytest -q tests/test_discogs_client.py tests/test_discogs_client_robustness.py tests/test_credit_idempotent_186.py tests/test_listen_tracker.py
+git diff --check
+```
+
+Require all existing META-1/META-2, username encoding, 429, blank-field, noninteger, and ambiguous-applied-POST tests to pass.
+
+- [ ] **Step 6: Independent writer-boundary review and commit**
+
+Reviewer attempts to promote 404, malformed pagination, multiple pages, duplicate IDs, boolean IDs, wrong releases, and missing keys to MISSING; attempts to leak observed IDs from ABORT; and verifies no stale POST occurs. Resolve findings and commit explicit files:
+
+```bash
+cd '/private/tmp/vnp-wave2-metadata-recovery'
+git add src/metadata/discogs/outcomes.py src/metadata/discogs/writer.py src/tracking/listen_tracker.py tests/test_discogs_client.py tests/test_discogs_client_robustness.py tests/test_credit_idempotent_186.py tests/test_listen_tracker.py
+git commit -m 'fix: classify definitive Discogs instance removal'
+```
+
+---
+
+### Task 3: Add serialized resolver recovery and latched identity (#421)
+
+**Files:**
+- Modify: `src/metadata/discogs/outcomes.py`
+- Modify: `src/metadata/models.py`
+- Modify: `src/metadata/discogs/reader.py`
+- Modify: `src/metadata/resolver.py`
+- Modify: `tests/test_models.py`
+- Modify: `tests/test_resolver.py`
+- Modify fixture-only resolver construction in `tests/test_cache_expiry.py`, `tests/test_resolver_error_no_cache.py`, `tests/test_coverart_timeout_238.py`, and `tests/test_tracklist_neighbours.py`
+
+**Interfaces:**
+- Produces: `CollectionIdentity`, `PlaySession.album_resolve_key`, `MetadataResolver.recover_collection_instance(resolve_key, expected_release_id, expected_instance_id, observed_instance_ids)`, and one reader gate shared by ordinary resolve and recovery.
+- Consumes: Task 1 strict rebuild/backoff and Task 2 validated observed instance tuple.
+
+- [ ] **Step 1: Write RED model-latching tests**
+
+Add to `tests/test_models.py`:
+
+- `test_log_track_latches_resolve_key_with_first_collection_identity`
+- `test_latched_album_resolve_key_does_not_follow_later_track`
+- `test_database_track_does_not_latch_album_resolve_key`
+
+The first collection track must atomically latch release ID, instance ID, and its exact `resolve_key`. Later tracks may update `last_release_resolve_key` but not the album latch.
+
+- [ ] **Step 2: Write RED resolver recovery tests**
+
+Add to `tests/test_resolver.py`:
+
+- `test_recovery_invalidates_exact_stale_positive_and_returns_same_release_new_instance`
+- `test_recovery_allows_absent_cache_entry_after_lru_eviction`
+- `test_recovery_does_not_erase_newer_nonmatching_cache_entry`
+- `test_recovery_accepts_newer_cache_only_when_it_matches_proven_singleton`
+- `test_recovery_refuses_same_instance`
+- `test_recovery_refuses_different_release`
+- `test_recovery_refuses_zero_or_multiple_replacement_instances`
+- `test_recovery_empty_enumeration_invalidates_stale_entry_and_refuses`
+- `test_duplicate_instances_leave_album_key_uncached`
+- `test_recovery_failure_leaves_known_stale_album_entry_invalidated`
+- `test_recovery_during_failed_speculative_cooldown_does_not_change_cooldown_state`
+
+Use exact cache tuples `(MetadataSource.DISCOGS_COLLECTION, payload, stored_at)` and assert the expected stale entry alone is removed. For the success case, the reader may return a collapsed instance, but the cached payload and returned identity must use the writer-proven singleton.
+
+- [ ] **Step 3: Write RED serialization tests**
+
+Add:
+
+- `test_concurrent_cache_misses_serialize_reader_sequences`
+- `test_waiting_resolve_rechecks_cache_after_acquiring_reader_gate`
+- `test_collection_cache_fast_path_does_not_enter_reader_gate`
+- `test_ordinary_resolve_and_recovery_are_serialized_by_one_gate`
+
+Use `asyncio.Event` barriers in mocked `reader.run` calls. Assert the maximum concurrent reader sequence is one, a waiting resolve consumes the newly populated cache instead of re-reading, and the immortal positive fast path does not wait behind recovery.
+
+Run:
+
+```bash
+cd '/private/tmp/vnp-wave2-metadata-recovery'
+'/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m pytest -q tests/test_models.py tests/test_resolver.py
+```
+
+Expected RED: no latched key, recovery method, or resolver gate exists.
+
+- [ ] **Step 4: Add identity type and session latch**
+
+Add to `outcomes.py`:
+
+```python
+@dataclass(frozen=True)
+class CollectionIdentity:
+    release_id: int
+    instance_id: int
+
+    def __post_init__(self):
+        if type(self.release_id) is not int or self.release_id <= 0:
+            raise ValueError("release_id must be a positive integer")
+        if type(self.instance_id) is not int or self.instance_id <= 0:
+            raise ValueError("instance_id must be a positive integer")
+```
+
+Add `album_resolve_key: Optional[tuple[str, str]] = None` beside the album IDs in `PlaySession` and set it in the same conditional block that latches those IDs.
+
+- [ ] **Step 5: Add one resolver-owned reader gate**
+
+Initialize `self._reader_gate = asyncio.Lock()`. Keep the pre-lock cache fast path, then acquire and recheck the cache before running the whole mutable reader sequence. Extract:
+
+```python
+async def _resolve_discogs_locked(
+    self, raw: "RawRecognitionResult", key: tuple[str, str]
+) -> tuple[Optional[TrackMetadata], bool]:
+    """Return (resolved metadata or None, whether Discogs completed cleanly)."""
+```
+
+Move the existing collection/database/speculative-refresh sequence into that method. `resolve()` releases the reader gate before invoking cover-art fallback and uses the returned boolean for the existing fallback-cache decision. Do not treat the executor as a lock and do not hold tracker lifecycle locks across this gate.
+
+Update every `MetadataResolver.__new__` test fixture to install `asyncio.Lock()` explicitly.
+
+- [ ] **Step 6: Add recovery rebuild without cooldown mutation**
+
+Add a reader method that strictly rebuilds collection state and re-runs normal album matching while bypassing only `_last_index_refresh_at`. It respects the separate build-failure backoff and swap-on-success and leaves `_last_speculative_refresh_succeeded` unchanged. It returns the ordinary validated release-level match; it does not claim instance multiplicity.
+
+- [ ] **Step 7: Implement conditional resolver recovery**
+
+Implement:
+
+```python
+async def recover_collection_instance(
+    self,
+    resolve_key: tuple[str, str],
+    expected_release_id: int,
+    expected_instance_id: int,
+    observed_instance_ids: tuple[int, ...],
+) -> Optional[CollectionIdentity]:
+```
+
+Validate the resolve key, stale IDs, and that every observed tuple member is a
+unique exact positive integer, but do not reject tuple cardinality yet. Under
+`_reader_gate`, inspect without erasing unrelated/newer cache state. Pop only
+the exact stale collection pair; absent is allowed. A newer entry is accepted
+only if the tuple contains exactly one replacement and its exact pair equals
+the expected release plus that singleton.
+
+After the exact stale entry has been removed, require cardinality one and a
+candidate different from the stale instance. Empty, multiple, or same-instance
+evidence returns `None` immediately without rebuilding or repopulating the key.
+This order ensures safe refusal does not leave the immortal stale entry intact.
+
+After a strict recovery rebuild, require one unambiguous match whose release ID equals `expected_release_id`. Copy its payload, overwrite `instance_id` with the proven singleton, store that positive entry, and return `CollectionIdentity`. On different/no/ambiguous match or error, leave the key uncached and return `None` after actionable non-secret logging.
+
+- [ ] **Step 8: Verify resolver/model GREEN**
+
+Run:
+
+```bash
+cd '/private/tmp/vnp-wave2-metadata-recovery'
+'/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m pytest -q tests/test_models.py tests/test_resolver.py tests/test_cache_expiry.py tests/test_resolver_error_no_cache.py tests/test_coverart_timeout_238.py tests/test_tracklist_neighbours.py tests/test_discogs_collection_index.py
+git diff --check
+```
+
+- [ ] **Step 9: Independent cache/concurrency review and commit**
+
+Reviewer attacks: stale-pop-after-await, LRU eviction, newer cache replacement, duplicate tuple, bool IDs, changed release, collapsed reader instance, failed recovery during active cooldown, two concurrent reader sequences, and a cache fast path blocked by I/O. Resolve findings and commit explicit files.
+
+```bash
+cd '/private/tmp/vnp-wave2-metadata-recovery'
+git add src/metadata/discogs/outcomes.py src/metadata/models.py src/metadata/discogs/reader.py src/metadata/resolver.py tests/test_models.py tests/test_resolver.py tests/test_cache_expiry.py tests/test_resolver_error_no_cache.py tests/test_coverart_timeout_238.py tests/test_tracklist_neighbours.py
+git commit -m 'feat: recover stale Discogs collection identity safely'
+```
+
+---
+
+### Task 4: Wire one recovered credit attempt through the tracker (#421)
+
+**Files:**
+- Modify: `src/tracking/listen_tracker.py`
+- Modify: `main.py`
+- Modify: `tests/test_listen_tracker.py`
+- Modify: `tests/test_credit_idempotent_186.py`
+- Modify: `tests/test_finalize_retry_after.py`
+- Modify: `tests/test_listen_tracker_conc2.py`
+- Modify: `tests/test_main_wiring.py`
+
+**Interfaces:**
+- Consumes: Task 2 `PlayCountReadResult` and Task 3 recovery callback/latched key.
+- Produces: `ListenTracker(..., recover_collection_instance=None)` with one pre-plan recovery path and recovered identity used by both Discogs fields.
+
+- [ ] **Step 1: Write tracker recovery RED tests**
+
+Extend tracker test helpers with an optional `AsyncMock` recovery callback. Add:
+
+- `test_definitive_missing_recovers_same_release_new_instance_once`
+- `test_abort_read_never_invokes_identity_recovery`
+- `test_recovery_refusal_writes_neither_discogs_field`
+- `test_second_definitive_missing_stops_both_field_writes`
+- `test_replacement_abort_skips_play_count_but_updates_last_played_once`
+- `test_recovered_play_count_failure_still_updates_last_played_on_replacement`
+- `test_recovery_uses_latched_key_stale_pair_and_observed_tuple`
+- `test_recovery_callback_is_spent_at_most_once`
+- `test_missing_recovery_callback_preserves_fail_closed_behavior`
+
+For success, the writer returns MISSING for `(999, 77)` with `(88,)`, then READY for `(999, 88)`. Assert the callback is awaited once with the exact four arguments, `set_play_count` targets 88 once (or repeats one absolute value under its existing retry), `update_last_played` targets 88 once, and the detached session is credited.
+
+- [ ] **Step 2: Add #186/#229 recovery RED tests**
+
+In `tests/test_credit_idempotent_186.py`, add:
+
+- `test_ambiguous_old_instance_post_never_invokes_recovery`
+- `test_recovered_absolute_post_retry_reuses_one_target`
+
+The second test makes the first recovered POST apply server-side but lose its response. Every repeated body must equal the one target computed from the single replacement read; final server count is exactly old+1.
+
+In `tests/test_finalize_retry_after.py`, add `test_rate_limited_replacement_read_does_not_replenish_recovery_budget`. Preserve all existing honored-wait bounds.
+
+In `tests/test_listen_tracker_conc2.py`, prove a recovery finalizer does not hold `_lifecycle_lock`, and separate finalizers remain serialized.
+
+- [ ] **Step 3: Write composition-root RED test**
+
+In `tests/test_main_wiring.py`, capture constructed resolver/tracker and compare the injected bound method by `__self__` and `__func__`; do not use object identity between separate bound-method attribute reads.
+
+Run:
+
+```bash
+cd '/private/tmp/vnp-wave2-metadata-recovery'
+'/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m pytest -q tests/test_listen_tracker.py tests/test_credit_idempotent_186.py tests/test_finalize_retry_after.py tests/test_listen_tracker_conc2.py tests/test_main_wiring.py
+```
+
+Expected RED: tracker has no recovery port and main does not inject one.
+
+- [ ] **Step 4: Implement one pre-plan recovery state machine**
+
+Add the optional callback to `ListenTracker.__init__`. In `_credit_completed_album`, keep a local `recovery_spent = False`. When and only when the initial read is MISSING:
+
+1. mark the budget spent before awaiting;
+2. require callback and `session.album_resolve_key`;
+3. forward the stale pair and immutable observed tuple;
+4. stop both fields if recovery refuses;
+5. update the detached session pair to the returned identity;
+6. perform one replacement read; and
+7. only READY may create the absolute count plan.
+
+A second MISSING terminates both fields. ABORT on the replacement remains a failed Play Count attempt without another recovery; because the replacement identity was safely established, META-7 still makes one Last Played attempt against it. Never invoke recovery after `plan` contains an absolute target.
+
+- [ ] **Step 5: Inject the narrow bound method**
+
+In `main.py`, retain the resolver variable and construct:
+
+```python
+tracker = ListenTracker(
+    DiscogsCollectionWriter(discogs_http, config.discogs),
+    lastfm,
+    recover_collection_instance=resolver.recover_collection_instance,
+)
+```
+
+Do not pass the reader or resolver object itself and do not change the shared transport.
+
+- [ ] **Step 6: Verify tracker/integration GREEN**
+
+Run:
+
+```bash
+cd '/private/tmp/vnp-wave2-metadata-recovery'
+'/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m pytest -q tests/test_listen_tracker.py tests/test_credit_idempotent_186.py tests/test_finalize_retry_after.py tests/test_listen_tracker_conc2.py tests/test_main_wiring.py tests/test_split_finalize_drain_187.py tests/test_listen_tracker_idempotency.py
+git diff --check
+```
+
+- [ ] **Step 7: Independent recovery/retry review and commit**
+
+Reviewer attacks: recovery after ambiguous POST, two recovery calls, a second missing result, reuse of old plan/IDs, Last Played on known-stale identity, META-7 suppression after safe replacement, callback absence/raise/cancel, and lifecycle-lock blockage. Resolve all findings and commit explicit files.
+
+```bash
+cd '/private/tmp/vnp-wave2-metadata-recovery'
+git add src/tracking/listen_tracker.py main.py tests/test_listen_tracker.py tests/test_credit_idempotent_186.py tests/test_finalize_retry_after.py tests/test_listen_tracker_conc2.py tests/test_main_wiring.py
+git commit -m 'feat: retry one credit on safe Discogs replacement'
+```
+
+---
+
+### Task 5: Add cross-layer acceptance evidence and durable documentation
+
+**Files:**
+- Create: `tests/test_metadata_recovery_wave2.py`
+- Modify: `docs/decisions/remediation-guardrails.md`
+- Modify: `CHANGELOG.md`
+- Modify: `docs/superpowers/specs/2026-08-22-wave2-metadata-recovery-design.md` only if implementation review resolves a documented interface detail
+- Modify: `docs/superpowers/plans/2026-08-22-wave2-metadata-recovery.md` checkboxes/status only after fresh evidence
+
+- [ ] **Step 1: Add the cross-layer acceptance matrix**
+
+Use real resolver/tracker orchestration with mocked HTTP/reader/writer seams. Add:
+
+- `test_failed_refresh_then_cooldown_skip_returns_database_uncached`
+- `test_stale_instance_recovers_to_safe_replacement_and_credits_once`
+- `test_duplicate_replacement_instances_never_select_or_cache_a_write_target`
+
+The first test records two displayed database results, zero cache entries, and no second page walk. The second begins with cached `(release=999, instance=77)`, gets a strict MISSING result carrying `(88,)`, rebuilds the same release, reads 88 once, and posts one absolute target. The duplicate test carries `(88, 89)`, clears only stale state, performs no field POST, and leaves the key uncached for the next play.
+
+- [ ] **Step 2: Run the integrated Wave 2 suite**
+
+```bash
+cd '/private/tmp/vnp-wave2-metadata-recovery'
+'/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m pytest -q tests/test_cache_expiry.py tests/test_resolver.py tests/test_resolver_error_no_cache.py tests/test_discogs_collection_index.py tests/test_discogs_client.py tests/test_models.py tests/test_credit_idempotent_186.py tests/test_listen_tracker.py tests/test_listen_tracker_conc2.py tests/test_finalize_retry_after.py tests/test_main_wiring.py tests/test_metadata_recovery_wave2.py
+git diff --check
+```
+
+- [ ] **Step 3: Update durable decisions and changelog**
+
+In the Wave 2 guardrail section record:
+
+- explicit refresh/cacheability states;
+- strict complete-index promotion plus separate failed-build backoff;
+- definitive missing proof only from validated single-page evidence;
+- writer-carried immutable observed instance tuple;
+- same release plus exactly one new instance for one recovery attempt;
+- ordinary positive cache immortality and memory-only index unchanged;
+- #186/#229/META-7 preserved.
+
+In `CHANGELOG.md` under Unreleased, describe user-visible long-uptime ownership recovery and safe replacement crediting without claiming live Discogs validation.
+
+- [ ] **Step 4: Independent documentation/spec review and commit**
+
+Review current implementation, issue contracts, and historical #191/#242/#169/#186/#229/META-7 behavior. Reject any claim that ambiguous or multi-page absence is definitive or that positive entries now expire.
+
+```bash
+cd '/private/tmp/vnp-wave2-metadata-recovery'
+git add tests/test_metadata_recovery_wave2.py docs/decisions/remediation-guardrails.md CHANGELOG.md docs/superpowers/specs/2026-08-22-wave2-metadata-recovery-design.md docs/superpowers/plans/2026-08-22-wave2-metadata-recovery.md
+git commit -m 'docs: record Wave 2 metadata recovery contract'
+```
+
+Omit unchanged paths from `git add`; never substitute a broad staging command.
+
+---
+
+### Task 6: Verify, adversarially review, and close Wave 2
+
+**Files:**
+- No production edits unless a confirmed review finding requires a new RED/GREEN fix round.
+- Update ignored audit/log/memory artifacts only after tracked code is final.
+
+- [ ] **Step 1: Run fresh local focused and full verification**
+
+Run the integrated command from Task 5, then:
+
+```bash
+cd '/private/tmp/vnp-wave2-metadata-recovery'
+'/Users/lanebecker-wmf/Documents/Claude.nosync/Projects/Vinyl Now Playing/.venv/bin/python' -m pytest -q
+git diff --check origin/main...HEAD
+git status --short --branch
+```
+
+Record the unsupported local Python version and any known environment-only failures separately from product failures.
+
+- [ ] **Step 2: Run independent adversarial review**
+
+Reviewers must attempt at least:
+
+- failed refresh → cooldown skip → false database cache;
+- incomplete/capped index promotion and repeated maximum page walks;
+- 404/multi-page/malformed response promoted to definitive missing;
+- duplicate-copy arbitrary selection or cache repopulation;
+- stale cache deletion after a newer resolve;
+- reader entry from finalizer without serialization;
+- changed release or same stale instance accepted;
+- recovery after an old absolute target/ambiguous POST;
+- a second recovery budget or recomputed count target;
+- Last Played targeting stale identity or losing META-7 independence; and
+- persisted instance state or ordinary positive expiry.
+
+Every confirmed finding receives a RED test, minimal fix, fresh focused/integrated runs, and another independent review. Stop only at zero open material findings.
+
+- [ ] **Step 3: Push and require supported exact-SHA CI**
+
+Push the reviewed branch, open the PR, and require successful `test (3.11)`, `test (3.12)`, `test (3.13)`, version metadata, and dependency audit for the exact head SHA. Do not merge from local Python 3.9 evidence alone.
+
+- [ ] **Step 4: Merge and reconcile issues/milestone**
+
+After owner-approved merge, verify post-merge main checks. Add exact SHA/run/test evidence to #420 and #421; close only when their acceptance criteria match the merged behavior. Update the Wave 2 milestone and the canonical ignored audit/log/shared memory with exact evidence and remaining risks. No live Discogs write is part of this closeout.

--- a/docs/superpowers/specs/2026-08-22-wave2-metadata-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-22-wave2-metadata-recovery-design.md
@@ -1,0 +1,443 @@
+# Wave 2 Metadata Recovery and Cache Coherence Design
+
+**Status:** Approved architecture; written-spec review pending
+**Date:** 2026-08-22
+**Issues:** #420 (R10-05) and #421 (R10-12)
+**Decision authority:** `docs/decisions/remediation-guardrails.md`
+
+## Outcome
+
+Wave 2 makes Discogs ownership state explicit and permits one narrowly bounded
+recovery when a previously valid collection instance has definitively
+disappeared. It does not turn the 24/7 appliance into a continuously syncing
+Discogs client, expire positive collection matches during ordinary reads, or
+trade a missed credit for a possible wrong-record write.
+
+The work lands in this order:
+
+1. #420 distinguishes an owned result, a completed clean no-match, and a
+   cooldown-skipped refresh. A skip or error that leaves ownership unknown may
+   return database metadata for the current display, but may not cache that
+   downgrade as if Discogs had proved the record unowned.
+2. #421 recognizes a missing instance only after a complete, successful
+   enumeration proves it absent. It then invalidates the exact stale positive
+   cache entry, rebuilds collection ownership once, and retries the current
+   Play Count credit once only if the same Discogs release resolves to exactly
+   one eligible new collection instance.
+
+`DESIGN.md` is not authority for this work. Current tested behavior, the live
+issue contracts, historical closure rationale, and the owner's ratified
+decisions control.
+
+## Binding invariants
+
+### Ownership and cache truth
+
+- The collection index remains process-local and memory-only. #169's rejected
+  persistence design is not reopened.
+- Positive `DISCOGS_COLLECTION` resolver entries remain immortal during
+  ordinary reads. There is no positive-entry TTL, background refresh, or
+  periodic revalidation.
+- The #191 15-minute speculative-refresh cooldown remains global and is stamped
+  before network I/O, including a failed attempt. Temporary failure must not
+  produce one full collection re-page per unowned album.
+- Failed or incomplete collection-index builds have a separate bounded
+  backoff. While it is active, ordinary resolution serves a prior complete
+  snapshot only as stale/unknown or fails fast when none exists; it may not
+  launch another page walk or authorize clean-negative caching. Recovery also
+  fails fast and spends that session's one recovery budget. A successful
+  complete rebuild clears this build-failure backoff.
+- A failed index rebuild preserves the last complete index and propagates the
+  error. #242 swap-on-success remains intact.
+- A displayed database result is not necessarily cacheable. A database
+  downgrade is cached only when the active collection state proves a completed,
+  clean ownership check.
+
+### Credit and write integrity
+
+- A missed Discogs credit is preferable to a phantom, duplicate, or wrong-copy
+  credit.
+- Recovery begins only from a definitive missing-instance result during the
+  read half, before a new absolute Play Count target is computed.
+- An ambiguous POST outcome never triggers identity recovery or another
+  read-modify-write. #186 remains: read once, compute one absolute target, and
+  retry only that same absolute POST.
+- The existing #229 bounded rate-limit behavior remains separate from the one
+  identity-recovery budget. Neither path may recursively activate the other.
+- Last Played retains the ratified META-7 independence from Play Count and its
+  single-attempt absolute-write behavior. Once recovery establishes one safe
+  replacement identity, Last Played uses that identity even if Play Count
+  independently fails. If recovery cannot establish a safe identity, neither
+  field targets the known-stale instance.
+- Confirmation, session epoch, side coverage, spin deduplication, and
+  `crediting`/`credited` gates are unchanged.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    R["Resolve artist and album"] --> C["Search current collection index"]
+    C -->|"owned"| P["Immortal positive cache"]
+    C -->|"miss plus database hit"| F["Speculative forced refresh"]
+    F --> O{"Explicit refresh outcome"}
+    O -->|"owned"| P
+    O -->|"clean no-match"| D["Cache database downgrade"]
+    O -->|"cooldown after failed/unknown attempt"| U["Return database metadata uncached"]
+    W["Read Play Count for latched identity"] --> M{"Definitive missing instance?"}
+    M -->|"no / ambiguous"| A["Existing success or fail-closed path"]
+    M -->|"yes"| I["Invalidate exact stale positive entry"]
+    I --> X["One serialized full collection rebuild"]
+    X --> S{"Same release, exactly one safe new instance?"}
+    S -->|"yes"| N["One replacement read and absolute credit plan"]
+    S -->|"no"| Z["Stop without a write"]
+```
+
+The reader remains responsible for Discogs collection enumeration and matching.
+The resolver remains responsible for ownership interpretation and album-cache
+coherence. The writer remains responsible for collection-field reads and
+writes. The tracker receives one narrow recovery capability rather than the
+reader or resolver as a general dependency.
+
+## #420: explicit refresh outcomes
+
+### Reader contract
+
+`DiscogsReader.refresh_index_and_research()` no longer returns an ambiguous
+`Optional[dict]`. It returns an immutable result with:
+
+- `OWNED`: a validated collection match is present;
+- `CLEAN_NO_MATCH`: a complete rebuild succeeded and produced no unambiguous
+  owned match;
+- `COOLDOWN_SKIPPED`: no rebuild was attempted because the global cooldown is
+  active.
+
+The result also records whether the active cooldown follows a successful full
+collection rebuild. This provenance is false as soon as a new forced attempt is
+stamped and becomes true only after that attempt has successfully completed the
+full collection rebuild. Exceptions remain exceptions; transport, parsing, and
+index-build failures are never converted to a result state.
+
+A rebuild is complete only when pagination metadata is present and valid, every
+advertised collection page finishes successfully, returned page metadata stays
+internally consistent, all required item identities validate, and the final
+page is reached below the defensive cap. Missing/malformed pagination or
+reaching the cap while another page is advertised is an unknown/error outcome:
+the partial candidate index is discarded, the prior complete index is restored
+under #242, and the result may not be `CLEAN_NO_MATCH` or authorize downgrade
+caching. This strict rule applies to any rebuild that would replace the active
+index; an incomplete index is never promoted as complete truth.
+
+Every failed/incomplete ordinary, speculative, or recovery rebuild stamps the
+separate build-failure backoff before returning or raising. Repeated tracks
+during that bounded window do not restart pagination. If a prior complete index
+exists, positive matches may still be served from it under the ordinary
+immortal-positive policy, but its misses are unknown and cannot authorize a
+database downgrade. If no complete index exists, collection ownership remains
+unavailable and uncached until backoff expires. This backoff limits page-walk
+frequency without changing the #191 speculative cooldown timestamp or recovery
+budget.
+
+On a cooldown skip:
+
+- if the active cooldown follows a successful rebuild, the existing collection
+  snapshot is authoritative enough to permit the normal database downgrade;
+- if it follows a failed or otherwise incomplete attempt, ownership remains
+  unknown and the database result is returned uncached.
+
+The implementation may conservatively leave a downgrade uncached when it
+cannot prove successful-refresh provenance. It may never infer clean ownership
+from elapsed time, a truthy database result, or the mere presence of a stale
+index.
+
+### Resolver contract
+
+The resolver branches on the explicit state, never result truthiness:
+
+| Refresh outcome | Display result | Album-cache action |
+|---|---|---|
+| `OWNED` | Collection metadata | Store immortal positive result |
+| `CLEAN_NO_MATCH` | Database metadata | Store existing one-hour downgrade |
+| `COOLDOWN_SKIPPED`, prior rebuild proven successful | Database metadata | May store existing one-hour downgrade |
+| `COOLDOWN_SKIPPED`, prior attempt failed/unknown | Database metadata | Do not cache |
+| Exception | Best available metadata/fallback | Do not cache a Discogs downgrade |
+
+This preserves both user-visible metadata availability and truthful retry
+behavior.
+
+## #421: definitive instance recovery
+
+### Public writer result
+
+`read_play_count()` gains an explicit result status rather than overloading
+`None` for every abort condition:
+
+- `READY`, with validated `field_id` and current integer count;
+- `DEFINITIVE_INSTANCE_MISSING`;
+- `ABORT`, for every other unsafe condition.
+
+The existing confirmed-blank field remains `READY` with count zero. Missing
+field configuration, non-integer owner data, malformed JSON, incomplete
+pagination, non-success HTTP status, transport error, and unknown response
+shape remain `ABORT` and authorize no write or recovery.
+
+### Proof required for “definitive”
+
+The collection-items-by-release response may contain multiple copies and may be
+paginated. Because Discogs supplies no snapshot token, traversing multiple
+pages while the collection changes cannot prove that an omitted item was absent
+from one coherent snapshot. Absence is therefore definitive only when all of
+the following are true:
+
+1. every request completed successfully with a parseable `200` response;
+2. pagination metadata is present, internally consistent, and proves the whole
+   result is page 1 of exactly 1 page;
+3. pagination `items` equals the number of returned release items and the
+   positive `per_page` value can contain that count;
+4. every item identifies the requested positive `release_id`, and every
+   `instance_id` is a unique positive integer; and
+5. the expected instance is absent from that validated complete set.
+
+An undocumented `404`, any `pages > 1` response, a one-page body without
+complete pagination proof, duplicate/malformed identities, or a body that
+merely omits the expected instance is not definitive. These remain `ABORT`
+until a separately reviewed contract or executed live evidence proves a
+stronger interpretation. Raw Discogs response bodies and credentials are never
+logged.
+
+### Latched recovery identity
+
+`PlaySession` stores `album_resolve_key` at the exact moment it first latches
+`album_release_id` and `album_instance_id`. It uses that track's original,
+normalized resolver key; it does not reconstruct identity from a decorated
+Discogs title or use `last_release_resolve_key`, which can later change.
+
+Recovery requires:
+
+- a non-empty latched resolver key;
+- exact positive-integer expected release and instance IDs;
+- a fresh, complete, multiplicity-preserving collection result for that key;
+- the same Discogs `release_id` as the stale identity; and
+- exactly one eligible positive replacement `instance_id`, different from the
+  stale instance.
+
+Restricting the current credit to the same release prevents an automatic write
+to a different pressing selected only by artist/album text. A successful fresh
+match for a different release may become the positive cache value for future
+sessions, but the current stale session is not credited. Broader cross-release
+recovery requires a new owner decision and stronger identity evidence.
+
+The ordinary collection index deliberately collapses duplicate copies of a
+release to one first-seen instance. Recovery may not use that collapsed value
+as identity proof. Its recovery-specific rebuild/match preserves all instances
+for the expected release long enough to prove that exactly one eligible new
+copy exists. Zero or multiple surviving/replacement copies refuse the current
+credit; collection order never selects a write target.
+
+### Narrow recovery port
+
+The tracker receives an optional async callable shaped like:
+
+```python
+async def recover_collection_instance(
+    resolve_key: tuple[str, str],
+    expected_release_id: int,
+    expected_instance_id: int,
+) -> CollectionIdentity | None: ...
+```
+
+`CollectionIdentity` contains validated release and instance IDs only. The
+resolver implements the callable; reader result dictionaries and cache details
+remain private to the metadata layer. A missing callback preserves current
+fail-closed behavior and supports focused tracker tests.
+
+### Conditional invalidation and rebuild
+
+While holding the resolver's reader/cache gate, recovery:
+
+1. inspects the cache entry for the key: an exact stale positive entry is
+   removed; an absent entry requires no deletion and remains recoverable from
+   the session's latched identity; a present nonmatching entry is never erased;
+2. invokes a distinct recovery refresh that bypasses the speculative cooldown,
+   while retaining swap-on-success, strict pagination completeness,
+   multiplicity, and all normal album-matching safeguards;
+3. stores a fresh positive result for future resolves only when the
+   multiplicity-preserving result contains exactly one eligible instance; zero
+   or multiple instances leave the key uncached rather than storing a collapsed
+   first-seen instance; and
+4. returns an identity only when the same-release/exactly-one-new-instance rules
+   pass.
+
+If another task has already replaced the cache entry, recovery must not erase
+it. It may use that newer entry only when it independently satisfies the same
+identity and multiplicity rules; otherwise it stops. An LRU-evicted or otherwise
+absent key does not block the one serialized fresh recovery because there is no
+newer cache value to overwrite.
+
+If rebuilding fails, the reader retains its prior complete index under #242,
+but the resolver does not restore the known-stale positive album-cache entry.
+The failed session remains uncredited and a later recognition can resolve
+again.
+
+The recovery rebuild does not consume, reset, or extend the #191 speculative
+refresh cooldown and does not change its success provenance. Even after a
+successful recovery rebuild, an active cooldown left by a failed speculative
+attempt remains conservatively uncacheable until the speculative state itself
+changes. Recovery's positive result may still populate the exact positive
+album entry only when its multiplicity proof found exactly one eligible
+instance. Recovery failure does stamp the separate build-failure backoff.
+
+## Serialization and concurrency
+
+Today the mutable reader is safe because track commits are its only caller.
+Recovery adds a finalizer caller, so the resolver owns one `asyncio.Lock` that
+serializes every reader sequence, including ordinary collection/database
+resolution, speculative refresh, and recovery refresh.
+
+Ordinary resolve performs a cache check before the lock for the fast path and
+rechecks after acquiring the lock before entering the reader. Recovery performs
+its expected-identity check and conditional invalidation while holding the same
+gate. No tracker lifecycle lock is held while waiting for Discogs I/O.
+
+The tracker's existing finalize lock continues to serialize album finalization;
+it is not repurposed as a reader lock. The shared Discogs executor remains the
+transport boundary, but executor serialization is not treated as cache-state
+coordination.
+
+## Recovery credit sequence
+
+When the first Play Count read returns `DEFINITIVE_INSTANCE_MISSING`:
+
+1. spend the session's single identity-recovery budget;
+2. call the recovery port with the latched key and exact stale pair;
+3. stop if no safe identity is returned;
+4. update only the detached session's album release/instance identity;
+5. read the replacement instance once and compute one new absolute target;
+6. use the existing bounded absolute-POST retry behavior;
+7. mark the session credited and update spin memory only after the Play Count
+   write succeeds; and
+8. preserve META-7 independence by attempting Last Played once against the safe
+   recovered pair, whether or not Play Count independently succeeds.
+
+A second definitive-missing result stops both field writes because the recovered
+target is no longer safe. An ambiguous replacement Play Count read aborts the
+count but preserves META-7's independent single Last Played attempt against the
+already established safe replacement identity. A transport/rate-limit exception
+follows the existing bounded read behavior but does not replenish the
+identity-recovery budget. Recovery never resumes a possibly applied old-instance
+POST because it is available only before the old absolute target exists.
+
+## Failure behavior
+
+| Failure or uncertainty | Required behavior |
+|---|---|
+| Forced refresh raises | Preserve prior reader index; mark cooldown provenance unsuccessful; do not cache downgrade. |
+| Index build is incomplete, malformed, or reaches its page cap | Discard the candidate, preserve any prior complete index as stale/unknown, stamp build-failure backoff, and do not page again during that window. |
+| Cooldown follows failed refresh | Return display metadata uncached; make no additional collection-page request. |
+| Complete refresh proves no ownership | Cache the normal database downgrade. |
+| Collection response omits instance without complete pagination proof | `ABORT`; no write, invalidation, refresh, or retry. |
+| Strict single-page enumeration proves instance missing | Permit the one conditional recovery attempt. |
+| Release lookup advertises multiple pages or inconsistent identities | `ABORT`; absence is not snapshot-safe and authorizes no recovery. |
+| Cache entry no longer matches expected stale pair | Do not erase it; accept only if independently safe, otherwise stop. |
+| Cache entry is absent | Delete nothing; permit the one serialized fresh recovery from the latched identity. |
+| Recovery returns no/ambiguous/different release or duplicate same-release copies | Keep current session uncredited; no Play Count or Last Played write. |
+| Recovery sees zero or multiple eligible instances | Leave the album key uncached; never store a collapsed first-seen write target. |
+| Replacement Play Count read is ambiguous/unsafe | Abort Play Count and do not initiate a second recovery; preserve one META-7 Last Played attempt against the established safe identity. |
+| Replacement read definitively proves the new instance missing | Stop both field writes; do not initiate a second recovery. |
+| Replacement absolute POST is ambiguous | Retry only the same absolute target under existing bounds. |
+| Recovery rebuild fails | Keep reader's last complete index, leave stale album entry invalidated, and stop this credit. |
+
+Every recovery refusal produces an actionable, non-secret log identifying the
+stage and numeric release/instance IDs where safe. It does not log raw response
+bodies, custom-field contents, access tokens, or configuration values.
+
+## Test and acceptance plan
+
+One shared table-driven state matrix covers:
+
+- record added after long uptime;
+- clean unowned miss;
+- successful refresh with no owned match;
+- successful refresh with an owned upgrade;
+- forced-refresh error with old-index restoration;
+- cooldown skip following failure;
+- cooldown skip following successful rebuild;
+- immortal positive cache under ordinary reads beyond downgrade TTL;
+- complete enumeration of a removed/replaced instance;
+- incomplete, malformed, multi-page, non-200, duplicate-ID, wrong-release, and
+  transport-ambiguous reads;
+- same-release/new-instance recovery;
+- same instance, changed release, duplicate instances of the same release, and
+  no-match refusal;
+- incomplete collection-index pagination and page-cap refusal without swapping
+  out the prior complete index;
+- repeated recognition after malformed/capped pagination making no second page
+  walk during the build-failure backoff, both with and without a prior index;
+- recovery during an active failed-attempt cooldown without changing its stamp
+  or cacheability provenance;
+- recovery after LRU eviction of the stale positive album entry;
+- duplicate-instance recovery leaving the album key uncached for the next play;
+- concurrent ordinary resolve and finalizer recovery;
+- replacement read failure and second-missing refusal;
+- ambiguous absolute POST retaining one computed target; and
+- META-7 Last Played independence on the safe recovered identity, plus no Last
+  Played write when recovery never establishes a safe target.
+
+Behavior changes are implemented RED-first. Focused verification includes:
+
+- `tests/test_cache_expiry.py`
+- `tests/test_resolver.py`
+- `tests/test_resolver_error_no_cache.py`
+- `tests/test_discogs_collection_index.py`
+- writer-focused Discogs tests
+- `tests/test_credit_idempotent_186.py`
+- `tests/test_listen_tracker.py`
+- `tests/test_listen_tracker_conc2.py`
+- `tests/test_finalize_retry_after.py`
+
+Before merge, run the full supported Python 3.11/3.12/3.13 matrix and dependency
+audit. The acceptance record must include the executed #420 failure-then-skip
+reproduction and the #421 stale-instance-to-safe-replacement integration test.
+No live Discogs write is required for unit acceptance; any later live diagnostic
+remains read-only unless separately authorized under the #366 controls.
+
+## Implementation sequence
+
+1. Add RED tests for #420's explicit refresh states and cacheability matrix.
+2. Implement the reader result and resolver branching without changing cooldown
+   or swap-on-success behavior.
+3. Verify and commit #420 independently.
+4. Add RED tests for complete enumeration and the public writer read outcome.
+5. Implement strict single-page definitive-missing proof while keeping all
+   multi-page or malformed ambiguity fail-closed.
+6. Add the latched resolve key, resolver gate, conditional invalidation, and
+   narrow recovery port with concurrency tests.
+7. Add the tracker single-recovery sequence and no-double-credit tests.
+8. Run focused and integrated suites, then an adversarial review aimed at
+   cooldown abuse, incomplete-pagination promotion, cache races, duplicate-copy
+   or wrong-release targeting, nested retries, and Last Played drift.
+9. Run supported CI, update durable guardrails/changelog/issue evidence, and
+   close #420/#421 only after exact-SHA verification succeeds.
+
+## Deliberately rejected alternatives
+
+- **Positive-cache TTL or background synchronization:** conflicts with the
+  owner's immortal-positive-read decision, adds recurring Discogs load, and can
+  still race writes.
+- **Inject the reader/resolver as a general tracker dependency:** recreates a
+  metadata backchannel and weakens the deliberate A-4 read/write split.
+- **Make the writer mutate resolver caches or rebuild collection search state:**
+  combines unrelated responsibilities into a Discogs god object.
+- **Treat any 404 or missing item in one `200` page as definitive:** converts an
+  undocumented or incomplete response into authorization for a different
+  write target.
+- **Retry the whole old read-modify-write after a write failure:** reopens the
+  #186 double-credit defect.
+- **Persist the collection index or an instance mapping:** reopens #169 without
+  a restart-safe removal/re-add design.
+
+## Revisit triggers
+
+Revisit this design if Discogs publishes and live evidence confirms a stronger
+single-instance existence contract, if same-release replacements are
+insufficient for real collection workflows, if measured reader serialization
+hurts recognition latency, or if the owner reopens persistent collection state.

--- a/docs/superpowers/specs/2026-08-22-wave2-metadata-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-22-wave2-metadata-recovery-design.md
@@ -1,6 +1,6 @@
 # Wave 2 Metadata Recovery and Cache Coherence Design
 
-**Status:** Approved architecture; written-spec review pending
+**Status:** Approved for planning and implementation
 **Date:** 2026-08-22
 **Issues:** #420 (R10-05) and #421 (R10-12)
 **Decision authority:** `docs/decisions/remediation-guardrails.md`
@@ -172,7 +172,8 @@ behavior.
 `None` for every abort condition:
 
 - `READY`, with validated `field_id` and current integer count;
-- `DEFINITIVE_INSTANCE_MISSING`;
+- `DEFINITIVE_INSTANCE_MISSING`, carrying the complete validated tuple of
+  currently observed instance IDs for the requested release;
 - `ABORT`, for every other unsafe condition.
 
 The existing confirmed-blank field remains `READY` with count zero. Missing
@@ -215,22 +216,30 @@ Recovery requires:
 
 - a non-empty latched resolver key;
 - exact positive-integer expected release and instance IDs;
-- a fresh, complete, multiplicity-preserving collection result for that key;
+- a fresh, complete collection rebuild that unambiguously matches the expected
+  release for that key;
+- the writer-proven complete instance tuple containing exactly one eligible
+  replacement;
 - the same Discogs `release_id` as the stale identity; and
 - exactly one eligible positive replacement `instance_id`, different from the
   stale instance.
 
 Restricting the current credit to the same release prevents an automatic write
-to a different pressing selected only by artist/album text. A successful fresh
-match for a different release may become the positive cache value for future
-sessions, but the current stale session is not credited. Broader cross-release
-recovery requires a new owner decision and stronger identity evidence.
+to a different pressing selected only by artist/album text. A recovery rebuild
+that matches a different release leaves this key uncached; a later ordinary
+resolve may establish that release under the normal rules, but the current
+stale session is not credited. Broader cross-release recovery requires a new
+owner decision and stronger identity evidence.
 
 The ordinary collection index deliberately collapses duplicate copies of a
 release to one first-seen instance. Recovery may not use that collapsed value
-as identity proof. Its recovery-specific rebuild/match preserves all instances
-for the expected release long enough to prove that exactly one eligible new
-copy exists. Zero or multiple surviving/replacement copies refuse the current
+as identity or multiplicity proof. The writer's strict, single-page
+collection-items-by-release read supplies the complete validated instance tuple
+from the same response that proves the stale instance absent. The resolver's
+recovery rebuild independently proves that the expected release remains the
+fresh, unambiguous album match. Recovery is authorized only when the writer's
+tuple contains exactly one eligible new instance and the reader resolves that
+same release. Zero or multiple surviving/replacement copies refuse the current
 credit; collection order never selects a write target.
 
 ### Narrow recovery port
@@ -242,6 +251,7 @@ async def recover_collection_instance(
     resolve_key: tuple[str, str],
     expected_release_id: int,
     expected_instance_id: int,
+    observed_instance_ids: tuple[int, ...],
 ) -> CollectionIdentity | None: ...
 ```
 
@@ -257,21 +267,24 @@ While holding the resolver's reader/cache gate, recovery:
 1. inspects the cache entry for the key: an exact stale positive entry is
    removed; an absent entry requires no deletion and remains recoverable from
    the session's latched identity; a present nonmatching entry is never erased;
-2. invokes a distinct recovery refresh that bypasses the speculative cooldown,
-   while retaining swap-on-success, strict pagination completeness,
-   multiplicity, and all normal album-matching safeguards;
+2. validates the writer-proven `observed_instance_ids` as a unique positive
+   tuple that excludes the stale instance, then invokes a distinct recovery
+   refresh that bypasses the speculative cooldown while retaining
+   swap-on-success, strict pagination completeness, and all normal
+   release-level album-matching safeguards;
 3. stores a fresh positive result for future resolves only when the
-   multiplicity-preserving result contains exactly one eligible instance; zero
-   or multiple instances leave the key uncached rather than storing a collapsed
-   first-seen instance; and
+   writer-proven tuple contains exactly one eligible instance and the fresh
+   reader match has the expected release ID; it replaces any collapsed
+   `instance_id` in the reader payload with that proven singleton; zero or
+   multiple instances leave the key uncached; and
 4. returns an identity only when the same-release/exactly-one-new-instance rules
    pass.
 
 If another task has already replaced the cache entry, recovery must not erase
-it. It may use that newer entry only when it independently satisfies the same
-identity and multiplicity rules; otherwise it stops. An LRU-evicted or otherwise
-absent key does not block the one serialized fresh recovery because there is no
-newer cache value to overwrite.
+it. It may use that newer entry only when its exact release/instance pair equals
+the writer-proven singleton replacement; otherwise it stops. An LRU-evicted or
+otherwise absent key does not block the one serialized fresh recovery because
+there is no newer cache value to overwrite.
 
 If rebuilding fails, the reader retains its prior complete index under #242,
 but the resolver does not restore the known-stale positive album-cache entry.
@@ -283,8 +296,9 @@ refresh cooldown and does not change its success provenance. Even after a
 successful recovery rebuild, an active cooldown left by a failed speculative
 attempt remains conservatively uncacheable until the speculative state itself
 changes. Recovery's positive result may still populate the exact positive
-album entry only when its multiplicity proof found exactly one eligible
-instance. Recovery failure does stamp the separate build-failure backoff.
+album entry only when the writer-proven multiplicity tuple contains exactly one
+eligible instance. Recovery failure does stamp the separate build-failure
+backoff.
 
 ## Serialization and concurrency
 
@@ -308,7 +322,8 @@ coordination.
 When the first Play Count read returns `DEFINITIVE_INSTANCE_MISSING`:
 
 1. spend the session's single identity-recovery budget;
-2. call the recovery port with the latched key and exact stale pair;
+2. call the recovery port with the latched key, exact stale pair, and complete
+   validated instance tuple carried by the missing result;
 3. stop if no safe identity is returned;
 4. update only the detached session's album release/instance identity;
 5. read the replacement instance once and compute one new absolute target;
@@ -365,6 +380,8 @@ One shared table-driven state matrix covers:
 - complete enumeration of a removed/replaced instance;
 - incomplete, malformed, multi-page, non-200, duplicate-ID, wrong-release, and
   transport-ambiguous reads;
+- missing-instance results carrying the exact validated replacement tuple and
+  no tuple escaping from an ambiguous read;
 - same-release/new-instance recovery;
 - same instance, changed release, duplicate instances of the same release, and
   no-match refusal;

--- a/main.py
+++ b/main.py
@@ -299,7 +299,9 @@ def build_components(config, state: PlayerState) -> "Components":
         # late) — not wall-clock windowed, so the tracker no longer needs the
         # silence timeout injected.
         tracker = ListenTracker(
-            DiscogsCollectionWriter(discogs_http, config.discogs), lastfm,
+            DiscogsCollectionWriter(discogs_http, config.discogs),
+            lastfm,
+            recover_collection_instance=resolver.recover_collection_instance,
         )
         # A-9: the application-layer commit service owns resolve → state → track →
         # scrobble; the recognition loop just confirms a result and hands it off.

--- a/src/metadata/discogs/outcomes.py
+++ b/src/metadata/discogs/outcomes.py
@@ -1,0 +1,28 @@
+"""Explicit outcomes for speculative Discogs collection refreshes."""
+
+from dataclasses import dataclass
+from enum import Enum, auto
+from types import MappingProxyType
+from typing import Any, Mapping, Optional
+
+
+class CollectionRefreshState(Enum):
+    OWNED = auto()
+    CLEAN_NO_MATCH = auto()
+    COOLDOWN_SKIPPED = auto()
+
+
+@dataclass(frozen=True)
+class CollectionRefreshResult:
+    state: CollectionRefreshState
+    result: Optional[Mapping[str, Any]] = None
+    cooldown_follows_successful_rebuild: bool = False
+
+    def __post_init__(self):
+        if (self.state is CollectionRefreshState.OWNED) != (self.result is not None):
+            raise ValueError("OWNED requires a result; other states forbid one")
+        if (self.state is not CollectionRefreshState.COOLDOWN_SKIPPED
+                and self.cooldown_follows_successful_rebuild):
+            raise ValueError("cooldown provenance is valid only for a skipped refresh")
+        if self.result is not None:
+            object.__setattr__(self, "result", MappingProxyType(dict(self.result)))

--- a/src/metadata/discogs/outcomes.py
+++ b/src/metadata/discogs/outcomes.py
@@ -12,6 +12,44 @@ class CollectionRefreshState(Enum):
     COOLDOWN_SKIPPED = auto()
 
 
+class PlayCountReadState(Enum):
+    """The safety classification of a Play Count read."""
+
+    READY = auto()
+    DEFINITIVE_INSTANCE_MISSING = auto()
+    ABORT = auto()
+
+
+@dataclass(frozen=True)
+class PlayCountReadResult:
+    """A validated Play Count read, or a safe reason not to write."""
+
+    state: PlayCountReadState
+    field_id: Optional[int] = None
+    current_count: Optional[int] = None
+    observed_instance_ids: tuple[int, ...] = ()
+
+    def __post_init__(self):
+        ready = self.state is PlayCountReadState.READY
+        missing = self.state is PlayCountReadState.DEFINITIVE_INSTANCE_MISSING
+        if ready:
+            if type(self.field_id) is not int or self.field_id <= 0:
+                raise ValueError("READY requires a positive integer field ID")
+            if type(self.current_count) is not int or self.current_count < 0:
+                raise ValueError("READY requires a nonnegative integer count")
+            if self.observed_instance_ids:
+                raise ValueError("READY cannot carry replacement instances")
+        elif self.field_id is not None or self.current_count is not None:
+            raise ValueError("non-READY results cannot carry field/count data")
+        if missing:
+            if (len(set(self.observed_instance_ids)) != len(self.observed_instance_ids)
+                    or any(type(value) is not int or value <= 0
+                           for value in self.observed_instance_ids)):
+                raise ValueError("MISSING instances must be unique positive integers")
+        elif self.observed_instance_ids:
+            raise ValueError("only MISSING can carry replacement instances")
+
+
 @dataclass(frozen=True)
 class CollectionRefreshResult:
     state: CollectionRefreshState

--- a/src/metadata/discogs/outcomes.py
+++ b/src/metadata/discogs/outcomes.py
@@ -6,6 +6,20 @@ from types import MappingProxyType
 from typing import Any, Mapping, Optional
 
 
+@dataclass(frozen=True)
+class CollectionIdentity:
+    """A validated, credit-safe Discogs collection identity."""
+
+    release_id: int
+    instance_id: int
+
+    def __post_init__(self):
+        if type(self.release_id) is not int or self.release_id <= 0:
+            raise ValueError("release_id must be a positive integer")
+        if type(self.instance_id) is not int or self.instance_id <= 0:
+            raise ValueError("instance_id must be a positive integer")
+
+
 class CollectionRefreshState(Enum):
     OWNED = auto()
     CLEAN_NO_MATCH = auto()

--- a/src/metadata/discogs/reader.py
+++ b/src/metadata/discogs/reader.py
@@ -14,6 +14,7 @@ It has no knowledge of the write side (play-count / last-played) — that lives 
 import logging
 import re
 import time
+from dataclasses import dataclass
 from typing import Optional, TYPE_CHECKING
 from urllib.parse import quote
 
@@ -21,7 +22,8 @@ import discogs_client
 
 from src.metadata.models import TracklistEntry
 from src.metadata.discogs.transport import DiscogsHttp, _API_BASE, _HTTP_TIMEOUT
-from src.metadata.errors import is_transient
+from src.metadata.discogs.outcomes import CollectionRefreshResult, CollectionRefreshState
+from src.metadata.errors import TransientMetadataError, is_transient
 from src.metadata.normalize import fold_text, strip_album_decoration
 
 if TYPE_CHECKING:
@@ -69,6 +71,25 @@ _DB_SEARCH_MEMO_TTL_SECONDS = 60.0
 # every genuinely-unowned record too. Seeded to -inf so the first refresh is
 # always allowed regardless of the monotonic epoch.
 _INDEX_REFRESH_COOLDOWN_SECONDS = 15 * 60
+
+# A failed pagination walk cannot prove an index miss.  Keep its retry rate
+# independent from the speculative-refresh cooldown so a malformed response or
+# service outage cannot cause a fresh collection walk for every album.
+_COLLECTION_BUILD_FAILURE_BACKOFF_SECONDS = 15 * 60
+
+
+class CollectionIndexIncomplete(TransientMetadataError):
+    """The collection endpoint did not yield one complete, trustworthy index."""
+
+
+class CollectionOwnershipUnknown(TransientMetadataError):
+    """A stale snapshot can answer a positive, but cannot prove a miss."""
+
+
+@dataclass(frozen=True)
+class _CollectionIndexView:
+    index: dict
+    misses_are_authoritative: bool
 
 # #179: Discogs disambiguates same-named artists by appending " (2)", " (3)",
 # etc. to the NAME field ("Nirvana (2)" is the UK 60s band).  The suffix is a
@@ -263,6 +284,10 @@ class DiscogsReader:
         # #191 (C): monotonic timestamp of the last forced staleness-refresh,
         # for the cooldown. -inf so the first refresh always runs.
         self._last_index_refresh_at: float = float("-inf")
+        # A separate failure-backoff protects strict full-index builds.  Unlike
+        # the speculative cooldown it is about index truth, not request policy.
+        self._last_collection_build_failure_at: Optional[float] = None
+        self._last_speculative_refresh_succeeded = False
         # R5-20: one-entry memo of the last database search. Within a single
         # resolve the SAME (artist, album) query is issued up to 3 times —
         # strategy 1 (limit 25), the database tier (limit 3), and the staleness
@@ -336,7 +361,8 @@ class DiscogsReader:
             )
             return None
 
-        index = self._get_collection_index()
+        index_view = self._get_collection_index()
+        index = index_view.index
 
         artist_key = _normalize_artist(artist)
         album_key = _normalize_term(album)
@@ -493,6 +519,10 @@ class DiscogsReader:
             ]
 
         if not matches:
+            if not index_view.misses_are_authoritative:
+                raise CollectionOwnershipUnknown(
+                    "the available collection index is a stale snapshot"
+                )
             return None
         if len(matches) > 1:
             # Refuse to guess (#179, SEC-1 principle): two owned entries
@@ -658,7 +688,116 @@ class DiscogsReader:
             self._db_search_key = key            # published LAST
         return self._db_search_page[:limit]
 
-    def _get_collection_index(self) -> dict:
+    def _collection_build_is_backed_off(self, now: float) -> bool:
+        return (
+            self._last_collection_build_failure_at is not None
+            and now - self._last_collection_build_failure_at
+            < _COLLECTION_BUILD_FAILURE_BACKOFF_SECONDS
+        )
+
+    @staticmethod
+    def _positive_int(value) -> bool:
+        return type(value) is int and value > 0
+
+    def _build_collection_index(self) -> dict:
+        """Fetch and validate every advertised collection page before swap-in.
+
+        The candidate remains local until the entire response is internally
+        consistent.  This makes an old complete snapshot safer than an apparent
+        partial replacement: its positives are still useful, but its misses are
+        explicitly marked non-authoritative by :meth:`_get_collection_index`.
+        """
+        candidate: dict = {}
+        expected_pages = expected_per_page = expected_items = None
+        raw_rows = 0
+        page = 1
+        try:
+            while True:
+                if page > _MAX_COLLECTION_PAGES:
+                    raise CollectionIndexIncomplete("collection pagination exceeded the page cap")
+                resp = self._http.request(
+                    "GET",
+                    f"{_API_BASE}/users/{self._username_path}/collection/folders/0/releases",
+                    params={"page": page, "per_page": 100, "sort": "added", "sort_order": "desc"},
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                if not isinstance(data, dict):
+                    raise CollectionIndexIncomplete("collection response was not an object")
+                releases = data.get("releases")
+                pagination = data.get("pagination")
+                if not isinstance(releases, list) or not isinstance(pagination, dict):
+                    raise CollectionIndexIncomplete("collection pagination was incomplete")
+                reported_page = pagination.get("page")
+                pages = pagination.get("pages")
+                per_page = pagination.get("per_page")
+                items = pagination.get("items")
+                if not all(self._positive_int(v) for v in (reported_page, pages, per_page)):
+                    raise CollectionIndexIncomplete("collection pagination was incomplete")
+                if type(items) is not int or items < 0:
+                    raise CollectionIndexIncomplete("collection pagination was incomplete")
+                if reported_page != page or pages < page or pages > _MAX_COLLECTION_PAGES:
+                    raise CollectionIndexIncomplete("collection pagination was incomplete")
+                if expected_pages is None:
+                    expected_pages, expected_per_page, expected_items = pages, per_page, items
+                elif (pages, per_page, items) != (expected_pages, expected_per_page, expected_items):
+                    raise CollectionIndexIncomplete("collection pagination changed during the walk")
+                if page < pages and len(releases) != per_page:
+                    raise CollectionIndexIncomplete("a non-final collection page was not full")
+                if page == pages and len(releases) > per_page:
+                    raise CollectionIndexIncomplete("the final collection page exceeded its size")
+
+                raw_rows += len(releases)
+                if raw_rows > items:
+                    raise CollectionIndexIncomplete("collection row count exceeded pagination total")
+                for item in releases:
+                    if not isinstance(item, dict):
+                        raise CollectionIndexIncomplete("collection release was malformed")
+                    basic = item.get("basic_information")
+                    release_id = basic.get("id") if isinstance(basic, dict) else None
+                    instance_id = item.get("instance_id")
+                    if not self._positive_int(release_id) or not self._positive_int(instance_id):
+                        raise CollectionIndexIncomplete("collection release identifiers were malformed")
+                    artists = basic.get("artists")
+                    title = basic.get("title")
+                    if not isinstance(title, str) or not isinstance(artists, list):
+                        raise CollectionIndexIncomplete("collection release was malformed")
+                    if any(not isinstance(a, dict) or not isinstance(a.get("name"), str) for a in artists):
+                        raise CollectionIndexIncomplete("collection release was malformed")
+                    if release_id not in candidate:
+                        artist_credit = _reconstruct_artist_credit(artists)
+                        candidate[release_id] = {
+                            "instance_id": instance_id,
+                            "title": title,
+                            "artists": [a["name"] for a in artists],
+                            "artist_credit": artist_credit,
+                            "_title_key": _normalize_term(title),
+                            "_artist_keys": [
+                                _normalize_artist(_ARTIST_DISAMBIG_RE.sub("", a["name"]))
+                                for a in artists
+                            ],
+                            "_credit_key": _normalize_artist(_ARTIST_DISAMBIG_RE.sub(
+                                "", artist_credit)),
+                            "master_id": basic.get("master_id") or None,
+                        }
+                if page == pages:
+                    if raw_rows != items:
+                        raise CollectionIndexIncomplete("collection row count did not match pagination total")
+                    break
+                page += 1
+        except Exception as exc:
+            self._last_collection_build_failure_at = time.monotonic()
+            if isinstance(exc, CollectionIndexIncomplete):
+                raise
+            raise CollectionIndexIncomplete("collection pagination was incomplete") from exc
+
+        self._collection_index = candidate
+        self._collection_index_built_at = time.monotonic()
+        self._last_collection_build_failure_at = None
+        log.debug("Built complete collection index: %d release(s).", len(candidate))
+        return candidate
+
+    def _get_collection_index(self) -> _CollectionIndexView:
         """Build (once per session) and return an in-memory index of the user's
         collection: ``{release_id: {"instance_id", "title", "artists", "master_id"}}``.
 
@@ -690,96 +829,32 @@ class DiscogsReader:
         that pins a downgrade for the session (B-4/B-13).  A successfully built
         (possibly empty) index is cached.
         """
+        now = time.monotonic()
+        if self._collection_build_is_backed_off(now):
+            if self._collection_index is not None:
+                return _CollectionIndexView(
+                    self._collection_index, misses_are_authoritative=False
+                )
+            raise CollectionOwnershipUnknown("collection index rebuild is backed off")
+
         # #191: serve the cached index only while it is within the TTL. A
         # built_at of None means the index was injected (tests) rather than built
         # here — trust it and never expire it. A real build stamps built_at, so
         # the TTL applies and a stale index rebuilds from the API below.
         if self._collection_index is not None and (
             self._collection_index_built_at is None
-            or time.monotonic() - self._collection_index_built_at
+            or now - self._collection_index_built_at
             < _COLLECTION_INDEX_TTL_SECONDS
         ):
-            return self._collection_index
-
-        index: dict = {}
-        page = 1
-        while True:
-            resp = self._http.request(
-                "GET",
-                f"{_API_BASE}/users/{self._username_path}/collection/folders/0/releases",
-                params={"page": page, "per_page": 100, "sort": "added", "sort_order": "desc"},
+            return _CollectionIndexView(
+                self._collection_index, misses_are_authoritative=True
             )
-            resp.raise_for_status()
-            data = resp.json()
 
-            releases = data.get("releases", [])
-            if not releases:
-                break
+        return _CollectionIndexView(
+            self._build_collection_index(), misses_are_authoritative=True
+        )
 
-            for item in releases:
-                basic = item.get("basic_information", {})
-                release_id = basic.get("id")
-                if release_id is None:
-                    continue
-                # Keep the first instance seen per release (mirrors the old
-                # "use instances[0]" behaviour for users who own duplicates).
-                if release_id not in index:
-                    index[release_id] = {
-                        "instance_id": item.get("instance_id"),
-                        "title": basic.get("title", ""),
-                        "artists": [a.get("name", "") for a in basic.get("artists", [])],
-                        # R5-07: the reconstructed multi-artist credit string, so a
-                        # Shazam joint credit ("A & B") can match a collaboration
-                        # album whose index names are ["A", "B"].
-                        "artist_credit": _reconstruct_artist_credit(basic.get("artists", [])),
-                        # R5-27: precompute the folded match keys ONCE at build,
-                        # so search_collection's #226 distinct-albums scan and
-                        # tier-1 comparisons don't re-fold every index entry on
-                        # every call (~8ms/miss at 3k records on x86, ~4-5x on the
-                        # Pi). Behaviour-identical to folding on the fly.
-                        "_title_key": _normalize_term(basic.get("title", "")),
-                        "_artist_keys": [
-                            _normalize_artist(_ARTIST_DISAMBIG_RE.sub("", a.get("name", "")))
-                            for a in basic.get("artists", [])
-                        ],
-                        "_credit_key": _normalize_artist(_ARTIST_DISAMBIG_RE.sub(
-                            "", _reconstruct_artist_credit(basic.get("artists", [])))),
-                        # #226: the master groups a work's pressings.  Two owned
-                        # entries at the same (artist, title) with DIFFERENT
-                        # masters are distinct albums (Peter Gabriel I/III), not
-                        # pressings — strategy 1 defers to refuse-to-guess.  0 /
-                        # missing means "no master": treated as absent (pressings
-                        # of a master-less release stay a valid single target).
-                        "master_id": basic.get("master_id") or None,
-                    }
-
-            pagination = data.get("pagination", {})
-            if page >= pagination.get("pages", 1):
-                break
-            if page >= _MAX_COLLECTION_PAGES:
-                # STAB-4: absolute safety ceiling.  Reaching it means the
-                # pagination response is malformed (no real personal collection
-                # has 100,000+ records), so stop with the partial index rather
-                # than paging without bound and hammering the rate limit.  The
-                # partial index is still cached below, so this build is not
-                # re-attempted per track.  A partial index can only cause
-                # false-negatives (an album beyond the cap resolves via the
-                # database tier with no instance_id) — never a wrong write target.
-                log.warning(
-                    "Collection paging hit the absolute cap of %d pages "
-                    "(%d releases indexed); stopping with a partial index. "
-                    "Suspect a malformed Discogs pagination response.",
-                    _MAX_COLLECTION_PAGES, len(index),
-                )
-                break
-            page += 1
-
-        self._collection_index = index
-        self._collection_index_built_at = time.monotonic()   # #191: stamp for the TTL
-        log.debug(f"Built collection index: {len(index)} release(s).")
-        return index
-
-    def refresh_index_and_research(self, artist: str, album: str) -> Optional[dict]:
+    def refresh_index_and_research(self, artist: str, album: str) -> CollectionRefreshResult:
         """#191 (C): force a stale-index rebuild and re-check ownership, once per
         cooldown.
 
@@ -800,31 +875,20 @@ class DiscogsReader:
         """
         now = time.monotonic()
         if now - self._last_index_refresh_at < _INDEX_REFRESH_COOLDOWN_SECONDS:
-            return None
+            return CollectionRefreshResult(
+                CollectionRefreshState.COOLDOWN_SKIPPED,
+                cooldown_follows_successful_rebuild=self._last_speculative_refresh_succeeded,
+            )
+        if self._collection_build_is_backed_off(now):
+            raise CollectionOwnershipUnknown("collection index rebuild is backed off")
         self._last_index_refresh_at = now
-        # R5-18: force a rebuild WITHOUT discarding the current index up front.
-        # Invalidating before the re-page meant a transient failure mid-rebuild
-        # (a dropped GET) left the reader with NO index at all, forcing a full
-        # re-page on every subsequent resolve until the next success — throwing
-        # away a snapshot that was fine seconds ago. Save the current snapshot,
-        # invalidate to force _get_collection_index to rebuild, and restore it if
-        # the rebuild raises (swap-on-success). The error still propagates so the
-        # resolver leaves the album uncached/retryable (B-4).
-        saved_index = self._collection_index
-        saved_built_at = self._collection_index_built_at
-        self._collection_index = None
-        self._collection_index_built_at = None
-        try:
-            return self.search_collection(artist, album)
-        except Exception:
-            # _get_collection_index assigns the new index only after a fully
-            # successful re-page, so on a raise self._collection_index is still
-            # None here — restore the previously-valid snapshot rather than
-            # leaving the reader index-less.
-            if self._collection_index is None:
-                self._collection_index = saved_index
-                self._collection_index_built_at = saved_built_at
-            raise
+        self._last_speculative_refresh_succeeded = False
+        self._build_collection_index()
+        self._last_speculative_refresh_succeeded = True
+        match = self.search_collection(artist, album)
+        if match is not None:
+            return CollectionRefreshResult(CollectionRefreshState.OWNED, result=match)
+        return CollectionRefreshResult(CollectionRefreshState.CLEAN_NO_MATCH)
 
     def _build_result(self, release, instance_id: Optional[int]) -> dict:
         """Build a standardised result dict from a Discogs Release object.

--- a/src/metadata/discogs/reader.py
+++ b/src/metadata/discogs/reader.py
@@ -862,16 +862,30 @@ class DiscogsReader:
         DATABASE knows the album — the signature of a record the owner may have
         just added (the index is a snapshot from up to the TTL ago). It discards
         the cached index and re-runs :meth:`search_collection` against a freshly
-        built one, returning the owned release if it is now present, else None.
+        built one. It returns an immutable :class:`CollectionRefreshResult`:
+
+        * ``OWNED`` carries the validated owned-release mapping in ``result``.
+        * ``CLEAN_NO_MATCH`` carries no ``result`` and means the complete rebuild
+          succeeded but found no unambiguous owned match.
+        * ``COOLDOWN_SKIPPED`` carries no ``result`` and means no rebuild was
+          attempted because the global cooldown is active.
+
+        For ``COOLDOWN_SKIPPED``, ``cooldown_follows_successful_rebuild`` records
+        the provenance of the active cooldown. It is true only when the cooldown
+        follows a successfully completed full collection rebuild; it is false
+        after a failed or otherwise incomplete attempt. Other states always carry
+        false provenance. Transport, parsing, and index-build failures remain
+        exceptions rather than becoming refresh results.
 
         The cooldown is load-bearing, not cosmetic: the same "missed collection,
         hit database" signal fires on EVERY record the user genuinely does not
         own (the common database-tier case), so without it every unowned-record
         play would trigger a full collection re-page. Within the cooldown this
-        returns None immediately and re-pages nothing. The cooldown is stamped on
-        the ATTEMPT (before the re-page), so a transiently-failing refresh does
-        not hammer Discogs — search_collection's build error still propagates so
-        the resolver leaves the album uncached/retryable (B-4).
+        returns ``COOLDOWN_SKIPPED`` immediately and re-pages nothing. The
+        cooldown is stamped on the ATTEMPT (before the re-page), so a
+        transiently-failing refresh does not hammer Discogs — the build error
+        still propagates so the resolver leaves the album uncached/retryable
+        (B-4).
         """
         now = time.monotonic()
         if now - self._last_index_refresh_at < _INDEX_REFRESH_COOLDOWN_SECONDS:

--- a/src/metadata/discogs/reader.py
+++ b/src/metadata/discogs/reader.py
@@ -677,12 +677,10 @@ class DiscogsReader:
             # the "memo is ready" flag the check above reads. A reader that observes
             # the new key is then guaranteed to also see the matching new page —
             # never this query's page returned for a different query's key. The
-            # reader path is single-caller today (the resolver serializes reader
-            # calls, so this races with nothing), making key-last defence-in-depth
-            # on the 2-worker Discogs pool rather than a lock: a reader that catches
-            # the stale key mid-fetch merely re-fetches (fail-safe redundant GET),
-            # it never mismatches. NOT a general thread-safety guarantee — the
-            # check-then-return is only safe because callers are serialized.
+            # The resolver-owned reader gate serializes every caller of this
+            # mutable memo. Publishing the key last remains a narrow defensive
+            # guarantee if a future reader caller is added incorrectly: it may
+            # issue a redundant fetch, but cannot pair a new key with old data.
             self._db_search_page = list(results.page(1))
             self._db_search_stamp = now
             self._db_search_key = key            # published LAST
@@ -891,6 +889,19 @@ class DiscogsReader:
         if match is not None:
             return CollectionRefreshResult(CollectionRefreshState.OWNED, result=match)
         return CollectionRefreshResult(CollectionRefreshState.CLEAN_NO_MATCH)
+
+    def rebuild_collection_and_research(self, artist: str, album: str) -> Optional[dict]:
+        """Strictly rebuild and re-match without changing speculative cooldown.
+
+        Recovery needs fresh ownership evidence even during the ordinary
+        speculative-refresh cooldown.  This deliberately consumes the separate
+        failed-build backoff and keeps the build's swap-on-success semantics,
+        but never reads or writes speculative cooldown/provenance state.
+        """
+        if self._collection_build_is_backed_off(time.monotonic()):
+            raise CollectionOwnershipUnknown("collection index rebuild is backed off")
+        self._build_collection_index()
+        return self.search_collection(artist, album)
 
     def _build_result(self, release, instance_id: Optional[int]) -> dict:
         """Build a standardised result dict from a Discogs Release object.

--- a/src/metadata/discogs/reader.py
+++ b/src/metadata/discogs/reader.py
@@ -738,6 +738,8 @@ class DiscogsReader:
                     raise CollectionIndexIncomplete("collection pagination was incomplete")
                 if reported_page != page or pages < page or pages > _MAX_COLLECTION_PAGES:
                     raise CollectionIndexIncomplete("collection pagination was incomplete")
+                if pages != max(1, (items + per_page - 1) // per_page):
+                    raise CollectionIndexIncomplete("collection pagination shape was inconsistent")
                 if expected_pages is None:
                     expected_pages, expected_per_page, expected_items = pages, per_page, items
                 elif (pages, per_page, items) != (expected_pages, expected_per_page, expected_items):

--- a/src/metadata/discogs/writer.py
+++ b/src/metadata/discogs/writer.py
@@ -11,11 +11,14 @@ It has no knowledge of the read side (search/tracklist/year) — that lives in
 """
 
 import logging
+from dataclasses import dataclass
 from datetime import date
-from typing import Optional, Union, TYPE_CHECKING
+from enum import Enum, auto
+from typing import Any, Optional, Union, TYPE_CHECKING
 from urllib.parse import quote
 
 from src.metadata.discogs.transport import DiscogsHttp, DiscogsRateLimited, _API_BASE, _as_id
+from src.metadata.discogs.outcomes import PlayCountReadResult, PlayCountReadState
 from src.util.clock import clock_is_trustworthy
 
 if TYPE_CHECKING:
@@ -43,6 +46,21 @@ class _ReadFailed:
 
 #: Singleton "current value is unknown" marker (see :class:`_ReadFailed`).
 _READ_FAILED = _ReadFailed()
+
+
+class _FieldValueReadState(Enum):
+    FOUND = auto()
+    DEFINITIVE_INSTANCE_MISSING = auto()
+    ABORT = auto()
+
+
+@dataclass(frozen=True)
+class _FieldValueRead:
+    """Private classification before field-value parsing."""
+
+    state: _FieldValueReadState
+    value: Any = None
+    observed_instance_ids: tuple[int, ...] = ()
 
 
 class DiscogsCollectionWriter:
@@ -80,11 +98,12 @@ class DiscogsCollectionWriter:
     # Public interface
     # -------------------------------------------------------------------------
 
-    def read_play_count(self, release_id: int, instance_id: int):
+    def read_play_count(self, release_id: int, instance_id: int) -> PlayCountReadResult:
         """Read the current Play Count and resolve the field id, in ONE step.
 
-        Returns ``(field_id, current_count)`` on success, or ``None`` when the
-        credit must be aborted WITHOUT writing:
+        Returns a typed state: ``READY`` with the resolved field/count,
+        ``DEFINITIVE_INSTANCE_MISSING`` only when a complete validated snapshot
+        proves the old instance is absent, or ``ABORT`` when writing is unsafe.
 
           * the ``Play Count`` custom field is not configured on the account;
           * the current value is UNKNOWN (``_READ_FAILED`` — the GET failed or the
@@ -111,25 +130,34 @@ class DiscogsCollectionWriter:
                 f"Custom field '{self.play_count_field_name}' not found in Discogs. "
                 f"Available fields: {list(fields.keys())}"
             )
-            return None
+            return PlayCountReadResult(PlayCountReadState.ABORT)
 
-        raw_value = self._get_field_value(release_id, instance_id, field_id)
-        if raw_value is _READ_FAILED:
+        field_read = self._read_field_value(release_id, instance_id, field_id)
+        if field_read.state is _FieldValueReadState.DEFINITIVE_INSTANCE_MISSING:
+            return PlayCountReadResult(
+                PlayCountReadState.DEFINITIVE_INSTANCE_MISSING,
+                observed_instance_ids=field_read.observed_instance_ids,
+            )
+        if field_read.state is _FieldValueReadState.ABORT:
             log.error(
                 f"Aborting Play Count increment for release {release_id} / instance "
                 f"{instance_id}: could not read the current value, so refusing to "
                 f"overwrite it (leaving the existing count intact)."
             )
-            return None
+            return PlayCountReadResult(PlayCountReadState.ABORT)
 
         # Coerce via str() before .strip(): a confirmed value is normally a
         # string, but Discogs can return it as a JSON number, and calling
         # .strip() on an int would raise (B-16). None / "" is a blank field.
+        raw_value = field_read.value
         text = str(raw_value).strip() if raw_value is not None else ""
         if not text:
-            return field_id, 0  # confirmed-blank field == zero plays
+            return PlayCountReadResult(PlayCountReadState.READY, field_id, 0)
         try:
-            return field_id, int(text)
+            count = int(text)
+            if count < 0:
+                raise ValueError("negative play count")
+            return PlayCountReadResult(PlayCountReadState.READY, field_id, count)
         except (ValueError, TypeError):
             # A present but non-integer value is real data we cannot safely
             # increment; overwriting it with an absolute 1 would destroy it
@@ -139,7 +167,7 @@ class DiscogsCollectionWriter:
                 f"{instance_id}: existing value {raw_value!r} is not an integer, so "
                 f"refusing to overwrite it with 1."
             )
-            return None
+            return PlayCountReadResult(PlayCountReadState.ABORT)
 
     def set_play_count(
         self, release_id: int, instance_id: int, field_id: int,
@@ -202,12 +230,12 @@ class DiscogsCollectionWriter:
         POST) for operator tooling and the unit tests.
         """
         try:
-            state = self.read_play_count(release_id, instance_id)
-            if state is None:
+            result = self.read_play_count(release_id, instance_id)
+            if result.state is not PlayCountReadState.READY:
                 return False
-            field_id, current_count = state
             return self.set_play_count(
-                release_id, instance_id, field_id, current_count, current_count + 1
+                release_id, instance_id, result.field_id, result.current_count,
+                result.current_count + 1,
             )
         except DiscogsRateLimited:
             # #229: must PROPAGATE, not be swallowed to False by the broad handler
@@ -333,23 +361,14 @@ class DiscogsCollectionWriter:
         log.debug(f"Collection fields loaded: {self._collection_fields}")
         return self._collection_fields
 
-    def _get_field_value(
+    def _read_field_value(
         self, release_id: int, instance_id: int, field_id: int
-    ) -> Union[str, None, _ReadFailed]:
-        """Read the current value of a custom field for a specific collection instance.
+    ) -> _FieldValueRead:
+        """Classify a field read without confusing absence with ambiguity.
 
-        GETs /users/{username}/collection/releases/{release_id}, finds the
-        matching instance_id, and returns the note value for field_id.
-
-        Three-state result, because the caller performs an absolute write and a
-        failed read must NOT be treated as 0 (META-1):
-
-          * ``str`` (possibly a JSON number the caller coerces) — the value is set.
-          * ``None`` — the instance was found but this field is unset: a
-            CONFIRMED-blank field, safe to treat as 0.
-          * :data:`_READ_FAILED` — the value is UNKNOWN and the caller must
-            abort: the GET failed, an exception was raised, or the instance was
-            not present in the 200 body (absent / paged / edited — ambiguous).
+        A found target can be read immediately: it does not need a full snapshot
+        proof.  When the target is absent, however, replacement evidence is
+        exposed only after validating every item in one complete response page.
         """
         try:
             # #229: this GET is the READ half of the credit's read-modify-write,
@@ -372,24 +391,40 @@ class DiscogsCollectionWriter:
                     f"_get_field_value: GET returned {resp.status_code} "
                     f"for release {release_id}; current value UNKNOWN (not writing)."
                 )
-                return _READ_FAILED
-            instances = resp.json().get("releases", [])
+                return _FieldValueRead(_FieldValueReadState.ABORT)
+            data = resp.json()
+            if not isinstance(data, dict):
+                return _FieldValueRead(_FieldValueReadState.ABORT)
+            instances = data.get("releases")
+            if not isinstance(instances, list):
+                return _FieldValueRead(_FieldValueReadState.ABORT)
             for inst in instances:
-                if inst.get("instance_id") == instance_id:
-                    for note in inst.get("notes", []):
+                if (isinstance(inst, dict)
+                        and type(inst.get("instance_id")) is int
+                        and inst["instance_id"] == instance_id):
+                    notes = inst.get("notes", [])
+                    if not isinstance(notes, list):
+                        return _FieldValueRead(_FieldValueReadState.ABORT)
+                    for note in notes:
+                        if not isinstance(note, dict):
+                            return _FieldValueRead(_FieldValueReadState.ABORT)
                         if note.get("field_id") == field_id:
-                            return note.get("value")
+                            return _FieldValueRead(_FieldValueReadState.FOUND, note.get("value"))
                     # Instance found but this field is unset — a CONFIRMED blank,
                     # safe to treat as 0.
-                    return None
-            # The instance is not in the response at all: ambiguous (genuinely
-            # absent, a paged response, or an edited collection), so the current
-            # value is UNKNOWN — not blank.
+                    return _FieldValueRead(_FieldValueReadState.FOUND)
+
+            observed_ids = self._validated_missing_instance_ids(data, release_id)
+            if observed_ids is not None:
+                return _FieldValueRead(
+                    _FieldValueReadState.DEFINITIVE_INSTANCE_MISSING,
+                    observed_instance_ids=observed_ids,
+                )
             log.debug(
                 f"_get_field_value: instance {instance_id} not found in "
                 f"release {release_id} response; current value UNKNOWN (not writing)."
             )
-            return _READ_FAILED
+            return _FieldValueRead(_FieldValueReadState.ABORT)
         except DiscogsRateLimited:
             # #229: propagate the honored-wait signal (the broad handler below
             # would otherwise swallow it to _READ_FAILED, aborting the credit
@@ -397,4 +432,50 @@ class DiscogsCollectionWriter:
             raise
         except Exception as e:
             log.debug(f"_get_field_value failed for release {release_id}: {e}")
-            return _READ_FAILED
+            return _FieldValueRead(_FieldValueReadState.ABORT)
+
+    @staticmethod
+    def _validated_missing_instance_ids(data: dict, release_id: int) -> Optional[tuple[int, ...]]:
+        """Return snapshot instance IDs only when absence is conclusively proven."""
+        pagination = data.get("pagination")
+        instances = data.get("releases")
+        if not isinstance(pagination, dict) or not isinstance(instances, list):
+            return None
+        try:
+            page = pagination["page"]
+            pages = pagination["pages"]
+            items = pagination["items"]
+            per_page = pagination["per_page"]
+        except KeyError:
+            return None
+        if (any(type(value) is not int for value in (page, pages, items, per_page))
+                or page != 1 or pages != 1 or items != len(instances)
+                or items < 0 or per_page < 1 or per_page < items):
+            return None
+
+        observed_ids = []
+        for instance in instances:
+            if not isinstance(instance, dict):
+                return None
+            instance_id = instance.get("instance_id")
+            folder_id = instance.get("folder_id")
+            basic_information = instance.get("basic_information")
+            if (type(instance_id) is not int or instance_id <= 0
+                    or type(folder_id) is not int or folder_id < 0
+                    or not isinstance(basic_information, dict)
+                    or type(basic_information.get("id")) is not int
+                    or basic_information["id"] != release_id):
+                return None
+            observed_ids.append(instance_id)
+        if len(set(observed_ids)) != len(observed_ids):
+            return None
+        return tuple(observed_ids)
+
+    def _get_field_value(
+        self, release_id: int, instance_id: int, field_id: int
+    ) -> Union[str, None, _ReadFailed]:
+        """Compatibility value-only facade for legacy callers and tests."""
+        result = self._read_field_value(release_id, instance_id, field_id)
+        if result.state is _FieldValueReadState.FOUND:
+            return result.value
+        return _READ_FAILED

--- a/src/metadata/discogs/writer.py
+++ b/src/metadata/discogs/writer.py
@@ -164,7 +164,7 @@ class DiscogsCollectionWriter:
             # (META-2). Abort rather than clobber.
             log.error(
                 f"Aborting Play Count increment for release {release_id} / instance "
-                f"{instance_id}: existing value {raw_value!r} is not an integer, so "
+                f"{instance_id}: existing field value is not an integer or is negative; "
                 f"refusing to overwrite it with 1."
             )
             return PlayCountReadResult(PlayCountReadState.ABORT)

--- a/src/metadata/models.py
+++ b/src/metadata/models.py
@@ -467,6 +467,9 @@ class PlaySession:
     potential_last_track: bool = False
     album_release_id: Optional[int] = None
     album_instance_id: Optional[int] = None
+    # The exact normalized resolver key of the track that latched the write
+    # identity.  It must not follow later tracks' split-detection evidence.
+    album_resolve_key: Optional[tuple[str, str]] = None
     # Most recent release ID seen from ANY source that carries one — including
     # DISCOGS_DATABASE results, which never latch the album_* pair above.
     # Used by ListenTracker's album-change auto-split (v1.3.5): comparing
@@ -766,3 +769,4 @@ class PlaySession:
         ):
             self.album_release_id = track.discogs_release_id
             self.album_instance_id = track.discogs_instance_id
+            self.album_resolve_key = track.resolve_key

--- a/src/metadata/resolver.py
+++ b/src/metadata/resolver.py
@@ -32,9 +32,11 @@ Note: an empty Shazam album string ("") keys all of an artist's unknown-album
 tracks together.  Those tracks would resolve identically anyway, so the
 collision is harmless and saves further duplicate lookups.
 
-Concurrency: resolve() is only ever awaited sequentially from
-TrackCommitService.commit on the single event loop, so the cache needs
-no locking.
+Concurrency: ordinary resolution and finalizer recovery can both enter the
+resolver.  The resolver-owned reader gate serializes each complete mutable
+reader sequence, including a submitted executor worker after its awaiting
+coroutine is cancelled.  Album-cache hits remain a lock-free fast path, and
+cover-art I/O remains outside the gate.
 """
 
 import asyncio
@@ -284,6 +286,34 @@ class MetadataResolver:
             if self._cache_get(key) is None:
                 self._cache_store(key, MetadataSource.FALLBACK, cover_url)
 
+    async def _run_reader_locked(self, fn, *args):
+        """Await one reader sequence without releasing the gate on cancellation.
+
+        ``run_in_executor`` cancellation only stops the await, not an already
+        running worker.  Shield the reader awaitable, then, when this caller is
+        cancelled, keep ownership of ``_reader_gate`` until that worker is done
+        before re-propagating cancellation.  The cancelled caller never consumes
+        the late result, so it cannot publish a cache entry after cancellation.
+        """
+        reader_task = asyncio.ensure_future(self.reader.run(fn, *args))
+        try:
+            return await asyncio.shield(reader_task)
+        except asyncio.CancelledError:
+            while not reader_task.done():
+                try:
+                    await asyncio.shield(reader_task)
+                except asyncio.CancelledError:
+                    # A repeated cancellation must still not release the gate
+                    # while the executor worker owns mutable reader state.
+                    continue
+            try:
+                reader_task.result()
+            except BaseException:
+                # The caller is already cancelled; retrieve a late reader error
+                # to avoid an unhandled-task warning, then preserve cancellation.
+                pass
+            raise
+
     async def _resolve_discogs_locked(
         self, raw: "RawRecognitionResult", key: tuple[str, str]
     ) -> tuple["Optional[TrackMetadata]", bool]:
@@ -299,7 +329,7 @@ class MetadataResolver:
         # the album uncached/retryable (B-4); anything else is an unexpected bug
         # and is logged loudly so it isn't mistaken for a routine miss.
         try:
-            result = await self.reader.run(
+            result = await self._run_reader_locked(
                 self.reader.search_collection, raw.artist, raw.album
             )
             if result:
@@ -313,7 +343,7 @@ class MetadataResolver:
 
         # Step 2: Discogs database
         try:
-            result = await self.reader.run(
+            result = await self._run_reader_locked(
                 self.reader.search_database, raw.artist, raw.album
             )
             if result:
@@ -328,7 +358,7 @@ class MetadataResolver:
                 # pinning the no-instance_id DATABASE downgrade.
                 if discogs_completed:
                     try:
-                        refresh_outcome = await self.reader.run(
+                        refresh_outcome = await self._run_reader_locked(
                             self.reader.refresh_index_and_research, raw.artist, raw.album
                         )
                     except Exception as e:
@@ -480,7 +510,7 @@ class MetadataResolver:
                 return None
             replacement_instance_id = observed_instance_ids[0]
             try:
-                fresh = await self.reader.run(
+                fresh = await self._run_reader_locked(
                     self.reader.rebuild_collection_and_research,
                     resolve_key[0], resolve_key[1],
                 )

--- a/src/metadata/resolver.py
+++ b/src/metadata/resolver.py
@@ -415,7 +415,34 @@ class MetadataResolver:
             or len(set(observed_instance_ids)) != len(observed_instance_ids)
             or any(type(value) is not int or value <= 0 for value in observed_instance_ids)
         ):
-            log.warning("Refusing invalid Discogs collection recovery evidence.")
+            safe_release_id = (
+                expected_release_id
+                if type(expected_release_id) is int and expected_release_id > 0
+                else None
+            )
+            safe_instance_id = (
+                expected_instance_id
+                if type(expected_instance_id) is int and expected_instance_id > 0
+                else None
+            )
+            if safe_release_id is not None and safe_instance_id is not None:
+                log.warning(
+                    "Discogs collection recovery stage=invalid-evidence "
+                    "expected_release_id=%d expected_instance_id=%d.",
+                    safe_release_id, safe_instance_id,
+                )
+            elif safe_release_id is not None:
+                log.warning(
+                    "Discogs collection recovery stage=invalid-evidence "
+                    "expected_release_id=%d.", safe_release_id,
+                )
+            elif safe_instance_id is not None:
+                log.warning(
+                    "Discogs collection recovery stage=invalid-evidence "
+                    "expected_instance_id=%d.", safe_instance_id,
+                )
+            else:
+                log.warning("Discogs collection recovery stage=invalid-evidence.")
             return None
 
         async with self._reader_gate:

--- a/src/metadata/resolver.py
+++ b/src/metadata/resolver.py
@@ -44,6 +44,7 @@ from typing import TYPE_CHECKING
 
 from src.metadata.models import TrackMetadata, MetadataSource
 from src.metadata.coverart import CoverArtFallback
+from src.metadata.discogs.outcomes import CollectionRefreshState
 from src.metadata.errors import is_transient, http_status
 from src.util.cache import BoundedCache
 
@@ -251,7 +252,7 @@ class MetadataResolver:
                 # pinning the no-instance_id DATABASE downgrade.
                 if discogs_completed:
                     try:
-                        upgraded = await self.reader.run(
+                        refresh_outcome = await self.reader.run(
                             self.reader.refresh_index_and_research, raw.artist, raw.album
                         )
                     except Exception as e:
@@ -266,8 +267,11 @@ class MetadataResolver:
                         # collection success re-arms it) rather than an orphan key
                         # that never re-arms.
                         self._log_discogs_error("collection", e)
-                        upgraded = None
-                    if upgraded:
+                        refresh_outcome = None
+                    if refresh_outcome is None:
+                        pass
+                    elif refresh_outcome.state is CollectionRefreshState.OWNED:
+                        upgraded = dict(refresh_outcome.result)
                         log.info(
                             f"Collection index was stale — {raw.artist} / {raw.album} "
                             f"is owned after a refresh; crediting via the collection."
@@ -277,6 +281,13 @@ class MetadataResolver:
                         return self._from_discogs(
                             raw, upgraded, MetadataSource.DISCOGS_COLLECTION
                         )
+                    elif refresh_outcome.state is CollectionRefreshState.CLEAN_NO_MATCH:
+                        pass
+                    elif refresh_outcome.state is CollectionRefreshState.COOLDOWN_SKIPPED:
+                        if not refresh_outcome.cooldown_follows_successful_rebuild:
+                            discogs_completed = False
+                    else:
+                        raise ValueError(f"unknown collection refresh state: {refresh_outcome.state}")
                 # Only cache the database downgrade if BOTH the collection lookup
                 # and the refresh above completed cleanly (a transient error must
                 # stay retryable, B-4).

--- a/src/metadata/resolver.py
+++ b/src/metadata/resolver.py
@@ -262,7 +262,7 @@ class MetadataResolver:
             else:
                 log.warning(f"Unexpected error in cover art lookup: {e}")
         if discogs_completed and cover_completed:
-            self._cache_store(key, MetadataSource.FALLBACK, cover_url)
+            await self._cache_fallback_if_absent(key, cover_url)
         return TrackMetadata(
             title=raw.title,
             artist=raw.artist,
@@ -271,6 +271,18 @@ class MetadataResolver:
             source=MetadataSource.FALLBACK,
             resolve_key=key,
         )
+
+    async def _cache_fallback_if_absent(self, key: tuple[str, str], cover_url) -> None:
+        """Store a clean fallback only if no gated resolve/recovery superseded it.
+
+        Cover-art I/O intentionally happens outside the reader gate.  A recovery
+        can therefore publish a fresh immortal collection identity while that
+        I/O is pending; re-entering the gate and compare-storing prevents the
+        old fallback completion from clobbering it.
+        """
+        async with self._reader_gate:
+            if self._cache_get(key) is None:
+                self._cache_store(key, MetadataSource.FALLBACK, cover_url)
 
     async def _resolve_discogs_locked(
         self, raw: "RawRecognitionResult", key: tuple[str, str]
@@ -420,11 +432,24 @@ class MetadataResolver:
                     and pair == (expected_release_id, observed_instance_ids[0])
                 ):
                     return CollectionIdentity(*pair)
-                log.info("Discogs collection recovery found a newer cache entry; leaving it intact.")
+                cached_release_id, cached_instance_id = pair if pair is not None else (None, None)
+                log.info(
+                    "Discogs collection recovery stage=newer-cache-refusal "
+                    "expected_release_id=%d expected_instance_id=%d "
+                    "observed_instance_ids=%s cached_release_id=%s "
+                    "cached_instance_id=%s; leaving cache intact.",
+                    expected_release_id, expected_instance_id, observed_instance_ids,
+                    cached_release_id, cached_instance_id,
+                )
                 return None
 
             if len(observed_instance_ids) != 1 or observed_instance_ids[0] == expected_instance_id:
-                log.info("Discogs collection recovery refused non-singleton replacement evidence.")
+                log.info(
+                    "Discogs collection recovery stage=observed-evidence-refusal "
+                    "expected_release_id=%d expected_instance_id=%d "
+                    "observed_instance_ids=%s.",
+                    expected_release_id, expected_instance_id, observed_instance_ids,
+                )
                 return None
             replacement_instance_id = observed_instance_ids[0]
             try:
@@ -432,15 +457,32 @@ class MetadataResolver:
                     self.reader.rebuild_collection_and_research,
                     resolve_key[0], resolve_key[1],
                 )
-            except Exception as exc:
-                log.warning("Discogs collection recovery rebuild failed: %s", exc)
+            except Exception:
+                log.warning(
+                    "Discogs collection recovery stage=rebuild-failed "
+                    "expected_release_id=%d expected_instance_id=%d "
+                    "observed_instance_id=%d.",
+                    expected_release_id, expected_instance_id, replacement_instance_id,
+                )
                 return None
             if not isinstance(fresh, dict):
-                log.info("Discogs collection recovery found no unambiguous fresh match.")
+                log.info(
+                    "Discogs collection recovery stage=rebuild-no-match "
+                    "expected_release_id=%d expected_instance_id=%d "
+                    "observed_instance_id=%d.",
+                    expected_release_id, expected_instance_id, replacement_instance_id,
+                )
                 return None
             release_id = fresh.get("release_id")
             if type(release_id) is not int or release_id != expected_release_id:
-                log.info("Discogs collection recovery resolved a different release.")
+                rebuilt_release_id = release_id if type(release_id) is int else None
+                log.info(
+                    "Discogs collection recovery stage=rebuild-release-refusal "
+                    "expected_release_id=%d expected_instance_id=%d "
+                    "observed_instance_id=%d rebuilt_release_id=%s.",
+                    expected_release_id, expected_instance_id, replacement_instance_id,
+                    rebuilt_release_id,
+                )
                 return None
             recovered = dict(fresh)
             recovered["instance_id"] = replacement_instance_id

--- a/src/metadata/resolver.py
+++ b/src/metadata/resolver.py
@@ -306,6 +306,10 @@ class MetadataResolver:
                     # A repeated cancellation must still not release the gate
                     # while the executor worker owns mutable reader state.
                     continue
+                except BaseException:
+                    # A late reader failure is retrieved below. It must not
+                    # replace the caller's already-pending cancellation.
+                    break
             try:
                 reader_task.result()
             except BaseException:

--- a/src/metadata/resolver.py
+++ b/src/metadata/resolver.py
@@ -44,7 +44,7 @@ from typing import TYPE_CHECKING
 
 from src.metadata.models import TrackMetadata, MetadataSource
 from src.metadata.coverart import CoverArtFallback
-from src.metadata.discogs.outcomes import CollectionRefreshState
+from src.metadata.discogs.outcomes import CollectionIdentity, CollectionRefreshState
 from src.metadata.errors import is_transient, http_status
 from src.util.cache import BoundedCache
 
@@ -100,6 +100,10 @@ class MetadataResolver:
         # shared with the renderer's six caches rather than re-hand-rolled here.
         # The #191 downgrade TTL lives on top of it in _cache_get/_cache_store.
         self._album_cache = BoundedCache(_ALBUM_CACHE_MAX)
+        # Reader methods mutate the collection index and the one-entry database
+        # memo.  Both ordinary resolves and stale-instance recovery share this
+        # gate; the executor is a transport boundary, not a state lock.
+        self._reader_gate = asyncio.Lock()
         # #189: a dead Discogs credential (401/403) or wrong username (404) is a
         # PERMANENT error that recurs on EVERY track's resolve — so its
         # actionable warning is logged once and then suppressed until a Discogs
@@ -213,6 +217,66 @@ class MetadataResolver:
             log.debug(f"Album cache hit for: {raw.artist} / {raw.album}")
             return self._from_cache(raw, cached)
 
+        # A concurrent miss may have completed while this task waited.  Keep
+        # only mutable Discogs work inside the gate; cover-art fallback remains
+        # independent and cannot delay a collection cache hit.
+        async with self._reader_gate:
+            cached = self._cache_get(key)
+            if cached is not None:
+                log.debug(f"Album cache hit after reader gate: {raw.artist} / {raw.album}")
+                return self._from_cache(raw, cached)
+            discogs_result, discogs_completed = await self._resolve_discogs_locked(raw, key)
+        if discogs_result is not None:
+            return discogs_result
+
+        # Step 3: Fallback — Shazam data + MusicBrainz cover art
+        log.info(f"Using fallback metadata for: {raw.artist} / {raw.album}")
+        # #190: a TRANSIENT MusicBrainz outage must not be cached as this
+        # album's FALLBACK payload — otherwise the album is pinned coverless
+        # for the whole session even after the service recovers.  Mirror the
+        # discogs_completed pattern: on a transient cover-art failure, return
+        # the fallback for THIS track but skip the cache so the next track
+        # retries.  A clean "no art exists" (None) still caches — that
+        # negative result is load-bearing for MusicBrainz rate limits.
+        cover_completed = True
+        try:
+            cover_url = await asyncio.wait_for(
+                loop.run_in_executor(
+                    None, self.coverart.get_cover_art_url, raw.artist, raw.album
+                ),
+                timeout=_COVER_ART_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            cover_url = None
+            cover_completed = False
+            log.warning(
+                "Cover art lookup exceeded %ss for '%s / %s'; abandoning it and "
+                "continuing (the commit pipeline is not blocked).",
+                _COVER_ART_TIMEOUT_SECONDS, raw.artist, raw.album,
+            )
+        except Exception as e:
+            cover_url = None
+            if is_transient(e):
+                cover_completed = False
+                log.info(f"Cover art couldn't determine (transient): {e}")
+            else:
+                log.warning(f"Unexpected error in cover art lookup: {e}")
+        if discogs_completed and cover_completed:
+            self._cache_store(key, MetadataSource.FALLBACK, cover_url)
+        return TrackMetadata(
+            title=raw.title,
+            artist=raw.artist,
+            album=raw.album,
+            cover_art_url=cover_url,
+            source=MetadataSource.FALLBACK,
+            resolve_key=key,
+        )
+
+    async def _resolve_discogs_locked(
+        self, raw: "RawRecognitionResult", key: tuple[str, str]
+    ) -> tuple["Optional[TrackMetadata]", bool]:
+        """Run the mutable Discogs sequence while ``_reader_gate`` is held."""
+
         # Tracks whether both Discogs tiers ran to completion.  Only a clean
         # "looked everywhere, found nothing" outcome may cache the fallback —
         # a raised exception (network blip, 429) must stay retryable.
@@ -230,7 +294,7 @@ class MetadataResolver:
                 log.debug(f"Resolved from Discogs collection: {raw.artist} / {raw.album}")
                 self._logged_discogs_config.pop("collection", None)   # #189: re-arm THIS tier
                 self._cache_store(key, MetadataSource.DISCOGS_COLLECTION, result)
-                return self._from_discogs(raw, result, MetadataSource.DISCOGS_COLLECTION)
+                return self._from_discogs(raw, result, MetadataSource.DISCOGS_COLLECTION), True
         except Exception as e:
             discogs_completed = False
             self._log_discogs_error("collection", e)
@@ -280,7 +344,7 @@ class MetadataResolver:
                         self._cache_store(key, MetadataSource.DISCOGS_COLLECTION, upgraded)
                         return self._from_discogs(
                             raw, upgraded, MetadataSource.DISCOGS_COLLECTION
-                        )
+                        ), True
                     elif refresh_outcome.state is CollectionRefreshState.CLEAN_NO_MATCH:
                         pass
                     elif refresh_outcome.state is CollectionRefreshState.COOLDOWN_SKIPPED:
@@ -293,58 +357,95 @@ class MetadataResolver:
                 # stay retryable, B-4).
                 if discogs_completed:
                     self._cache_store(key, MetadataSource.DISCOGS_DATABASE, result)
-                return self._from_discogs(raw, result, MetadataSource.DISCOGS_DATABASE)
+                return self._from_discogs(raw, result, MetadataSource.DISCOGS_DATABASE), discogs_completed
         except Exception as e:
             discogs_completed = False
             self._log_discogs_error("database", e)
 
-        # Step 3: Fallback — Shazam data + MusicBrainz cover art
-        log.info(f"Using fallback metadata for: {raw.artist} / {raw.album}")
-        # #190: a TRANSIENT MusicBrainz outage must not be cached as this
-        # album's FALLBACK payload — otherwise the album is pinned coverless
-        # for the whole session even after the service recovers.  Mirror the
-        # discogs_completed pattern: on a transient cover-art failure, return
-        # the fallback for THIS track but skip the cache so the next track
-        # retries.  A clean "no art exists" (None) still caches — that
-        # negative result is load-bearing for MusicBrainz rate limits.
-        cover_completed = True
-        try:
-            cover_url = await asyncio.wait_for(
-                loop.run_in_executor(
-                    None, self.coverart.get_cover_art_url, raw.artist, raw.album
-                ),
-                timeout=_COVER_ART_TIMEOUT_SECONDS,
-            )
-        except asyncio.TimeoutError:
-            # R5-08: the cover-art call outran its ceiling. Treat it like any
-            # transient outage — return the fallback for THIS track but DON'T
-            # cache, so the next track retries — and let the abandoned executor
-            # thread wind down on the coverart socket-timeout floor. The pipeline
-            # is unblocked NOW rather than frozen until restart.
-            cover_url = None
-            cover_completed = False
-            log.warning(
-                "Cover art lookup exceeded %ss for '%s / %s'; abandoning it and "
-                "continuing (the commit pipeline is not blocked).",
-                _COVER_ART_TIMEOUT_SECONDS, raw.artist, raw.album,
-            )
-        except Exception as e:
-            cover_url = None
-            if is_transient(e):
-                cover_completed = False
-                log.info(f"Cover art couldn't determine (transient): {e}")
-            else:
-                log.warning(f"Unexpected error in cover art lookup: {e}")
-        if discogs_completed and cover_completed:
-            self._cache_store(key, MetadataSource.FALLBACK, cover_url)
-        return TrackMetadata(
-            title=raw.title,
-            artist=raw.artist,
-            album=raw.album,
-            cover_art_url=cover_url,
-            source=MetadataSource.FALLBACK,
-            resolve_key=key,
+        return None, discogs_completed
+
+    @staticmethod
+    def _valid_recovery_key(key) -> bool:
+        return (
+            isinstance(key, tuple)
+            and len(key) == 2
+            and all(isinstance(part, str) and bool(part.strip()) for part in key)
         )
+
+    @staticmethod
+    def _collection_pair(entry) -> "Optional[tuple[int, int]]":
+        if entry is None:
+            return None
+        source, payload, _stored_at = entry
+        if source is not MetadataSource.DISCOGS_COLLECTION or not isinstance(payload, dict):
+            return None
+        release_id = payload.get("release_id")
+        instance_id = payload.get("instance_id")
+        if type(release_id) is not int or release_id <= 0:
+            return None
+        if type(instance_id) is not int or instance_id <= 0:
+            return None
+        return release_id, instance_id
+
+    async def recover_collection_instance(
+        self,
+        resolve_key: tuple[str, str],
+        expected_release_id: int,
+        expected_instance_id: int,
+        observed_instance_ids: tuple[int, ...],
+    ) -> "Optional[CollectionIdentity]":
+        """Replace exactly one definitively stale collection identity safely."""
+        if (
+            not self._valid_recovery_key(resolve_key)
+            or type(expected_release_id) is not int or expected_release_id <= 0
+            or type(expected_instance_id) is not int or expected_instance_id <= 0
+            or not isinstance(observed_instance_ids, tuple)
+            or len(set(observed_instance_ids)) != len(observed_instance_ids)
+            or any(type(value) is not int or value <= 0 for value in observed_instance_ids)
+        ):
+            log.warning("Refusing invalid Discogs collection recovery evidence.")
+            return None
+
+        async with self._reader_gate:
+            entry = self._album_cache.get(resolve_key)
+            pair = self._collection_pair(entry)
+            stale_pair = (expected_release_id, expected_instance_id)
+            if pair == stale_pair:
+                self._album_cache.pop(resolve_key)
+            elif entry is not None:
+                # Another resolve has replaced this key.  It is already safe
+                # only when it exactly agrees with the writer's singleton proof.
+                if (
+                    len(observed_instance_ids) == 1
+                    and pair == (expected_release_id, observed_instance_ids[0])
+                ):
+                    return CollectionIdentity(*pair)
+                log.info("Discogs collection recovery found a newer cache entry; leaving it intact.")
+                return None
+
+            if len(observed_instance_ids) != 1 or observed_instance_ids[0] == expected_instance_id:
+                log.info("Discogs collection recovery refused non-singleton replacement evidence.")
+                return None
+            replacement_instance_id = observed_instance_ids[0]
+            try:
+                fresh = await self.reader.run(
+                    self.reader.rebuild_collection_and_research,
+                    resolve_key[0], resolve_key[1],
+                )
+            except Exception as exc:
+                log.warning("Discogs collection recovery rebuild failed: %s", exc)
+                return None
+            if not isinstance(fresh, dict):
+                log.info("Discogs collection recovery found no unambiguous fresh match.")
+                return None
+            release_id = fresh.get("release_id")
+            if type(release_id) is not int or release_id != expected_release_id:
+                log.info("Discogs collection recovery resolved a different release.")
+                return None
+            recovered = dict(fresh)
+            recovered["instance_id"] = replacement_instance_id
+            self._cache_store(resolve_key, MetadataSource.DISCOGS_COLLECTION, recovered)
+            return CollectionIdentity(expected_release_id, replacement_instance_id)
 
     def _from_discogs(
         self,

--- a/src/tracking/listen_tracker.py
+++ b/src/tracking/listen_tracker.py
@@ -80,13 +80,15 @@ never trigger a split.
 import asyncio
 import logging
 import time
-from typing import Callable, Optional, TYPE_CHECKING
+from typing import Awaitable, Callable, Optional, TYPE_CHECKING
 
 from src.metadata.models import MetadataSource, PlaySession, TrackMetadata
 from src.metadata.normalize import fold_text
 from src.audio.silence import AudioEvent
 from src.metadata.discogs.transport import DiscogsRateLimited
-from src.metadata.discogs.outcomes import PlayCountReadResult, PlayCountReadState
+from src.metadata.discogs.outcomes import (
+    CollectionIdentity, PlayCountReadResult, PlayCountReadState,
+)
 from src.tracking.spin_memory import SpinMemory
 from src.util.clock import clock_is_trustworthy
 
@@ -172,6 +174,10 @@ class _DefinitiveMissingInstance(Exception):
         super().__init__("collection instance is definitively missing")
         self.result = result
 
+
+class _ReplacementReadAborted(Exception):
+    """A safely recovered identity whose one replacement read was inconclusive."""
+
 # R7-03 (flip-resume): how far back a newly-armed session may reach to inherit an
 # immediately-prior UNARMED session's closing-side rows (Lane, 2026-08-11: fixed
 # 5-minute wall-clock, same closing side only).  R8-01 (#345, Lane 2026-08-12):
@@ -192,6 +198,10 @@ class ListenTracker:
         self,
         writer: "DiscogsCollectionWriter",
         lastfm: Optional["LastFmClient"] = None,
+        recover_collection_instance: Optional[
+            Callable[[tuple[str, str], int, int, tuple[int, ...]],
+                     Awaitable[Optional[CollectionIdentity]]]
+        ] = None,
     ):
         # A-4: depend only on the Discogs WRITE half (Play Count / Last Played),
         # injected at the composition root (main.py).  A-3 had already moved this
@@ -199,6 +209,11 @@ class ListenTracker:
         # to just the collection writer.
         self.writer = writer
         self.lastfm = lastfm
+        # #421: the tracker gets one narrow, async recovery port rather than a
+        # metadata reader/resolver dependency.  It is used only before an
+        # absolute Play Count target exists, after the writer has conclusively
+        # proven the latched collection instance missing.
+        self._recover_collection_instance = recover_collection_instance
         # R5-22: love-on-completion needs a WORKING Last.fm client. If the user
         # asked for it but the client is disabled (scrobble_enabled off, missing
         # creds, pylast absent, or init failure), warn ONCE at startup — otherwise
@@ -1009,24 +1024,109 @@ class ListenTracker:
         # leaves `plan` unset so the next attempt safely re-reads (the GET is
         # idempotent), while a landed-but-unobserved POST re-POSTs the SAME target.
         plan: dict = {}
+        # #421: this budget belongs to the detached session, not the retry loop.
+        # A replacement read that is rate-limited may retry under #229, but it
+        # must never restart resolver recovery or select another identity.
+        recovery_spent = False
+        replacement_identity_established = False
+
+        def _valid_resolve_key(key) -> bool:
+            return (
+                isinstance(key, tuple)
+                and len(key) == 2
+                and all(isinstance(part, str) and bool(part.strip()) for part in key)
+            )
+
+        async def _read_replacement() -> None:
+            """Perform the replacement read without opening another recovery path."""
+            result = await self.writer.run(
+                self.writer.read_play_count,
+                session.album_release_id,
+                session.album_instance_id,
+            )
+            if result.state is PlayCountReadState.DEFINITIVE_INSTANCE_MISSING:
+                # A second complete snapshot says the just-established target is
+                # stale too.  Neither field may write to it and recovery is spent.
+                raise _DefinitiveMissingInstance(result)
+            if result.state is not PlayCountReadState.READY:
+                # The identity is still safe for META-7 Last Played, but an
+                # inconclusive replacement read must not get a second recovery or
+                # fabricate an absolute Play Count target.
+                raise _ReplacementReadAborted()
+            plan["field_id"] = result.field_id
+            plan["current"] = result.current_count
+            plan["target"] = result.current_count + 1
 
         async def _credit_attempt() -> bool:
+            nonlocal recovery_spent, replacement_identity_established
             if not plan:
-                result = await self.writer.run(
-                    self.writer.read_play_count,
-                    session.album_release_id,
-                    session.album_instance_id,
-                )
-                if result.state is PlayCountReadState.DEFINITIVE_INSTANCE_MISSING:
-                    raise _DefinitiveMissingInstance(result)
-                if result.state is not PlayCountReadState.READY:
-                    # Field missing / unreadable / non-integer — abort WITHOUT
-                    # writing (META-1/META-2), already logged loud by the reader.
-                    # Treated as a failed attempt so a transient read is retried.
-                    return False
-                plan["field_id"] = result.field_id
-                plan["current"] = result.current_count
-                plan["target"] = result.current_count + 1
+                if replacement_identity_established:
+                    # #229 can re-enter here after a rate-limited replacement
+                    # GET.  It retries that GET only; the recovery budget remains
+                    # spent and the established pair cannot change.
+                    await _read_replacement()
+                else:
+                    result = await self.writer.run(
+                        self.writer.read_play_count,
+                        session.album_release_id,
+                        session.album_instance_id,
+                    )
+                    if result.state is PlayCountReadState.DEFINITIVE_INSTANCE_MISSING:
+                        if recovery_spent:
+                            raise _DefinitiveMissingInstance(result)
+                        recovery_spent = True  # spend BEFORE an await/cancellation point
+                        stale_release_id = session.album_release_id
+                        stale_instance_id = session.album_instance_id
+                        resolve_key = session.album_resolve_key
+                        if (
+                            self._recover_collection_instance is None
+                            or not _valid_resolve_key(resolve_key)
+                            or type(stale_release_id) is not int or stale_release_id <= 0
+                            or type(stale_instance_id) is not int or stale_instance_id <= 0
+                        ):
+                            raise _DefinitiveMissingInstance(result)
+                        try:
+                            identity = await self._recover_collection_instance(
+                                resolve_key,
+                                stale_release_id,
+                                stale_instance_id,
+                                result.observed_instance_ids,
+                            )
+                        except asyncio.CancelledError:
+                            raise
+                        except Exception as exc:
+                            log.warning(
+                                "Discogs collection recovery failed for release %s / "
+                                "instance %s: %s; suppressing both field writes.",
+                                stale_release_id, stale_instance_id, exc,
+                            )
+                            raise _DefinitiveMissingInstance(result) from exc
+                        if (
+                            not isinstance(identity, CollectionIdentity)
+                            or identity.release_id != stale_release_id
+                            or identity.instance_id == stale_instance_id
+                        ):
+                            log.info(
+                                "Discogs collection recovery refused release %s / "
+                                "instance %s; suppressing both field writes.",
+                                stale_release_id, stale_instance_id,
+                            )
+                            raise _DefinitiveMissingInstance(result)
+                        # Update the detached session only after the narrow port
+                        # has established the same-release replacement safely.
+                        session.album_release_id = identity.release_id
+                        session.album_instance_id = identity.instance_id
+                        replacement_identity_established = True
+                        await _read_replacement()
+                    elif result.state is not PlayCountReadState.READY:
+                        # Field missing / unreadable / non-integer — abort WITHOUT
+                        # writing (META-1/META-2), already logged loud by the reader.
+                        # Treated as a failed attempt so a transient read is retried.
+                        return False
+                    else:
+                        plan["field_id"] = result.field_id
+                        plan["current"] = result.current_count
+                        plan["target"] = result.current_count + 1
             return await self.writer.run(
                 self.writer.set_play_count,
                 session.album_release_id,
@@ -1047,6 +1147,17 @@ class ListenTracker:
                 session.album_release_id, session.album_instance_id,
             )
             return
+        except _ReplacementReadAborted:
+            # Recovery established a safe replacement, so META-7 retains its
+            # independent one-shot Last Played attempt.  Only the Play Count
+            # plan is absent; do not retry this ambiguous read or recover again.
+            success = False
+            log.error(
+                "⚠ Discogs Play Count credit FAILED for recovered release %s / "
+                "instance %s: replacement read was inconclusive; no count write "
+                "was attempted.",
+                session.album_release_id, session.album_instance_id,
+            )
         if success:
             session.credited = True  # committed ONLY after the write landed (#163)
             # R8-02 (#346): remember that this release was credited THIS SPIN so

--- a/src/tracking/listen_tracker.py
+++ b/src/tracking/listen_tracker.py
@@ -86,6 +86,7 @@ from src.metadata.models import MetadataSource, PlaySession, TrackMetadata
 from src.metadata.normalize import fold_text
 from src.audio.silence import AudioEvent
 from src.metadata.discogs.transport import DiscogsRateLimited
+from src.metadata.discogs.outcomes import PlayCountReadResult, PlayCountReadState
 from src.tracking.spin_memory import SpinMemory
 from src.util.clock import clock_is_trustworthy
 
@@ -162,6 +163,14 @@ _HONORED_RETRY_AFTER_CAP_SECONDS = 90.0
 # IN-THREAD by the transport rather than honoured; such a credit also exceeds the cap
 # and is backgrounded too — harmless, the credit still lands via _bg_tasks.)
 _SPLIT_CREDIT_INLINE_WAIT_SECONDS = 5.0
+
+
+class _DefinitiveMissingInstance(Exception):
+    """Terminal signal for an old collection instance proven stale."""
+
+    def __init__(self, result: PlayCountReadResult):
+        super().__init__("collection instance is definitively missing")
+        self.result = result
 
 # R7-03 (flip-resume): how far back a newly-armed session may reach to inherit an
 # immediately-prior UNARMED session's closing-side rows (Lane, 2026-08-11: fixed
@@ -962,6 +971,8 @@ class ListenTracker:
                     "wait in the event loop (sleeping %ss) before retrying (#229).",
                     label, n, _FINALIZE_WRITE_ATTEMPTS, e.retry_after, backoff,
                 )
+            except _DefinitiveMissingInstance:
+                raise
             except Exception as e:
                 log.warning(
                     "%s attempt %d/%d raised: %s", label, n, _FINALIZE_WRITE_ATTEMPTS, e
@@ -1001,20 +1012,21 @@ class ListenTracker:
 
         async def _credit_attempt() -> bool:
             if not plan:
-                state = await self.writer.run(
+                result = await self.writer.run(
                     self.writer.read_play_count,
                     session.album_release_id,
                     session.album_instance_id,
                 )
-                if state is None:
+                if result.state is PlayCountReadState.DEFINITIVE_INSTANCE_MISSING:
+                    raise _DefinitiveMissingInstance(result)
+                if result.state is not PlayCountReadState.READY:
                     # Field missing / unreadable / non-integer — abort WITHOUT
                     # writing (META-1/META-2), already logged loud by the reader.
                     # Treated as a failed attempt so a transient read is retried.
                     return False
-                field_id, current_count = state
-                plan["field_id"] = field_id
-                plan["current"] = current_count
-                plan["target"] = current_count + 1
+                plan["field_id"] = result.field_id
+                plan["current"] = result.current_count
+                plan["target"] = result.current_count + 1
             return await self.writer.run(
                 self.writer.set_play_count,
                 session.album_release_id,
@@ -1024,9 +1036,17 @@ class ListenTracker:
                 plan["target"],
             )
 
-        success = await self._finalize_write_with_retry(
-            "Discogs Play Count increment", _credit_attempt
-        )
+        try:
+            success = await self._finalize_write_with_retry(
+                "Discogs Play Count increment", _credit_attempt
+            )
+        except _DefinitiveMissingInstance:
+            log.error(
+                "⚠ Discogs Play Count credit FAILED for release %s / instance %s: "
+                "the collection instance is definitively missing; suppressing Last Played.",
+                session.album_release_id, session.album_instance_id,
+            )
+            return
         if success:
             session.credited = True  # committed ONLY after the write landed (#163)
             # R8-02 (#346): remember that this release was credited THIS SPIN so

--- a/src/tracking/listen_tracker.py
+++ b/src/tracking/listen_tracker.py
@@ -1094,13 +1094,15 @@ class ListenTracker:
                             )
                         except asyncio.CancelledError:
                             raise
-                        except Exception as exc:
+                        except Exception:
                             log.warning(
-                                "Discogs collection recovery failed for release %s / "
-                                "instance %s: %s; suppressing both field writes.",
-                                stale_release_id, stale_instance_id, exc,
+                                "Discogs collection recovery "
+                                "stage=recovery-callback-failed "
+                                "expected_release_id=%d expected_instance_id=%d; "
+                                "suppressing both field writes.",
+                                stale_release_id, stale_instance_id,
                             )
-                            raise _DefinitiveMissingInstance(result) from exc
+                            raise _DefinitiveMissingInstance(result) from None
                         if (
                             not isinstance(identity, CollectionIdentity)
                             or identity.release_id != stale_release_id

--- a/src/tracking/listen_tracker.py
+++ b/src/tracking/listen_tracker.py
@@ -986,7 +986,7 @@ class ListenTracker:
                     "wait in the event loop (sleeping %ss) before retrying (#229).",
                     label, n, _FINALIZE_WRITE_ATTEMPTS, e.retry_after, backoff,
                 )
-            except _DefinitiveMissingInstance:
+            except (_DefinitiveMissingInstance, _ReplacementReadAborted):
                 raise
             except Exception as e:
                 log.warning(
@@ -1105,6 +1105,8 @@ class ListenTracker:
                             not isinstance(identity, CollectionIdentity)
                             or identity.release_id != stale_release_id
                             or identity.instance_id == stale_instance_id
+                            or len(result.observed_instance_ids) != 1
+                            or identity.instance_id != result.observed_instance_ids[0]
                         ):
                             log.info(
                                 "Discogs collection recovery refused release %s / "

--- a/tests/test_cache_expiry.py
+++ b/tests/test_cache_expiry.py
@@ -24,6 +24,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from src.metadata.models import MetadataSource, TracklistEntry
+from src.metadata.discogs.outcomes import CollectionRefreshResult, CollectionRefreshState
 from tests.factories import make_discogs_reader
 
 
@@ -31,10 +32,18 @@ from tests.factories import make_discogs_reader
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _page(releases, page=1, pages=1):
+def _page(releases, page=1, pages=1, per_page=100, items=None):
     resp = MagicMock()
     resp.status_code = 200
-    resp.json.return_value = {"releases": releases, "pagination": {"page": page, "pages": pages}}
+    resp.json.return_value = {
+        "releases": releases,
+        "pagination": {
+            "page": page,
+            "pages": pages,
+            "per_page": per_page,
+            "items": len(releases) if items is None else items,
+        },
+    }
     return resp
 
 
@@ -67,7 +76,9 @@ def _make_resolver(reader=None, coverart=None):
     if reader is None:
         r.reader.search_collection.return_value = None
         r.reader.search_database.return_value = None
-        r.reader.refresh_index_and_research.return_value = None
+        r.reader.refresh_index_and_research.return_value = CollectionRefreshResult(
+            CollectionRefreshState.CLEAN_NO_MATCH
+        )
         r.reader.run = AsyncMock(side_effect=lambda fn, *a: fn(*a))
     r.coverart = coverart or MagicMock()
     r.coverart.get_cover_art_url.return_value = None
@@ -155,7 +166,7 @@ def test_index_not_rebuilt_within_ttl(monkeypatch):
 # C — cooldown'd staleness-triggered refresh (reader).
 # ---------------------------------------------------------------------------
 
-def test_refresh_and_research_upgrades_a_just_added_record(monkeypatch):
+def test_refresh_returns_owned_after_complete_rebuild(monkeypatch):
     """refresh_index_and_research force-rebuilds a stale index and re-checks
     ownership, finding a record added after the original build."""
     import src.metadata.discogs.reader as reader_mod
@@ -172,9 +183,80 @@ def test_refresh_and_research_upgrades_a_just_added_record(monkeypatch):
                             _item(555, 77, "Sister", ["Sonic Youth"])])
     )
 
-    upgraded = reader.refresh_index_and_research("Sonic Youth", "Sister")
-    assert upgraded is not None
-    assert upgraded["instance_id"] == 77          # the just-added record's instance
+    outcome = reader.refresh_index_and_research("Sonic Youth", "Sister")
+    assert outcome.state is CollectionRefreshState.OWNED
+    assert outcome.result["instance_id"] == 77          # the just-added record's instance
+
+
+def test_refresh_returns_clean_no_match_after_complete_rebuild(monkeypatch):
+    import src.metadata.discogs.reader as reader_mod
+    clock = _Clock()
+    monkeypatch.setattr(reader_mod.time, "monotonic", clock)
+    reader = make_discogs_reader()
+    reader._collection_index = {}
+    reader._collection_index_built_at = clock.t
+    reader._database_search = MagicMock(return_value=[])
+    reader._http.request = MagicMock(return_value=_page([]))
+
+    outcome = reader.refresh_index_and_research("Sonic Youth", "Sister")
+
+    assert outcome.state is CollectionRefreshState.CLEAN_NO_MATCH
+    assert outcome.result is None
+
+
+def test_refresh_returns_cooldown_skipped_after_successful_rebuild(monkeypatch):
+    import src.metadata.discogs.reader as reader_mod
+    clock = _Clock()
+    monkeypatch.setattr(reader_mod.time, "monotonic", clock)
+    reader = make_discogs_reader()
+    reader._collection_index = {}
+    reader._collection_index_built_at = clock.t
+    reader._database_search = MagicMock(return_value=[])
+    reader._http.request = MagicMock(return_value=_page([]))
+
+    reader.refresh_index_and_research("Sonic Youth", "Sister")
+    calls = reader._http.request.call_count
+    outcome = reader.refresh_index_and_research("Sonic Youth", "Sister")
+
+    assert outcome.state is CollectionRefreshState.COOLDOWN_SKIPPED
+    assert outcome.cooldown_follows_successful_rebuild is True
+    assert reader._http.request.call_count == calls
+
+
+def test_failed_refresh_marks_cooldown_provenance_unknown(monkeypatch):
+    import src.metadata.discogs.reader as reader_mod
+    clock = _Clock()
+    monkeypatch.setattr(reader_mod.time, "monotonic", clock)
+    reader = make_discogs_reader()
+    reader._collection_index = {111: {"instance_id": 42, "title": "Goo", "artists": ["Sonic Youth"]}}
+    reader._collection_index_built_at = clock.t
+    reader._http.request = MagicMock(side_effect=ConnectionError("blip"))
+
+    with pytest.raises(reader_mod.CollectionIndexIncomplete):
+        reader.refresh_index_and_research("Sonic Youth", "Sister")
+
+    outcome = reader.refresh_index_and_research("Sonic Youth", "Sister")
+    assert outcome.state is CollectionRefreshState.COOLDOWN_SKIPPED
+    assert outcome.cooldown_follows_successful_rebuild is False
+
+
+def test_cooldown_skip_after_failed_refresh_does_not_repage(monkeypatch):
+    import src.metadata.discogs.reader as reader_mod
+    clock = _Clock()
+    monkeypatch.setattr(reader_mod.time, "monotonic", clock)
+    reader = make_discogs_reader()
+    reader._collection_index = {}
+    reader._collection_index_built_at = clock.t
+    reader._http.request = MagicMock(side_effect=ConnectionError("blip"))
+
+    with pytest.raises(reader_mod.CollectionIndexIncomplete):
+        reader.refresh_index_and_research("Sonic Youth", "Sister")
+    calls = reader._http.request.call_count
+    outcome = reader.refresh_index_and_research("Sonic Youth", "Sister")
+
+    assert outcome.state is CollectionRefreshState.COOLDOWN_SKIPPED
+    assert outcome.cooldown_follows_successful_rebuild is False
+    assert reader._http.request.call_count == calls
 
 
 def test_refresh_preserves_the_prior_index_on_a_transient_rebuild_failure(monkeypatch):
@@ -193,7 +275,7 @@ def test_refresh_preserves_the_prior_index_on_a_transient_rebuild_failure(monkey
     reader._collection_index_built_at = clock.t
     reader._http.request = MagicMock(side_effect=ConnectionError("blip"))
 
-    with pytest.raises(ConnectionError):
+    with pytest.raises(reader_mod.CollectionIndexIncomplete):
         reader.refresh_index_and_research("Someone", "New Album")
 
     # The previously-valid index survived; the error still propagated (B-4).
@@ -242,7 +324,9 @@ async def test_database_downgrade_cache_expires_and_re_resolves(monkeypatch):
     reader.run = AsyncMock(side_effect=lambda fn, *a: fn(*a))
     reader.search_collection.return_value = None
     reader.search_database.return_value = _db_result()
-    reader.refresh_index_and_research.return_value = None       # C finds nothing yet
+    reader.refresh_index_and_research.return_value = CollectionRefreshResult(
+        CollectionRefreshState.CLEAN_NO_MATCH
+    )
     resolver = _make_resolver(reader=reader)
 
     first = await resolver.resolve(make_raw())
@@ -276,7 +360,9 @@ async def test_collection_cache_never_expires(monkeypatch):
     reader.search_collection.return_value = {"release_id": 555, "instance_id": 77,
                                              "album": "Sister", "tracklist": []}
     reader.search_database.return_value = None
-    reader.refresh_index_and_research.return_value = None
+    reader.refresh_index_and_research.return_value = CollectionRefreshResult(
+        CollectionRefreshState.CLEAN_NO_MATCH
+    )
     resolver = _make_resolver(reader=reader)
 
     first = await resolver.resolve(make_raw())
@@ -303,9 +389,10 @@ async def test_resolver_upgrades_via_refresh_on_database_hit():
     reader.run = AsyncMock(side_effect=lambda fn, *a: fn(*a))
     reader.search_collection.return_value = None                # stale index misses
     reader.search_database.return_value = _db_result()          # DB knows the album
-    reader.refresh_index_and_research.return_value = {          # refresh finds it owned
-        "release_id": 555, "instance_id": 77, "album": "Sister", "tracklist": [],
-    }
+    reader.refresh_index_and_research.return_value = CollectionRefreshResult(
+        CollectionRefreshState.OWNED,
+        {"release_id": 555, "instance_id": 77, "album": "Sister", "tracklist": []},
+    )
     resolver = _make_resolver(reader=reader)
 
     result = await resolver.resolve(make_raw())
@@ -323,7 +410,9 @@ async def test_refresh_is_not_triggered_when_the_collection_lookup_errored():
     reader.run = AsyncMock(side_effect=lambda fn, *a: fn(*a))
     reader.search_collection.side_effect = ConnectionError("blip")   # errored, not a clean miss
     reader.search_database.return_value = _db_result()
-    reader.refresh_index_and_research.return_value = None
+    reader.refresh_index_and_research.return_value = CollectionRefreshResult(
+        CollectionRefreshState.CLEAN_NO_MATCH
+    )
     resolver = _make_resolver(reader=reader)
 
     result = await resolver.resolve(make_raw())
@@ -339,9 +428,64 @@ async def test_resolver_keeps_database_when_refresh_finds_nothing():
     reader.run = AsyncMock(side_effect=lambda fn, *a: fn(*a))
     reader.search_collection.return_value = None
     reader.search_database.return_value = _db_result()
-    reader.refresh_index_and_research.return_value = None       # still not owned
+    reader.refresh_index_and_research.return_value = CollectionRefreshResult(
+        CollectionRefreshState.CLEAN_NO_MATCH
+    )
     resolver = _make_resolver(reader=reader)
 
     result = await resolver.resolve(make_raw())
     assert result.source is MetadataSource.DISCOGS_DATABASE
     reader.refresh_index_and_research.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_resolver_caches_database_after_clean_no_match():
+    reader = MagicMock()
+    reader.run = AsyncMock(side_effect=lambda fn, *a: fn(*a))
+    reader.search_collection.return_value = None
+    reader.search_database.return_value = _db_result()
+    reader.refresh_index_and_research.return_value = CollectionRefreshResult(
+        CollectionRefreshState.CLEAN_NO_MATCH
+    )
+    resolver = _make_resolver(reader=reader)
+
+    result = await resolver.resolve(make_raw())
+
+    assert result.source is MetadataSource.DISCOGS_DATABASE
+    assert len(resolver._album_cache) == 1
+
+
+@pytest.mark.asyncio
+async def test_resolver_caches_database_on_cooldown_after_proven_success():
+    reader = MagicMock()
+    reader.run = AsyncMock(side_effect=lambda fn, *a: fn(*a))
+    reader.search_collection.return_value = None
+    reader.search_database.return_value = _db_result()
+    reader.refresh_index_and_research.return_value = CollectionRefreshResult(
+        CollectionRefreshState.COOLDOWN_SKIPPED,
+        cooldown_follows_successful_rebuild=True,
+    )
+    resolver = _make_resolver(reader=reader)
+
+    result = await resolver.resolve(make_raw())
+
+    assert result.source is MetadataSource.DISCOGS_DATABASE
+    assert len(resolver._album_cache) == 1
+
+
+@pytest.mark.asyncio
+async def test_resolver_does_not_cache_database_on_cooldown_after_failed_refresh():
+    reader = MagicMock()
+    reader.run = AsyncMock(side_effect=lambda fn, *a: fn(*a))
+    reader.search_collection.return_value = None
+    reader.search_database.return_value = _db_result()
+    reader.refresh_index_and_research.return_value = CollectionRefreshResult(
+        CollectionRefreshState.COOLDOWN_SKIPPED,
+        cooldown_follows_successful_rebuild=False,
+    )
+    resolver = _make_resolver(reader=reader)
+
+    result = await resolver.resolve(make_raw())
+
+    assert result.source is MetadataSource.DISCOGS_DATABASE
+    assert len(resolver._album_cache) == 0

--- a/tests/test_cache_expiry.py
+++ b/tests/test_cache_expiry.py
@@ -19,6 +19,7 @@ Fix: monotonic-clock TTL on the index (B1) and on the resolver's DATABASE/FALLBA
 entries only — COLLECTION hits never expire (B2) — plus a cooldown'd
 staleness-triggered refresh (C).
 """
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -83,6 +84,7 @@ def _make_resolver(reader=None, coverart=None):
     r.coverart = coverart or MagicMock()
     r.coverart.get_cover_art_url.return_value = None
     r._album_cache = BoundedCache(_ALBUM_CACHE_MAX)
+    r._reader_gate = asyncio.Lock()
     r._logged_discogs_config = {}
     return r
 

--- a/tests/test_coverart_timeout_238.py
+++ b/tests/test_coverart_timeout_238.py
@@ -32,6 +32,7 @@ def _resolver(cover_fn):
     r.coverart = MagicMock()
     r.coverart.get_cover_art_url = cover_fn
     r._album_cache = BoundedCache(_ALBUM_CACHE_MAX)
+    r._reader_gate = asyncio.Lock()
     r._logged_discogs_config = {}
     return r
 

--- a/tests/test_credit_idempotent_186.py
+++ b/tests/test_credit_idempotent_186.py
@@ -9,7 +9,7 @@ pre-#186 code re-read the incremented value on retry and posted current+1 again
 (6 -> 7 for one play); the fixed code re-POSTs the same absolute target (6).
 """
 import asyncio
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import requests
@@ -155,3 +155,50 @@ async def test_transient_read_then_success_still_credits_once():
     assert server["count"] == 6, "credited exactly +1 after the read recovered"
     assert posts["n"] == 1
     assert session.credited is True
+
+
+@pytest.mark.asyncio
+async def test_definitively_missing_instance_skips_post_last_played_and_retry():
+    """A complete snapshot proving removal is terminal until recovery can repair it."""
+    http = make_discogs_http()
+    writer = make_discogs_writer(
+        http=http, config=make_discogs_config(last_played_field_name="Last Played")
+    )
+    writer._collection_fields = {"Play Count": 3, "Last Played": 7}
+    calls = {"get": 0, "post": 0, "last_played": 0}
+
+    def fake_get(url, **kw):
+        calls["get"] += 1
+        response = MagicMock(); response.status_code = 200
+        response.json.return_value = {
+            "pagination": {"page": 1, "pages": 1, "items": 1, "per_page": 1},
+            "releases": [{
+                "instance_id": 888, "folder_id": 0,
+                "basic_information": {"id": 999}, "notes": [],
+            }],
+        }
+        return response
+
+    def fake_post(url, **kw):
+        calls["post"] += 1
+        response = MagicMock(); response.status_code = 204
+        return response
+
+    http.session.get = fake_get
+    http.session.post = fake_post
+    original_last_played = writer.update_last_played
+
+    def count_last_played(*args):
+        calls["last_played"] += 1
+        return original_last_played(*args)
+
+    writer.update_last_played = count_last_played
+    tracker = ListenTracker(writer=writer)
+    session = _session()
+
+    with patch("src.tracking.listen_tracker.asyncio.sleep", new=AsyncMock()) as sleep:
+        await tracker._credit_completed_album(session)
+
+    assert calls == {"get": 1, "post": 0, "last_played": 0}
+    sleep.assert_not_awaited()
+    assert session.credited is False

--- a/tests/test_credit_idempotent_186.py
+++ b/tests/test_credit_idempotent_186.py
@@ -16,6 +16,7 @@ import requests
 
 from src.tracking.listen_tracker import ListenTracker
 from src.metadata.models import PlaySession
+from src.metadata.discogs.outcomes import CollectionIdentity
 from tests.factories import make_discogs_writer, make_discogs_http, make_discogs_config
 
 
@@ -202,3 +203,70 @@ async def test_definitively_missing_instance_skips_post_last_played_and_retry():
     assert calls == {"get": 1, "post": 0, "last_played": 0}
     sleep.assert_not_awaited()
     assert session.credited is False
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_old_instance_post_never_invokes_recovery():
+    """A response-lost absolute POST is not missing-instance evidence."""
+    writer, _server, _posts = _writer_with_seam(first_post="lost", start=5)
+    recovery = AsyncMock(return_value=CollectionIdentity(999, 888))
+    tracker = ListenTracker(writer=writer, recover_collection_instance=recovery)
+    session = _session()
+
+    await tracker._credit_completed_album(session)
+
+    recovery.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recovered_absolute_post_retry_reuses_one_target():
+    """A recovered credit still retries only one precomputed absolute value."""
+    http = make_discogs_http()
+    writer = make_discogs_writer(
+        http=http, config=make_discogs_config(last_played_field_name=None)
+    )
+    writer._collection_fields = {"Play Count": 3}
+    server = {"count": 5}
+    post_bodies = []
+    gets = {"n": 0}
+
+    def fake_get(url, **kw):
+        gets["n"] += 1
+        response = MagicMock(); response.status_code = 200
+        if gets["n"] == 1:
+            response.json.return_value = {
+                "pagination": {"page": 1, "pages": 1, "items": 1, "per_page": 1},
+                "releases": [{
+                    "instance_id": 888, "folder_id": 0,
+                    "basic_information": {"id": 999}, "notes": [],
+                }],
+            }
+        else:
+            response.json.return_value = {"releases": [{
+                "instance_id": 888,
+                "notes": [{"field_id": 3, "value": str(server["count"])}],
+            }]}
+        return response
+
+    def fake_post(url, **kw):
+        post_bodies.append(kw["json"])
+        server["count"] = int(kw["json"]["value"])
+        if len(post_bodies) == 1:
+            raise requests.exceptions.ReadTimeout("response lost after apply")
+        response = MagicMock(); response.status_code = 204
+        return response
+
+    http.session.get = fake_get
+    http.session.post = fake_post
+    recovery = AsyncMock(return_value=CollectionIdentity(999, 888))
+    tracker = ListenTracker(writer=writer, recover_collection_instance=recovery)
+    session = _session()
+    session.album_resolve_key = ("sonic youth", "sister")
+
+    await tracker._credit_completed_album(session)
+
+    recovery.assert_awaited_once_with(("sonic youth", "sister"), 999, 777, (888,))
+    assert gets["n"] == 2
+    assert post_bodies == [{"value": "6"}, {"value": "6"}]
+    assert server["count"] == 6
+    assert session.credited is True

--- a/tests/test_discogs_client.py
+++ b/tests/test_discogs_client.py
@@ -353,6 +353,26 @@ def test_nonempty_garbage_value_aborts_without_writing(caplog):
     assert "not an integer" in caplog.text
 
 
+def test_noninteger_play_count_aborts_without_logging_note_content(caplog):
+    """A malformed field must not expose its user-entered note in error logs."""
+    client = make_client()
+    secret = "discogs-note-secret-8f7d0a"
+    raw_note = {"field_id": _FIELD_ID, "value": secret, "private": "do-not-log"}
+    client._http.session.get = MagicMock(return_value=make_get_response(
+        200,
+        {"releases": [{"instance_id": 42, "notes": [raw_note]}]},
+    ))
+    client._http.session.post = MagicMock(return_value=make_post_response(204))
+
+    with caplog.at_level(logging.ERROR):
+        result = client.increment_play_count(release_id=111, instance_id=42)
+
+    assert result is False
+    client._http.session.post.assert_not_called()
+    assert secret not in caplog.text
+    assert repr(raw_note) not in caplog.text
+
+
 def test_whitespace_only_value_treated_as_zero():
     """Whitespace-only string → treat as 0, post '1'."""
     client = make_client()

--- a/tests/test_discogs_client.py
+++ b/tests/test_discogs_client.py
@@ -1144,7 +1144,10 @@ def test_reader_collection_index_percent_encodes_username_in_url():
     resp = MagicMock()
     resp.status_code = 200
     resp.raise_for_status.return_value = None
-    resp.json.return_value = {"releases": [], "pagination": {"pages": 1}}
+    resp.json.return_value = {
+        "releases": [],
+        "pagination": {"page": 1, "pages": 1, "per_page": 100, "items": 0},
+    }
     reader._http.request = MagicMock(return_value=resp)
 
     reader._get_collection_index()

--- a/tests/test_discogs_client.py
+++ b/tests/test_discogs_client.py
@@ -42,6 +42,7 @@ import pytest
 import requests
 
 from src.metadata.discogs.writer import _READ_FAILED
+from src.metadata.discogs.outcomes import PlayCountReadResult, PlayCountReadState
 from tests.factories import make_discogs_config, make_discogs_writer, make_discogs_reader
 
 
@@ -114,6 +115,158 @@ def instance_response(instance_id: int, field_id: int, value: str):
             }
         ]
     }
+
+
+def complete_single_page_response(release_id: int, instances: list[dict]):
+    """Build a complete one-page collection snapshot for typed-read tests."""
+    return {
+        "pagination": {
+            "page": 1,
+            "pages": 1,
+            "items": len(instances),
+            "per_page": max(1, len(instances)),
+        },
+        "releases": [
+            {
+                "instance_id": instance["instance_id"],
+                "folder_id": instance.get("folder_id", 0),
+                "basic_information": {"id": instance.get("release_id", release_id)},
+                "notes": instance.get("notes", []),
+            }
+            for instance in instances
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# read_play_count — typed outcomes / definitive missing-instance evidence (#421)
+# ---------------------------------------------------------------------------
+
+def test_read_play_count_returns_ready_with_integer_count():
+    """A found instance exposes the field and parsed count in a READY result."""
+    client = make_client()
+    client._http.session.get = MagicMock(return_value=make_get_response(
+        200, complete_single_page_response(111, [{
+            "instance_id": 42, "notes": [{"field_id": _FIELD_ID, "value": "5"}],
+        }]),
+    ))
+
+    result = client.read_play_count(111, 42)
+
+    assert result == PlayCountReadResult(PlayCountReadState.READY, _FIELD_ID, 5)
+
+
+def test_read_play_count_returns_ready_for_confirmed_blank():
+    """An existing instance with no value is a safe, confirmed zero."""
+    client = make_client()
+    client._http.session.get = MagicMock(return_value=make_get_response(
+        200, complete_single_page_response(111, [{"instance_id": 42}]),
+    ))
+
+    result = client.read_play_count(111, 42)
+
+    assert result == PlayCountReadResult(PlayCountReadState.READY, _FIELD_ID, 0)
+
+
+def test_read_play_count_definitively_missing_only_from_valid_complete_single_page():
+    """Only a validated complete snapshot may prove the old instance is gone."""
+    client = make_client()
+    client._http.session.get = MagicMock(return_value=make_get_response(
+        200, complete_single_page_response(111, [
+            {"instance_id": 18}, {"instance_id": 91},
+        ]),
+    ))
+
+    result = client.read_play_count(111, 42)
+
+    assert result == PlayCountReadResult(
+        PlayCountReadState.DEFINITIVE_INSTANCE_MISSING,
+        observed_instance_ids=(18, 91),
+    )
+
+
+def test_read_play_count_definitively_missing_with_empty_observed_tuple():
+    """A valid empty collection response is different from an ambiguous abort."""
+    client = make_client()
+    client._http.session.get = MagicMock(return_value=make_get_response(
+        200, complete_single_page_response(111, []),
+    ))
+
+    result = client.read_play_count(111, 42)
+
+    assert result == PlayCountReadResult(
+        PlayCountReadState.DEFINITIVE_INSTANCE_MISSING,
+        observed_instance_ids=(),
+    )
+
+
+def test_found_expected_instance_is_ready_not_missing():
+    """A target found in a response never needs absence-proof validation."""
+    client = make_client()
+    client._http.session.get = MagicMock(return_value=make_get_response(200, {
+        "releases": [{"instance_id": 42, "notes": []}],
+    }))
+
+    result = client.read_play_count(111, 42)
+
+    assert result == PlayCountReadResult(PlayCountReadState.READY, _FIELD_ID, 0)
+
+
+def test_noninteger_count_is_abort_not_missing():
+    """Real nonnumeric field data must not be overwritten or mistaken for removal."""
+    client = make_client()
+    client._http.session.get = MagicMock(return_value=make_get_response(
+        200, complete_single_page_response(111, [{
+            "instance_id": 42, "notes": [{"field_id": _FIELD_ID, "value": "five"}],
+        }]),
+    ))
+
+    result = client.read_play_count(111, 42)
+
+    assert result == PlayCountReadResult(PlayCountReadState.ABORT)
+
+
+@pytest.mark.parametrize("body", [
+    {"releases": []},
+    {"pagination": {"page": 1, "pages": 2, "items": 1, "per_page": 1}, "releases": [{"instance_id": 18, "folder_id": 0, "basic_information": {"id": 111}}]},
+    {"pagination": {"page": 1, "pages": 1, "items": 2, "per_page": 2}, "releases": [{"instance_id": 18, "folder_id": 0, "basic_information": {"id": 111}}]},
+    {"pagination": {"page": 1, "pages": 1, "items": 2, "per_page": 1}, "releases": [{"instance_id": 18, "folder_id": 0, "basic_information": {"id": 111}}, {"instance_id": 19, "folder_id": 0, "basic_information": {"id": 111}}]},
+    {"pagination": {"page": 1, "pages": 1, "items": 1, "per_page": 0}, "releases": [{"instance_id": 18, "folder_id": 0, "basic_information": {"id": 111}}]},
+    complete_single_page_response(111, [{"instance_id": 18}, {"instance_id": 18}]),
+    complete_single_page_response(111, [{"instance_id": True}]),
+    complete_single_page_response(111, [{"instance_id": 18, "release_id": 112}]),
+    {"pagination": {"page": 1, "pages": 1, "items": 1, "per_page": 1}, "releases": [{"instance_id": 18, "folder_id": True, "basic_information": {"id": 111}}]},
+])
+def test_missing_instance_evidence_remains_abort(body):
+    """Incomplete or malformed snapshots must never expose replacement IDs."""
+    client = make_client()
+    client._http.session.get = MagicMock(return_value=make_get_response(200, body))
+
+    result = client.read_play_count(111, 42)
+
+    assert result == PlayCountReadResult(PlayCountReadState.ABORT)
+    assert result.observed_instance_ids == ()
+
+
+@pytest.mark.parametrize("response", [
+    make_get_response(404, {}), make_get_response(500, {}),
+])
+def test_non_200_or_transport_failure_remains_abort(response):
+    client = make_client()
+    client._http.session.get = MagicMock(return_value=response)
+
+    assert client.read_play_count(111, 42) == PlayCountReadResult(PlayCountReadState.ABORT)
+
+
+def test_malformed_json_or_transport_failure_remains_abort():
+    client = make_client()
+    response = make_get_response(200, {})
+    response.json.side_effect = ValueError("bad JSON")
+    client._http.session.get = MagicMock(return_value=response)
+    assert client.read_play_count(111, 42) == PlayCountReadResult(PlayCountReadState.ABORT)
+
+    client._http.session.get = MagicMock(side_effect=requests.ConnectionError("offline"))
+    assert client.read_play_count(111, 42) == PlayCountReadResult(PlayCountReadState.ABORT)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_discogs_collection_index.py
+++ b/tests/test_discogs_collection_index.py
@@ -6,13 +6,25 @@ within a session, so we now build an in-memory index ONCE and match locally.
 """
 from unittest.mock import MagicMock
 
+import pytest
+
 from tests.factories import make_discogs_reader
 
 
-def _page(releases, page, pages):
+def _page(releases, page, pages, per_page=None, items=None):
     resp = MagicMock()
     resp.status_code = 200
-    resp.json.return_value = {"releases": releases, "pagination": {"page": page, "pages": pages}}
+    if per_page is None:
+        per_page = max(len(releases), 1)
+    resp.json.return_value = {
+        "releases": releases,
+        "pagination": {
+            "page": page,
+            "pages": pages,
+            "per_page": per_page,
+            "items": len(releases) if items is None else items,
+        },
+    }
     return resp
 
 
@@ -41,11 +53,11 @@ def test_index_built_once_paginated_and_cached():
     client = make_discogs_reader()
     client._collection_index = None
     client._http.request = MagicMock(side_effect=[
-        _page([_item(111, 42, "Sister", ["Sonic Youth"], master_id=900)], 1, 2),
-        _page([_item(222, 43, "Goo", ["Sonic Youth"])], 2, 2),
+        _page([_item(111, 42, "Sister", ["Sonic Youth"], master_id=900)], 1, 2, items=2),
+        _page([_item(222, 43, "Goo", ["Sonic Youth"])], 2, 2, items=2),
     ])
 
-    idx = client._get_collection_index()
+    idx = client._get_collection_index().index
 
     assert set(idx.keys()) == {111, 222}
     # #226: master_id is captured from basic_information (present here) …
@@ -65,7 +77,7 @@ def test_index_built_once_paginated_and_cached():
     assert client._http.request.call_count == 2          # one GET per page
 
     # Second call is served from cache — no further HTTP.
-    idx2 = client._get_collection_index()
+    idx2 = client._get_collection_index().index
     assert idx2 is idx
     assert client._http.request.call_count == 2
 
@@ -98,7 +110,7 @@ def test_first_instance_kept_for_duplicate_release():
             _item(111, 99, "Sister", ["Sonic Youth"]),   # duplicate copy
         ], 1, 1),
     ])
-    idx = client._get_collection_index()
+    idx = client._get_collection_index().index
     assert idx[111]["instance_id"] == 42             # first instance wins
 
 
@@ -106,40 +118,208 @@ def test_first_instance_kept_for_duplicate_release():
 # STAB-4 — the paging loop has an ABSOLUTE page cap (crash-loop rate-limit guard)
 # ---------------------------------------------------------------------------
 
-def test_stab4_paging_stops_at_absolute_cap_with_partial_index():
-    """A malformed / hostile ``pagination.pages`` (or a logic bug) must NOT let
-    the loop page without bound.  It must stop at an absolute ceiling, keep the
-    partial index it built, and cache it (so it is not re-hammered per track).
-
-    On today's uncapped ``while True`` this fetches until the fake's hard stop
-    trips (RED); after the fix it stops at the cap (GREEN).
-    """
+def test_page_cap_rejects_partial_index_and_preserves_prior_complete_snapshot(monkeypatch):
     from src.metadata.discogs import reader as reader_mod
+    monkeypatch.setattr(reader_mod, "_MAX_COLLECTION_PAGES", 2)
+    prior = {99: {"instance_id": 9, "title": "Known", "artists": ["A"]}}
+    client = make_discogs_reader()
+    client._collection_index = prior
+    client._collection_index_built_at = -reader_mod._COLLECTION_INDEX_TTL_SECONDS
+    monkeypatch.setattr(reader_mod.time, "monotonic", lambda: reader_mod._COLLECTION_INDEX_TTL_SECONDS + 1)
+    client._http.request = MagicMock(side_effect=[
+        _page([_item(1, 1, "One", ["A"])], 1, 3, per_page=1, items=3),
+        _page([_item(2, 2, "Two", ["A"])], 2, 3, per_page=1, items=3),
+    ])
 
-    HARD_STOP = 5000            # today's unbounded loop blows past any sane cap
-    calls = {"n": 0}
+    with pytest.raises(reader_mod.CollectionIndexIncomplete):
+        client._get_collection_index()
 
-    def hostile_request(method, url, params=None):
-        calls["n"] += 1
-        if calls["n"] > HARD_STOP:
-            raise AssertionError(f"unbounded paging: fetched >{HARD_STOP} pages")
-        page = params["page"]
-        # Every page is full and pagination claims a billion pages, so the only
-        # thing that can end this loop is an absolute cap.
-        return _page([_item(page, page, f"T{page}", ["A"])], page, 10 ** 9)
+    assert client._collection_index is prior
+    assert client._collection_index_built_at == -reader_mod._COLLECTION_INDEX_TTL_SECONDS
 
+
+def test_page_cap_without_prior_snapshot_leaves_index_unavailable(monkeypatch):
+    from src.metadata.discogs import reader as reader_mod
+    monkeypatch.setattr(reader_mod, "_MAX_COLLECTION_PAGES", 1)
     client = make_discogs_reader()
     client._collection_index = None
-    client._http.request = MagicMock(side_effect=hostile_request)
+    client._http.request = MagicMock(return_value=_page(
+        [_item(1, 1, "One", ["A"])], 1, 2, per_page=1, items=2
+    ))
 
-    idx = client._get_collection_index()               # must RETURN, not run away
+    with pytest.raises(reader_mod.CollectionIndexIncomplete):
+        client._get_collection_index()
 
-    cap = reader_mod._MAX_COLLECTION_PAGES
-    assert calls["n"] == cap                            # stopped exactly at the cap
-    assert len(idx) == cap                              # partial index preserved
-    # Cached: a second call makes no further HTTP (not re-hammered per track).
-    client._get_collection_index()
-    assert client._http.request.call_count == cap
+    assert client._collection_index is None
+
+
+def test_failed_build_backoff_prevents_second_page_walk_with_prior_snapshot(monkeypatch):
+    from src.metadata.discogs import reader as reader_mod
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(reader_mod.time, "monotonic", lambda: clock["t"])
+    prior = {99: {"instance_id": 9, "title": "Known", "artists": ["A"]}}
+    client = make_discogs_reader()
+    client._collection_index = prior
+    client._collection_index_built_at = -reader_mod._COLLECTION_INDEX_TTL_SECONDS
+    client._http.request = MagicMock(side_effect=ConnectionError("down"))
+
+    with pytest.raises(reader_mod.CollectionIndexIncomplete):
+        client._get_collection_index()
+    calls = client._http.request.call_count
+    view = client._get_collection_index()
+
+    assert view.index is prior
+    assert view.misses_are_authoritative is False
+    assert client._http.request.call_count == calls
+
+
+def test_failed_build_backoff_prevents_second_page_walk_without_snapshot(monkeypatch):
+    from src.metadata.discogs import reader as reader_mod
+    monkeypatch.setattr(reader_mod.time, "monotonic", lambda: 1000.0)
+    client = make_discogs_reader()
+    client._collection_index = None
+    client._http.request = MagicMock(side_effect=ConnectionError("down"))
+
+    with pytest.raises(reader_mod.CollectionIndexIncomplete):
+        client._get_collection_index()
+    calls = client._http.request.call_count
+    with pytest.raises(reader_mod.CollectionOwnershipUnknown):
+        client._get_collection_index()
+
+    assert client._http.request.call_count == calls
+
+
+def test_build_backoff_serves_positive_from_prior_snapshot(monkeypatch):
+    from src.metadata.discogs import reader as reader_mod
+    monkeypatch.setattr(reader_mod.time, "monotonic", lambda: 1000.0)
+    client = make_discogs_reader()
+    client._collection_index = {1: {"instance_id": 7, "title": "Sister", "artists": ["Sonic Youth"]}}
+    client._collection_index_built_at = -reader_mod._COLLECTION_INDEX_TTL_SECONDS
+    client._http.request = MagicMock(side_effect=ConnectionError("down"))
+    with pytest.raises(reader_mod.CollectionIndexIncomplete):
+        client._get_collection_index()
+    client._database_search = MagicMock(return_value=[])
+    client._client.release = MagicMock(return_value=MagicMock(id=1))
+    client._build_result = MagicMock(return_value={"instance_id": 7})
+
+    assert client.search_collection("Sonic Youth", "Sister") == {"instance_id": 7}
+
+
+def test_build_backoff_miss_is_unknown_not_clean(monkeypatch):
+    from src.metadata.discogs import reader as reader_mod
+    monkeypatch.setattr(reader_mod.time, "monotonic", lambda: 1000.0)
+    client = make_discogs_reader()
+    client._collection_index = {1: {"instance_id": 7, "title": "Goo", "artists": ["Sonic Youth"]}}
+    client._collection_index_built_at = -reader_mod._COLLECTION_INDEX_TTL_SECONDS
+    client._http.request = MagicMock(side_effect=ConnectionError("down"))
+    with pytest.raises(reader_mod.CollectionIndexIncomplete):
+        client._get_collection_index()
+    client._database_search = MagicMock(return_value=[])
+
+    with pytest.raises(reader_mod.CollectionOwnershipUnknown):
+        client.search_collection("Sonic Youth", "Sister")
+
+
+def test_build_backoff_refusal_does_not_change_speculative_cooldown_state(monkeypatch):
+    from src.metadata.discogs import reader as reader_mod
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(reader_mod.time, "monotonic", lambda: clock["t"])
+    client = make_discogs_reader()
+    client._last_collection_build_failure_at = clock["t"]
+    client._last_index_refresh_at = -1000.0
+
+    with pytest.raises(reader_mod.CollectionOwnershipUnknown):
+        client.refresh_index_and_research("Sonic Youth", "Sister")
+
+    assert client._last_index_refresh_at == -1000.0
+
+
+def test_successful_complete_rebuild_clears_failure_backoff(monkeypatch):
+    from src.metadata.discogs import reader as reader_mod
+    monkeypatch.setattr(reader_mod.time, "monotonic", lambda: 2000.0)
+    client = make_discogs_reader()
+    client._last_collection_build_failure_at = 2000.0 - reader_mod._COLLECTION_BUILD_FAILURE_BACKOFF_SECONDS - 1
+    client._collection_index = None
+    client._http.request = MagicMock(return_value=_page([], 1, 1, per_page=100, items=0))
+
+    view = client._get_collection_index()
+
+    assert view.index == {}
+    assert client._last_collection_build_failure_at is None
+
+
+def test_complete_multi_page_duplicate_release_counts_raw_rows(monkeypatch):
+    from src.metadata.discogs import reader as reader_mod
+    monkeypatch.setattr(reader_mod.time, "monotonic", lambda: 1000.0)
+    client = make_discogs_reader()
+    client._collection_index = None
+    client._http.request = MagicMock(side_effect=[
+        _page([_item(1, 7, "One", ["A"]), _item(2, 8, "Two", ["A"])], 1, 2,
+              per_page=2, items=3),
+        _page([_item(1, 9, "One", ["A"])], 2, 2, per_page=2, items=3),
+    ])
+
+    view = client._get_collection_index()
+
+    assert set(view.index) == {1, 2}
+    assert view.index[1]["instance_id"] == 7
+
+
+def test_advertised_pages_beyond_cap_never_promotes_candidate_index(monkeypatch):
+    from src.metadata.discogs import reader as reader_mod
+    monkeypatch.setattr(reader_mod, "_MAX_COLLECTION_PAGES", 1)
+    client = make_discogs_reader()
+    prior = {99: {"instance_id": 9, "title": "Known", "artists": ["A"]}}
+    client._collection_index = prior
+    client._collection_index_built_at = 0
+    monkeypatch.setattr(reader_mod.time, "monotonic", lambda: reader_mod._COLLECTION_INDEX_TTL_SECONDS + 1)
+    client._http.request = MagicMock(return_value=_page(
+        [_item(1, 1, "One", ["A"])], 1, 2, per_page=1, items=2
+    ))
+
+    with pytest.raises(reader_mod.CollectionIndexIncomplete):
+        client._get_collection_index()
+
+    assert client._collection_index is prior
+
+
+@pytest.mark.parametrize("responses", [
+    [{"releases": [], "pagination": None}],
+    [{"releases": [], "pagination": {"page": 2, "pages": 1, "per_page": 100, "items": 0}}],
+    [
+        {"releases": [_item(1, 1, "One", ["A"])], "pagination": {"page": 1, "pages": 2, "per_page": 1, "items": 2}},
+        {"releases": [_item(2, 2, "Two", ["A"])], "pagination": {"page": 2, "pages": 3, "per_page": 1, "items": 2}},
+    ],
+    [
+        {"releases": [_item(1, 1, "One", ["A"])], "pagination": {"page": 1, "pages": 2, "per_page": 1, "items": 2}},
+        {"releases": [_item(2, 2, "Two", ["A"])], "pagination": {"page": 2, "pages": 2, "per_page": 1, "items": 3}},
+    ],
+    [{"releases": [], "pagination": {"page": 1, "pages": 1, "per_page": True, "items": 0}}],
+    [{"releases": [_item(True, 1, "One", ["A"])], "pagination": {"page": 1, "pages": 1, "per_page": 1, "items": 1}}],
+    [{"releases": [_item(1, False, "One", ["A"])], "pagination": {"page": 1, "pages": 1, "per_page": 1, "items": 1}}],
+    [
+        {"releases": [_item(1, 1, "One", ["A"])], "pagination": {"page": 1, "pages": 2, "per_page": 1, "items": 2}},
+        {"releases": [], "pagination": {"page": 2, "pages": 2, "per_page": 1, "items": 2}},
+    ],
+])
+def test_incomplete_pagination_never_promotes_candidate_index(monkeypatch, responses):
+    from src.metadata.discogs import reader as reader_mod
+    prior = {99: {"instance_id": 9, "title": "Known", "artists": ["A"]}}
+    client = make_discogs_reader()
+    client._collection_index = prior
+    client._collection_index_built_at = 0
+    monkeypatch.setattr(reader_mod.time, "monotonic", lambda: reader_mod._COLLECTION_INDEX_TTL_SECONDS + 1)
+    mocked = []
+    for data in responses:
+        response = MagicMock(status_code=200)
+        response.json.return_value = data
+        mocked.append(response)
+    client._http.request = MagicMock(side_effect=mocked)
+
+    with pytest.raises(reader_mod.CollectionIndexIncomplete):
+        client._get_collection_index()
+
+    assert client._collection_index is prior
 
 
 def test_stab4_cap_is_generous_enough_for_any_real_collection():

--- a/tests/test_discogs_collection_index.py
+++ b/tests/test_discogs_collection_index.py
@@ -283,6 +283,24 @@ def test_advertised_pages_beyond_cap_never_promotes_candidate_index(monkeypatch)
     assert client._collection_index is prior
 
 
+def test_advertised_extra_empty_final_page_never_promotes_candidate_index():
+    """The metadata cannot advertise a second empty page after all claimed
+    items were already supplied by page one."""
+    from src.metadata.discogs import reader as reader_mod
+
+    client = make_discogs_reader()
+    client._collection_index = None
+    client._http.request = MagicMock(side_effect=[
+        _page([_item(1, 1, "One", ["A"])], 1, 2, per_page=1, items=1),
+        _page([], 2, 2, per_page=1, items=1),
+    ])
+
+    with pytest.raises(reader_mod.CollectionIndexIncomplete):
+        client._get_collection_index()
+
+    assert client._collection_index is None
+
+
 @pytest.mark.parametrize("responses", [
     [{"releases": [], "pagination": None}],
     [{"releases": [], "pagination": {"page": 2, "pages": 1, "per_page": 100, "items": 0}}],

--- a/tests/test_discogs_search_errors.py
+++ b/tests/test_discogs_search_errors.py
@@ -43,11 +43,14 @@ def test_database_search_returns_empty_on_genuine_no_match():
 # ---------------------------------------------------------------------------
 
 def test_collection_index_build_error_propagates():
+    from src.metadata.discogs.reader import CollectionIndexIncomplete
+
     client = make_discogs_reader()
     client._collection_index = None
     client._http.request = MagicMock(side_effect=requests.exceptions.Timeout("slow"))
-    with pytest.raises(requests.exceptions.Timeout):
+    with pytest.raises(CollectionIndexIncomplete) as raised:
         client.search_collection("artist", "album")
+    assert isinstance(raised.value.__cause__, requests.exceptions.Timeout)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_finalize_retry_after.py
+++ b/tests/test_finalize_retry_after.py
@@ -17,6 +17,10 @@ from src.tracking.listen_tracker import (
     _HONORED_RETRY_AFTER_CAP_SECONDS,
 )
 from src.metadata.discogs.transport import DiscogsRateLimited
+from src.metadata.discogs.outcomes import (
+    CollectionIdentity, PlayCountReadResult, PlayCountReadState,
+)
+from src.metadata.models import PlaySession
 from tests.test_listen_tracker import make_writer_mock
 
 
@@ -102,3 +106,32 @@ async def test_finalize_generic_exception_still_linear_backoff():
         _FINALIZE_RETRY_BACKOFF_SECONDS * n
         for n in range(1, _FINALIZE_WRITE_ATTEMPTS)
     ]
+
+
+async def test_rate_limited_replacement_read_does_not_replenish_recovery_budget():
+    """#229 can retry a throttled replacement read, never the recovery itself."""
+    writer = make_writer_mock()
+    writer.read_play_count.side_effect = [
+        PlayCountReadResult(
+            PlayCountReadState.DEFINITIVE_INSTANCE_MISSING,
+            observed_instance_ids=(88,),
+        ),
+        DiscogsRateLimited(60),
+        PlayCountReadResult(PlayCountReadState.READY, 3, 4),
+    ]
+    recovery = AsyncMock(return_value=CollectionIdentity(999, 88))
+    tracker = ListenTracker(writer=writer, recover_collection_instance=recovery)
+    session = PlaySession(
+        album_release_id=999,
+        album_instance_id=77,
+        album_resolve_key=("sonic youth", "sister"),
+    )
+
+    with patch(
+        "src.tracking.listen_tracker.asyncio.sleep", new_callable=AsyncMock
+    ) as sleep:
+        await tracker._credit_completed_album(session)
+
+    recovery.assert_awaited_once_with(("sonic youth", "sister"), 999, 77, (88,))
+    writer.set_play_count.assert_called_once_with(999, 88, 3, 4, 5)
+    assert [call.args[0] for call in sleep.call_args_list] == [60.0]

--- a/tests/test_listen_tracker.py
+++ b/tests/test_listen_tracker.py
@@ -25,7 +25,9 @@ from src.audio.silence import AudioEvent
 from src.metadata.models import (
     MetadataSource, TracklistEntry, TrackMetadata, PlaySession
 )
-from src.metadata.discogs.outcomes import PlayCountReadResult, PlayCountReadState
+from src.metadata.discogs.outcomes import (
+    CollectionIdentity, PlayCountReadResult, PlayCountReadState,
+)
 from src.tracking.listen_tracker import ListenTracker
 
 
@@ -115,6 +117,7 @@ def make_tracker(
     increment_play_count_return=True,
     last_played_field_name=None,
     update_last_played_return=True,
+    recover_collection_instance=None,
 ):
     writer = make_writer_mock(
         increment_play_count_return=increment_play_count_return,
@@ -122,8 +125,197 @@ def make_tracker(
         update_last_played_return=update_last_played_return,
     )
     # A-4: ListenTracker takes a DiscogsCollectionWriter directly.
-    tracker = ListenTracker(writer)
+    tracker = ListenTracker(
+        writer, recover_collection_instance=recover_collection_instance,
+    )
     return tracker, writer
+
+
+# ---------------------------------------------------------------------------
+# #421 — one safe collection-instance replacement before absolute credit plan
+# ---------------------------------------------------------------------------
+
+def _latched_session(resolve_key=("sonic youth", "sister")):
+    session = PlaySession()
+    session.album_release_id = 999
+    session.album_instance_id = 77
+    session.album_resolve_key = resolve_key
+    return session
+
+
+@pytest.mark.asyncio
+async def test_definitive_missing_recovers_same_release_new_instance_once():
+    """A proven-stale instance may make exactly one safe same-release retry."""
+    writer = make_writer_mock(last_played_field_name="Last Played")
+    writer.read_play_count.side_effect = [
+        PlayCountReadResult(
+            PlayCountReadState.DEFINITIVE_INSTANCE_MISSING,
+            observed_instance_ids=(88,),
+        ),
+        PlayCountReadResult(PlayCountReadState.READY, 3, 4),
+    ]
+    recovery = AsyncMock(return_value=CollectionIdentity(999, 88))
+    tracker = ListenTracker(writer, recover_collection_instance=recovery)
+    session = _latched_session()
+
+    await tracker._credit_completed_album(session)
+
+    recovery.assert_awaited_once_with(("sonic youth", "sister"), 999, 77, (88,))
+    writer.set_play_count.assert_called_once_with(999, 88, 3, 4, 5)
+    writer.update_last_played.assert_called_once_with(999, 88)
+    assert (session.album_release_id, session.album_instance_id) == (999, 88)
+    assert session.credited is True
+
+
+@pytest.mark.asyncio
+async def test_abort_read_never_invokes_identity_recovery():
+    writer = make_writer_mock()
+    writer.read_play_count.return_value = PlayCountReadResult(PlayCountReadState.ABORT)
+    recovery = AsyncMock(return_value=CollectionIdentity(999, 88))
+    tracker = ListenTracker(writer, recover_collection_instance=recovery)
+
+    await tracker._credit_completed_album(_latched_session())
+
+    recovery.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recovery_refusal_writes_neither_discogs_field():
+    writer = make_writer_mock(last_played_field_name="Last Played")
+    writer.read_play_count.return_value = PlayCountReadResult(
+        PlayCountReadState.DEFINITIVE_INSTANCE_MISSING,
+        observed_instance_ids=(88,),
+    )
+    recovery = AsyncMock(return_value=None)
+    tracker = ListenTracker(writer, recover_collection_instance=recovery)
+
+    await tracker._credit_completed_album(_latched_session())
+
+    recovery.assert_awaited_once()
+    writer.set_play_count.assert_not_called()
+    writer.update_last_played.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_second_definitive_missing_stops_both_field_writes():
+    writer = make_writer_mock(last_played_field_name="Last Played")
+    writer.read_play_count.side_effect = [
+        PlayCountReadResult(
+            PlayCountReadState.DEFINITIVE_INSTANCE_MISSING,
+            observed_instance_ids=(88,),
+        ),
+        PlayCountReadResult(
+            PlayCountReadState.DEFINITIVE_INSTANCE_MISSING,
+            observed_instance_ids=(),
+        ),
+    ]
+    recovery = AsyncMock(return_value=CollectionIdentity(999, 88))
+    tracker = ListenTracker(writer, recover_collection_instance=recovery)
+
+    await tracker._credit_completed_album(_latched_session())
+
+    recovery.assert_awaited_once()
+    writer.set_play_count.assert_not_called()
+    writer.update_last_played.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_replacement_abort_skips_play_count_but_updates_last_played_once():
+    writer = make_writer_mock(last_played_field_name="Last Played")
+    writer.read_play_count.side_effect = [
+        PlayCountReadResult(
+            PlayCountReadState.DEFINITIVE_INSTANCE_MISSING,
+            observed_instance_ids=(88,),
+        ),
+        PlayCountReadResult(PlayCountReadState.ABORT),
+    ]
+    tracker = ListenTracker(
+        writer, recover_collection_instance=AsyncMock(return_value=CollectionIdentity(999, 88)),
+    )
+
+    await tracker._credit_completed_album(_latched_session())
+
+    writer.set_play_count.assert_not_called()
+    writer.update_last_played.assert_called_once_with(999, 88)
+
+
+@pytest.mark.asyncio
+async def test_recovered_play_count_failure_still_updates_last_played_on_replacement():
+    writer = make_writer_mock(
+        increment_play_count_return=False, last_played_field_name="Last Played",
+    )
+    writer.read_play_count.side_effect = [
+        PlayCountReadResult(
+            PlayCountReadState.DEFINITIVE_INSTANCE_MISSING,
+            observed_instance_ids=(88,),
+        ),
+        PlayCountReadResult(PlayCountReadState.READY, 3, 4),
+    ]
+    tracker = ListenTracker(
+        writer, recover_collection_instance=AsyncMock(return_value=CollectionIdentity(999, 88)),
+    )
+
+    with patch("src.tracking.listen_tracker.asyncio.sleep", new=AsyncMock()):
+        await tracker._credit_completed_album(_latched_session())
+
+    assert writer.set_play_count.call_count == 3
+    assert all(call.args[:2] == (999, 88) for call in writer.set_play_count.call_args_list)
+    writer.update_last_played.assert_called_once_with(999, 88)
+
+
+@pytest.mark.asyncio
+async def test_recovery_uses_latched_key_stale_pair_and_observed_tuple():
+    writer = make_writer_mock()
+    writer.read_play_count.side_effect = [
+        PlayCountReadResult(
+            PlayCountReadState.DEFINITIVE_INSTANCE_MISSING,
+            observed_instance_ids=(88, 89),
+        ),
+    ]
+    recovery = AsyncMock(return_value=None)
+    tracker = ListenTracker(writer, recover_collection_instance=recovery)
+    session = _latched_session(("latched artist", "latched album"))
+
+    await tracker._credit_completed_album(session)
+
+    recovery.assert_awaited_once_with(
+        ("latched artist", "latched album"), 999, 77, (88, 89),
+    )
+
+
+@pytest.mark.asyncio
+async def test_recovery_callback_is_spent_at_most_once():
+    writer = make_writer_mock(last_played_field_name="Last Played")
+    writer.read_play_count.side_effect = [
+        PlayCountReadResult(
+            PlayCountReadState.DEFINITIVE_INSTANCE_MISSING,
+            observed_instance_ids=(88,),
+        ),
+        PlayCountReadResult(
+            PlayCountReadState.DEFINITIVE_INSTANCE_MISSING,
+            observed_instance_ids=(89,),
+        ),
+    ]
+    recovery = AsyncMock(return_value=CollectionIdentity(999, 88))
+    tracker = ListenTracker(writer, recover_collection_instance=recovery)
+
+    await tracker._credit_completed_album(_latched_session())
+
+    recovery.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_missing_recovery_callback_preserves_fail_closed_behavior():
+    writer = make_writer_mock(last_played_field_name="Last Played")
+    writer.read_play_count.return_value = PlayCountReadResult(
+        PlayCountReadState.DEFINITIVE_INSTANCE_MISSING,
+        observed_instance_ids=(88,),
+    )
+
+    await ListenTracker(writer)._credit_completed_album(_latched_session())
+
+    writer.set_play_count.assert_not_called()
+    writer.update_last_played.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_listen_tracker.py
+++ b/tests/test_listen_tracker.py
@@ -197,6 +197,42 @@ async def test_recovery_refusal_writes_neither_discogs_field():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("observed_instance_ids", "callback_instance_id"),
+    [
+        ((88,), 89),
+        ((88, 89), 88),
+        ((), 88),
+    ],
+    ids=["different-singleton", "multiple-observed", "empty-observed"],
+)
+async def test_recovery_requires_the_writer_proven_singleton_replacement(
+    observed_instance_ids, callback_instance_id,
+):
+    """A callback cannot turn incomplete or mismatched evidence into a write."""
+    writer = make_writer_mock(last_played_field_name="Last Played")
+    writer.read_play_count.side_effect = [
+        PlayCountReadResult(
+            PlayCountReadState.DEFINITIVE_INSTANCE_MISSING,
+            observed_instance_ids=observed_instance_ids,
+        ),
+        PlayCountReadResult(PlayCountReadState.READY, 3, 4),
+    ]
+    recovery = AsyncMock(return_value=CollectionIdentity(999, callback_instance_id))
+    tracker = ListenTracker(writer, recover_collection_instance=recovery)
+    session = _latched_session()
+
+    await tracker._credit_completed_album(session)
+
+    recovery.assert_awaited_once_with(
+        ("sonic youth", "sister"), 999, 77, observed_instance_ids,
+    )
+    writer.set_play_count.assert_not_called()
+    writer.update_last_played.assert_not_called()
+    assert (session.album_release_id, session.album_instance_id) == (999, 77)
+
+
+@pytest.mark.asyncio
 async def test_second_definitive_missing_stops_both_field_writes():
     writer = make_writer_mock(last_played_field_name="Last Played")
     writer.read_play_count.side_effect = [
@@ -233,8 +269,62 @@ async def test_replacement_abort_skips_play_count_but_updates_last_played_once()
         writer, recover_collection_instance=AsyncMock(return_value=CollectionIdentity(999, 88)),
     )
 
-    await tracker._credit_completed_album(_latched_session())
+    with patch("src.tracking.listen_tracker.asyncio.sleep", new=AsyncMock()) as sleep:
+        await tracker._credit_completed_album(_latched_session())
 
+    assert writer.read_play_count.call_count == 2
+    sleep.assert_not_awaited()
+    writer.set_play_count.assert_not_called()
+    writer.update_last_played.assert_called_once_with(999, 88)
+
+
+@pytest.mark.asyncio
+async def test_replacement_abort_never_continues_to_a_later_ready_read():
+    writer = make_writer_mock(last_played_field_name="Last Played")
+    writer.read_play_count.side_effect = [
+        PlayCountReadResult(
+            PlayCountReadState.DEFINITIVE_INSTANCE_MISSING,
+            observed_instance_ids=(88,),
+        ),
+        PlayCountReadResult(PlayCountReadState.ABORT),
+        PlayCountReadResult(PlayCountReadState.READY, 3, 4),
+    ]
+    tracker = ListenTracker(
+        writer, recover_collection_instance=AsyncMock(return_value=CollectionIdentity(999, 88)),
+    )
+
+    with patch("src.tracking.listen_tracker.asyncio.sleep", new=AsyncMock()) as sleep:
+        await tracker._credit_completed_album(_latched_session())
+
+    assert writer.read_play_count.call_count == 2
+    sleep.assert_not_awaited()
+    writer.set_play_count.assert_not_called()
+    writer.update_last_played.assert_called_once_with(999, 88)
+
+
+@pytest.mark.asyncio
+async def test_replacement_abort_never_continues_to_a_later_missing_read():
+    writer = make_writer_mock(last_played_field_name="Last Played")
+    writer.read_play_count.side_effect = [
+        PlayCountReadResult(
+            PlayCountReadState.DEFINITIVE_INSTANCE_MISSING,
+            observed_instance_ids=(88,),
+        ),
+        PlayCountReadResult(PlayCountReadState.ABORT),
+        PlayCountReadResult(
+            PlayCountReadState.DEFINITIVE_INSTANCE_MISSING,
+            observed_instance_ids=(),
+        ),
+    ]
+    tracker = ListenTracker(
+        writer, recover_collection_instance=AsyncMock(return_value=CollectionIdentity(999, 88)),
+    )
+
+    with patch("src.tracking.listen_tracker.asyncio.sleep", new=AsyncMock()) as sleep:
+        await tracker._credit_completed_album(_latched_session())
+
+    assert writer.read_play_count.call_count == 2
+    sleep.assert_not_awaited()
     writer.set_play_count.assert_not_called()
     writer.update_last_played.assert_called_once_with(999, 88)
 

--- a/tests/test_listen_tracker.py
+++ b/tests/test_listen_tracker.py
@@ -197,6 +197,34 @@ async def test_recovery_refusal_writes_neither_discogs_field():
 
 
 @pytest.mark.asyncio
+async def test_recovery_callback_exception_logs_only_safe_stage_and_identity_context(caplog):
+    """Recovery failures cannot expose raw response/custom-field exception text."""
+    writer = make_writer_mock(last_played_field_name="Last Played")
+    writer.read_play_count.return_value = PlayCountReadResult(
+        PlayCountReadState.DEFINITIVE_INSTANCE_MISSING,
+        observed_instance_ids=(88,),
+    )
+    secret_body = "PRIVATE-CUSTOM-FIELD-BODY"
+    sentinel = "UNREDACTED-RECOVERY-SENTINEL"
+
+    async def failing_recovery(*_args):
+        raise RuntimeError(f"{secret_body} {sentinel}")
+
+    tracker = ListenTracker(writer, recover_collection_instance=failing_recovery)
+    with caplog.at_level(logging.WARNING):
+        await tracker._credit_completed_album(_latched_session())
+
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "stage=recovery-callback-failed" in messages
+    assert "expected_release_id=999" in messages
+    assert "expected_instance_id=77" in messages
+    assert secret_body not in messages
+    assert sentinel not in messages
+    writer.set_play_count.assert_not_called()
+    writer.update_last_played.assert_not_called()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("observed_instance_ids", "callback_instance_id"),
     [

--- a/tests/test_listen_tracker.py
+++ b/tests/test_listen_tracker.py
@@ -25,6 +25,7 @@ from src.audio.silence import AudioEvent
 from src.metadata.models import (
     MetadataSource, TracklistEntry, TrackMetadata, PlaySession
 )
+from src.metadata.discogs.outcomes import PlayCountReadResult, PlayCountReadState
 from src.tracking.listen_tracker import ListenTracker
 
 
@@ -53,7 +54,9 @@ def make_writer_mock(
     # instance) — so one credit landing == one increment_play_count call, and any
     # return_value/side_effect a test configures on increment_play_count still
     # drives the set's outcome (success, failure, raise, DiscogsRateLimited).
-    writer.read_play_count.return_value = (3, 0)
+    writer.read_play_count.return_value = PlayCountReadResult(
+        PlayCountReadState.READY, 3, 0
+    )
     writer.set_play_count.side_effect = (
         lambda release_id, instance_id, field_id, current, target:
         writer.increment_play_count(release_id, instance_id)

--- a/tests/test_listen_tracker_conc2.py
+++ b/tests/test_listen_tracker_conc2.py
@@ -18,6 +18,11 @@ import asyncio
 import pytest
 
 from src.audio.silence import AudioEvent
+from src.metadata.discogs.outcomes import (
+    CollectionIdentity, PlayCountReadResult, PlayCountReadState,
+)
+from src.metadata.models import PlaySession
+from src.tracking.listen_tracker import ListenTracker
 from tests.test_listen_tracker import make_tracker, make_track
 
 
@@ -133,3 +138,99 @@ async def test_conc2_finalizes_are_serialized_no_concurrent_writer_calls():
     assert max_inside == 1                    # never two writer calls at once
     assert writer.increment_play_count.call_count == 2  # both did credit, serially
     assert writer.set_play_count.call_count == 2            # the serialized write ran twice
+
+
+@pytest.mark.asyncio
+async def test_conc2_recovery_finalizer_does_not_hold_lifecycle_lock():
+    """Recovery is finalize work, so a waiting resolver must not stall recognition."""
+    tracker, writer = make_tracker()
+    writer.read_play_count.return_value = PlayCountReadResult(
+        PlayCountReadState.DEFINITIVE_INSTANCE_MISSING,
+        observed_instance_ids=(88,),
+    )
+    entered_recovery = asyncio.Event()
+    release_recovery = asyncio.Event()
+
+    async def recovery(*_args):
+        entered_recovery.set()
+        await release_recovery.wait()
+        return None
+
+    tracker = ListenTracker(writer, recover_collection_instance=recovery)
+    stale = PlaySession()
+    stale.log_track(
+        make_track(
+            "Master-Dik", release_id=999, instance_id=77,
+            resolve_key=("sonic youth", "sister"),
+        )
+    )
+    finalize = asyncio.create_task(tracker._finalize_detached(stale))
+    await asyncio.wait_for(entered_recovery.wait(), timeout=1)
+
+    try:
+        await asyncio.wait_for(
+            tracker.on_track_identified(make_track("So What", release_id=333, instance_id=444)),
+            timeout=1,
+        )
+        recognized = True
+    except asyncio.TimeoutError:
+        recognized = False
+    finally:
+        release_recovery.set()
+        await finalize
+
+    assert recognized, "recovery finalizer held _lifecycle_lock"
+    assert tracker._session is not None
+    assert tracker._session.album_release_id == 333
+
+
+@pytest.mark.asyncio
+async def test_conc2_recovery_finalizers_remain_serialized():
+    """The recovery callback runs under the finalize queue, not concurrently."""
+    _tracker, writer = make_tracker()
+    recovery_entered = asyncio.Event()
+    release_recovery = asyncio.Event()
+    second_read_started = asyncio.Event()
+
+    def read(release_id, instance_id):
+        if instance_id == 77:
+            return PlayCountReadResult(
+                PlayCountReadState.DEFINITIVE_INSTANCE_MISSING,
+                observed_instance_ids=(88,),
+            )
+        second_read_started.set()
+        return PlayCountReadResult(PlayCountReadState.READY, 3, 0)
+
+    writer.read_play_count.side_effect = read
+    original_run = writer.run
+
+    async def run(fn, *args):
+        return await original_run(fn, *args)
+
+    writer.run = run
+
+    async def recovery(*_args):
+        recovery_entered.set()
+        await release_recovery.wait()
+        return CollectionIdentity(999, 88)
+
+    tracker = ListenTracker(writer, recover_collection_instance=recovery)
+    stale = PlaySession()
+    stale.log_track(
+        make_track(
+            "Master-Dik", release_id=999, instance_id=77,
+            resolve_key=("sonic youth", "sister"),
+        )
+    )
+    independent = PlaySession()
+    independent.log_track(make_track("Master-Dik", release_id=333, instance_id=444))
+    first = asyncio.create_task(tracker._finalize_detached(stale))
+    await asyncio.wait_for(recovery_entered.wait(), timeout=1)
+    second = asyncio.create_task(tracker._finalize_detached(independent))
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert not second_read_started.is_set(), "second finalizer bypassed _finalize_lock"
+
+    release_recovery.set()
+    await asyncio.gather(first, second)
+    assert second_read_started.is_set()

--- a/tests/test_main_wiring.py
+++ b/tests/test_main_wiring.py
@@ -444,6 +444,44 @@ def test_build_components_returns_wired_bundle(tmp_path):
     assert isinstance(components.tracker, ListenTracker)
 
 
+def test_build_components_injects_only_resolver_recovery_bound_method(monkeypatch, tmp_path):
+    """#421 keeps tracker metadata access to one narrow bound recovery port."""
+    captured = {}
+
+    class Resolver:
+        async def recover_collection_instance(self, *_args):
+            return None
+
+    resolver = Resolver()
+    monkeypatch.setattr(main_module, "DiscogsHttp", lambda *_args: MagicMock())
+    monkeypatch.setattr(main_module, "DiscogsReader", lambda *_args: MagicMock())
+    monkeypatch.setattr(main_module, "MetadataResolver", lambda *_args: resolver)
+    monkeypatch.setattr(main_module, "LastFmClient", lambda *_args: MagicMock())
+
+    def tracker_ctor(writer, lastfm, **kwargs):
+        captured["writer"] = writer
+        captured["lastfm"] = lastfm
+        captured.update(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr(main_module, "ListenTracker", tracker_ctor)
+    monkeypatch.setattr(main_module, "DiscogsCollectionWriter", lambda *_args: MagicMock())
+    monkeypatch.setattr(main_module, "TrackCommitService", lambda *_args: MagicMock())
+    monkeypatch.setattr(main_module, "DisplayRenderer", lambda *_args: MagicMock())
+    monkeypatch.setattr(main_module, "SilenceDetector", lambda *_args: MagicMock())
+    monkeypatch.setattr(main_module, "RecognitionLoop", lambda *_args: MagicMock())
+    from src.audio import capture as capture_module
+    monkeypatch.setattr(capture_module, "AudioCapture", lambda *_args: MagicMock())
+
+    build_components(
+        _app_config(cover_art_cache_dir=str(tmp_path / "cache")), PlayerState(),
+    )
+
+    injected = captured["recover_collection_instance"]
+    assert injected.__self__ is resolver
+    assert injected.__func__ is resolver.recover_collection_instance.__func__
+
+
 @pytest.mark.asyncio
 async def test_install_io_executor_routes_default_run_in_executor():
     """CRIT-3: after install_io_executor, every run_in_executor(None, …) runs on

--- a/tests/test_metadata_recovery_wave2.py
+++ b/tests/test_metadata_recovery_wave2.py
@@ -180,7 +180,12 @@ async def test_stale_instance_recovers_to_safe_replacement_and_credits_once():
 
     assert reader.rebuild_calls == 1
     assert len(gets) == 2
-    assert [body for _url, body in posts] == [{"value": "6"}]
+    assert len(posts) == 1
+    post_url, post_body = posts[0]
+    assert post_url.endswith(
+        "/collection/folders/0/releases/999/instances/88/fields/3"
+    )
+    assert post_body == {"value": "6"}
     assert (session.album_release_id, session.album_instance_id) == (_STALE_RELEASE_ID, 88)
     assert session.credited is True
     cached = resolver._cache_get(_KEY)

--- a/tests/test_metadata_recovery_wave2.py
+++ b/tests/test_metadata_recovery_wave2.py
@@ -1,0 +1,252 @@
+"""Cross-layer acceptance evidence for Wave 2 metadata recovery (#420/#421).
+
+These tests deliberately join the real resolver, tracker, and writer behavior.
+Only Discogs' collection-search/rebuild reader seam and HTTP transport seam are
+substituted, so the matrix protects the handoff between cache truth, definitive
+writer evidence, and the one safe absolute credit.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.audio.recognizer import RawRecognitionResult
+from src.metadata.discogs.outcomes import CollectionRefreshResult, CollectionRefreshState
+from src.metadata.models import MetadataSource, PlaySession
+from src.metadata.resolver import MetadataResolver
+from src.tracking.listen_tracker import ListenTracker
+from tests.factories import make_discogs_config, make_discogs_http, make_discogs_writer
+
+
+_KEY = ("sonic youth", "sister")
+_STALE_RELEASE_ID = 999
+_STALE_INSTANCE_ID = 77
+_PLAY_COUNT_FIELD_ID = 3
+
+
+def _response(body, status_code=200):
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = body
+    return response
+
+
+def _complete_snapshot(instances):
+    """Return the strict one-page writer snapshot used for missing proof."""
+    return {
+        "pagination": {
+            "page": 1,
+            "pages": 1,
+            "items": len(instances),
+            "per_page": max(1, len(instances)),
+        },
+        "releases": instances,
+    }
+
+
+class _ReaderSeam:
+    """Small synchronous reader seam driven through the resolver's real gate."""
+
+    def __init__(self, *, rebuild_result=None):
+        self.rebuild_result = rebuild_result
+        self.refresh_attempts = 0
+        self.page_walks = 0
+        self.rebuild_calls = 0
+
+    async def run(self, fn, *args):
+        return fn(*args)
+
+    def search_collection(self, _artist, _album):
+        return None
+
+    def search_database(self, _artist, _album):
+        return {
+            "album": "Sister",
+            "release_id": _STALE_RELEASE_ID,
+            "instance_id": None,
+            "tracklist": [],
+            "genres": [],
+        }
+
+    def refresh_index_and_research(self, _artist, _album):
+        self.refresh_attempts += 1
+        if self.refresh_attempts == 1:
+            self.page_walks += 1
+            raise ConnectionError("simulated collection page failure")
+        return CollectionRefreshResult(
+            CollectionRefreshState.COOLDOWN_SKIPPED,
+            cooldown_follows_successful_rebuild=False,
+        )
+
+    def rebuild_collection_and_research(self, _artist, _album):
+        self.rebuild_calls += 1
+        return self.rebuild_result
+
+
+def _resolver(reader):
+    resolver = MetadataResolver(reader, coverart=MagicMock())
+    resolver.coverart.get_cover_art_url.return_value = None
+    return resolver
+
+
+def _session():
+    session = PlaySession()
+    session.album_release_id = _STALE_RELEASE_ID
+    session.album_instance_id = _STALE_INSTANCE_ID
+    session.album_resolve_key = _KEY
+    return session
+
+
+def _writer_with_http_responses(*responses):
+    """Build the real writer with a deterministic, no-network HTTP seam."""
+    http = make_discogs_http()
+    writer = make_discogs_writer(
+        http=http,
+        config=make_discogs_config(last_played_field_name=None),
+    )
+    writer._collection_fields = {"Play Count": _PLAY_COUNT_FIELD_ID}
+    gets = []
+    posts = []
+    pending = iter(responses)
+
+    def fake_get(url, **_kwargs):
+        gets.append(url)
+        return next(pending)
+
+    def fake_post(url, **kwargs):
+        posts.append((url, kwargs["json"]))
+        return _response({}, status_code=204)
+
+    http.session.get = fake_get
+    http.session.post = fake_post
+    return writer, gets, posts
+
+
+def _stale_cache_payload(instance_id=_STALE_INSTANCE_ID):
+    return {
+        "album": "Sister",
+        "release_id": _STALE_RELEASE_ID,
+        "instance_id": instance_id,
+        "tracklist": [],
+        "genres": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_failed_refresh_then_cooldown_skip_returns_database_uncached():
+    """#420: failed refresh provenance forbids a false database downgrade cache."""
+    reader = _ReaderSeam()
+    resolver = _resolver(reader)
+    raw = RawRecognitionResult("Schizophrenia", "Sonic Youth", "Sister")
+
+    first = await resolver.resolve(raw)
+    second = await resolver.resolve(raw)
+
+    assert (first.source, second.source) == (
+        MetadataSource.DISCOGS_DATABASE,
+        MetadataSource.DISCOGS_DATABASE,
+    )
+    assert len(resolver._album_cache) == 0
+    assert reader.page_walks == 1
+    assert reader.refresh_attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_stale_instance_recovers_to_safe_replacement_and_credits_once():
+    """#421: a strict MISSING tuple permits one same-release replacement credit."""
+    reader = _ReaderSeam(rebuild_result=_stale_cache_payload(instance_id=88))
+    resolver = _resolver(reader)
+    resolver._cache_store(_KEY, MetadataSource.DISCOGS_COLLECTION, _stale_cache_payload())
+    writer, gets, posts = _writer_with_http_responses(
+        _response(_complete_snapshot([
+            {
+                "instance_id": 88,
+                "folder_id": 0,
+                "basic_information": {"id": _STALE_RELEASE_ID},
+                "notes": [],
+            },
+        ])),
+        _response({"releases": [
+            {
+                "instance_id": 88,
+                "notes": [{"field_id": _PLAY_COUNT_FIELD_ID, "value": "5"}],
+            },
+        ]}),
+    )
+    tracker = ListenTracker(writer, recover_collection_instance=resolver.recover_collection_instance)
+    session = _session()
+
+    await tracker._credit_completed_album(session)
+
+    assert reader.rebuild_calls == 1
+    assert len(gets) == 2
+    assert [body for _url, body in posts] == [{"value": "6"}]
+    assert (session.album_release_id, session.album_instance_id) == (_STALE_RELEASE_ID, 88)
+    assert session.credited is True
+    cached = resolver._cache_get(_KEY)
+    assert cached is not None
+    assert cached[0] is MetadataSource.DISCOGS_COLLECTION
+    assert cached[1]["instance_id"] == 88
+
+
+@pytest.mark.asyncio
+async def test_duplicate_replacement_instances_never_select_or_cache_a_write_target():
+    """#421: multiplicity is a refusal, not permission to choose the first copy."""
+    reader = _ReaderSeam(rebuild_result=_stale_cache_payload(instance_id=88))
+    resolver = _resolver(reader)
+    resolver._cache_store(_KEY, MetadataSource.DISCOGS_COLLECTION, _stale_cache_payload())
+    writer, gets, posts = _writer_with_http_responses(
+        _response(_complete_snapshot([
+            {
+                "instance_id": 88,
+                "folder_id": 0,
+                "basic_information": {"id": _STALE_RELEASE_ID},
+                "notes": [],
+            },
+            {
+                "instance_id": 89,
+                "folder_id": 0,
+                "basic_information": {"id": _STALE_RELEASE_ID},
+                "notes": [],
+            },
+        ])),
+    )
+    tracker = ListenTracker(writer, recover_collection_instance=resolver.recover_collection_instance)
+
+    await tracker._credit_completed_album(_session())
+
+    assert len(gets) == 1
+    assert reader.rebuild_calls == 0
+    assert posts == []
+    assert resolver._cache_get(_KEY) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "malformed_instance",
+    [
+        {"instance_id": 88, "basic_information": {"id": _STALE_RELEASE_ID}},
+        {"instance_id": 88, "folder_id": 0},
+        {"instance_id": "88", "folder_id": 0, "basic_information": {"id": _STALE_RELEASE_ID}},
+        {"instance_id": 0, "folder_id": 0, "basic_information": {"id": _STALE_RELEASE_ID}},
+        {"instance_id": -88, "folder_id": 0, "basic_information": {"id": _STALE_RELEASE_ID}},
+    ],
+    ids=["missing-folder", "missing-basic-information", "string-id", "zero-id", "negative-id"],
+)
+async def test_malformed_missing_snapshot_never_escapes_to_recovery_or_post(malformed_instance):
+    """Deferred Task 2 shapes remain ABORTs through the complete tracker path."""
+    reader = _ReaderSeam(rebuild_result=_stale_cache_payload(instance_id=88))
+    resolver = _resolver(reader)
+    resolver._cache_store(_KEY, MetadataSource.DISCOGS_COLLECTION, _stale_cache_payload())
+    writer, _gets, posts = _writer_with_http_responses(
+        _response(_complete_snapshot([malformed_instance])),
+    )
+    tracker = ListenTracker(writer, recover_collection_instance=resolver.recover_collection_instance)
+
+    await tracker._credit_completed_album(_session())
+
+    assert reader.rebuild_calls == 0
+    assert posts == []
+    cached = resolver._cache_get(_KEY)
+    assert cached is not None
+    assert cached[1]["instance_id"] == _STALE_INSTANCE_ID

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -225,6 +225,47 @@ def test_log_track_latches_release_id_from_first_discogs_track():
     assert session.album_instance_id == 200
 
 
+def test_log_track_latches_resolve_key_with_first_collection_identity():
+    """Dropping the key assignment would make recovery target a later album."""
+    session = PlaySession()
+    track = make_track("Catholic Block", release_id=100, instance_id=200)
+    track.resolve_key = ("sonic youth", "sister")
+
+    session.log_track(track)
+
+    assert (session.album_release_id, session.album_instance_id) == (100, 200)
+    assert session.album_resolve_key == ("sonic youth", "sister")
+
+
+def test_latched_album_resolve_key_does_not_follow_later_track():
+    """A later recognition may update split evidence but cannot retarget credit."""
+    session = PlaySession()
+    first = make_track("Catholic Block", release_id=100, instance_id=200)
+    first.resolve_key = ("sonic youth", "sister")
+    later = make_track("Pipeline/Kill Time", release_id=999, instance_id=888)
+    later.resolve_key = ("sonic youth", "daydream nation")
+
+    session.log_track(first)
+    session.log_track(later)
+
+    assert session.album_resolve_key == ("sonic youth", "sister")
+    assert session.last_release_resolve_key == ("sonic youth", "daydream nation")
+
+
+def test_database_track_does_not_latch_album_resolve_key():
+    """A database-only match has no collection identity to recover."""
+    session = PlaySession()
+    track = make_track(
+        "Catholic Block", release_id=100, instance_id=None,
+        source=MetadataSource.DISCOGS_DATABASE,
+    )
+    track.resolve_key = ("sonic youth", "sister")
+
+    session.log_track(track)
+
+    assert session.album_resolve_key is None
+
+
 def test_log_track_does_not_latch_fallback_track():
     """Fallback tracks have no discogs_release_id — should not latch."""
     session = PlaySession()

--- a/tests/test_reader_efficiency_w6.py
+++ b/tests/test_reader_efficiency_w6.py
@@ -34,7 +34,10 @@ def _release(rid):
 def _page(items):
     def make(pn, pg):
         resp = MagicMock(); resp.status_code = 200
-        resp.json.return_value = {"releases": items, "pagination": {"page": pn, "pages": pg}}
+        resp.json.return_value = {
+            "releases": items,
+            "pagination": {"page": pn, "pages": pg, "per_page": len(items) or 1, "items": len(items)},
+        }
         return resp
     return make
 
@@ -66,7 +69,9 @@ def test_r5_20_same_query_is_searched_once_across_collection_and_database():
         return m
 
     reader._client.search = MagicMock(side_effect=fake_search)
-    reader._get_collection_index = MagicMock(return_value={})
+    reader._get_collection_index = MagicMock(return_value=reader_mod._CollectionIndexView(
+        index={}, misses_are_authoritative=True
+    ))
 
     reader.search_collection("Radiohead", "Kid A")   # strategy 1, limit 25
     reader.search_database("Radiohead", "Kid A")       # database tier, limit 3
@@ -103,7 +108,7 @@ def test_r5_20_memo_respects_the_requested_limit():
 def test_r5_27_index_titles_are_not_refolded_on_every_search():
     reader = make_discogs_reader()
     reader._http.request = MagicMock(
-        return_value=_page([_item(i, i, f"Album {i}", [f"Artist {i}"]) for i in range(200)])(1, 1)
+        return_value=_page([_item(i, i, f"Album {i}", [f"Artist {i}"]) for i in range(1, 201)])(1, 1)
     )
     reader._database_search = MagicMock(return_value=[])
     reader._get_collection_index()          # builds + precomputes the folded keys

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -17,6 +17,7 @@ import pytest
 
 from src.audio.recognizer import RawRecognitionResult
 from src.metadata.models import MetadataSource, TracklistEntry
+from src.metadata.discogs.outcomes import CollectionRefreshResult, CollectionRefreshState
 
 
 # ---------------------------------------------------------------------------
@@ -59,7 +60,9 @@ def mock_discogs():
     # refresh the index and re-check ownership. Default to "still not owned" so
     # these tests exercise the DATABASE/FALLBACK tiers as before; the C-upgrade
     # path has its own tests in test_cache_expiry.py.
-    m.refresh_index_and_research.return_value = None
+    m.refresh_index_and_research.return_value = CollectionRefreshResult(
+        CollectionRefreshState.CLEAN_NO_MATCH
+    )
     # #61: the resolver now dispatches Discogs searches through reader.run(fn, …)
     # (the dedicated-executor delegate) instead of loop.run_in_executor(None, …).
     # The mock's run awaits and simply calls the target, so return values /

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -17,6 +17,7 @@ import time
 from unittest.mock import MagicMock, AsyncMock
 import pytest
 
+import src.metadata.resolver as resolver_mod
 from src.audio.recognizer import RawRecognitionResult
 from src.metadata.models import MetadataSource, TracklistEntry
 from src.metadata.discogs.outcomes import (
@@ -107,6 +108,38 @@ def _put_collection(resolver, key, result):
 
 
 @pytest.mark.asyncio
+async def test_fallback_outside_reader_gate_cannot_clobber_recovered_collection_identity(
+    resolver, mock_discogs, monkeypatch,
+):
+    """A delayed fallback must not replace a recovery's positive collection cache."""
+    resolver._reader_gate = asyncio.Lock()
+    cover_started, release_cover = asyncio.Event(), asyncio.Event()
+
+    async def delayed_wait_for(awaitable, timeout):
+        cover_started.set()
+        await release_cover.wait()
+        return await awaitable
+
+    monkeypatch.setattr(resolver_mod.asyncio, "wait_for", delayed_wait_for)
+    mock_discogs.rebuild_collection_and_research.return_value = make_discogs_result(100, 200)
+
+    ordinary = asyncio.create_task(resolver.resolve(make_raw()))
+    await cover_started.wait()
+    recovered = await resolver.recover_collection_instance(
+        ("miles davis", "kind of blue"), 100, 200, (300,)
+    )
+    assert recovered == CollectionIdentity(100, 300)
+    assert resolver._album_cache.get(("miles davis", "kind of blue"))[1]["instance_id"] == 300
+
+    release_cover.set()
+    await ordinary
+
+    cached = resolver._album_cache.get(("miles davis", "kind of blue"))
+    assert cached[0] is MetadataSource.DISCOGS_COLLECTION
+    assert cached[1]["instance_id"] == 300
+
+
+@pytest.mark.asyncio
 async def test_recovery_invalidates_exact_stale_positive_and_returns_same_release_new_instance(
     resolver, mock_discogs,
 ):
@@ -186,6 +219,35 @@ async def test_recovery_failure_leaves_known_stale_album_entry_invalidated(resol
 
     assert await resolver.recover_collection_instance(key, 100, 200, (300,)) is None
     assert resolver._album_cache.get(key) is None
+
+
+@pytest.mark.asyncio
+async def test_recovery_refusal_log_includes_safe_identity_stage(resolver, mock_discogs, caplog):
+    caplog.set_level("INFO", logger="src.metadata.resolver")
+    key = ("miles davis", "kind of blue")
+    _put_collection(resolver, key, make_discogs_result(100, 200))
+
+    assert await resolver.recover_collection_instance(key, 100, 200, (200,)) is None
+
+    assert "stage=observed-evidence-refusal" in caplog.text
+    assert "expected_release_id=100" in caplog.text
+    assert "expected_instance_id=200" in caplog.text
+    assert "observed_instance_ids=(200,)" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_recovery_rebuild_failure_log_redacts_exception_value(resolver, mock_discogs, caplog):
+    key = ("miles davis", "kind of blue")
+    _put_collection(resolver, key, make_discogs_result(100, 200))
+    mock_discogs.rebuild_collection_and_research.side_effect = RuntimeError("secret response body")
+
+    assert await resolver.recover_collection_instance(key, 100, 200, (300,)) is None
+
+    assert "stage=rebuild-failed" in caplog.text
+    assert "expected_release_id=100" in caplog.text
+    assert "expected_instance_id=200" in caplog.text
+    assert "observed_instance_id=300" in caplog.text
+    assert "secret response body" not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -251,6 +251,35 @@ async def test_recovery_rebuild_failure_log_redacts_exception_value(resolver, mo
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "expected_release_id, expected_instance_id, observed_instance_ids, safe_fields, sentinel",
+    [
+        (100, "invalid-instance-sentinel", (300,), ("expected_release_id=100",), "invalid-instance-sentinel"),
+        ("invalid-release-sentinel", 200, (300,), ("expected_instance_id=200",), "invalid-release-sentinel"),
+        (100, 200, ("invalid-observed-sentinel",),
+         ("expected_release_id=100", "expected_instance_id=200"), "invalid-observed-sentinel"),
+    ],
+)
+async def test_invalid_recovery_evidence_log_keeps_only_independently_valid_ids(
+    resolver, mock_discogs, caplog, expected_release_id, expected_instance_id,
+    observed_instance_ids, safe_fields, sentinel,
+):
+    """Malformed evidence is diagnosable without emitting its raw values."""
+    caplog.set_level("WARNING", logger="src.metadata.resolver")
+
+    result = await resolver.recover_collection_instance(
+        ("miles davis", "kind of blue"), expected_release_id,
+        expected_instance_id, observed_instance_ids,
+    )
+
+    assert result is None
+    assert "stage=invalid-evidence" in caplog.text
+    for safe_field in safe_fields:
+        assert safe_field in caplog.text
+    assert sentinel not in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_recovery_refuses_same_instance(resolver, mock_discogs):
     key = ("miles davis", "kind of blue")
     _put_collection(resolver, key, make_discogs_result(100, 200))

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -12,12 +12,18 @@ Verifies:
   - NotImplementedError (stub) falls through gracefully
   - All TrackMetadata fields are populated correctly from each source
 """
+import asyncio
+import time
 from unittest.mock import MagicMock, AsyncMock
 import pytest
 
 from src.audio.recognizer import RawRecognitionResult
 from src.metadata.models import MetadataSource, TracklistEntry
-from src.metadata.discogs.outcomes import CollectionRefreshResult, CollectionRefreshState
+from src.metadata.discogs.outcomes import (
+    CollectionIdentity,
+    CollectionRefreshResult,
+    CollectionRefreshState,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -89,8 +95,252 @@ def resolver(mock_discogs, mock_coverart):
     r.reader = mock_discogs
     r.coverart = mock_coverart
     r._album_cache = BoundedCache(_ALBUM_CACHE_MAX)  # Normally created in __init__ (bypassed via __new__)
+    r._reader_gate = asyncio.Lock()
     r._logged_discogs_config = {}
     return r
+
+
+def _put_collection(resolver, key, result):
+    resolver._album_cache.put(
+        key, (MetadataSource.DISCOGS_COLLECTION, result, time.monotonic())
+    )
+
+
+@pytest.mark.asyncio
+async def test_recovery_invalidates_exact_stale_positive_and_returns_same_release_new_instance(
+    resolver, mock_discogs,
+):
+    """Using reader's collapsed instance would credit the wrong surviving copy."""
+    key = ("miles davis", "kind of blue")
+    _put_collection(resolver, key, make_discogs_result(100, 200))
+    mock_discogs.rebuild_collection_and_research.return_value = make_discogs_result(100, 200)
+
+    identity = await resolver.recover_collection_instance(key, 100, 200, (300,))
+
+    assert identity == CollectionIdentity(100, 300)
+    cached = resolver._album_cache.get(key)
+    assert cached[0] is MetadataSource.DISCOGS_COLLECTION
+    assert cached[1]["instance_id"] == 300
+
+
+@pytest.mark.asyncio
+async def test_recovery_allows_absent_cache_entry_after_lru_eviction(resolver, mock_discogs):
+    key = ("miles davis", "kind of blue")
+    mock_discogs.rebuild_collection_and_research.return_value = make_discogs_result(100, 999)
+
+    identity = await resolver.recover_collection_instance(key, 100, 200, (300,))
+
+    assert identity == CollectionIdentity(100, 300)
+
+
+@pytest.mark.asyncio
+async def test_recovery_does_not_erase_newer_nonmatching_cache_entry(resolver, mock_discogs):
+    key = ("miles davis", "kind of blue")
+    newer = make_discogs_result(101, 301)
+    _put_collection(resolver, key, newer)
+
+    assert await resolver.recover_collection_instance(key, 100, 200, (300,)) is None
+    assert resolver._album_cache.get(key)[1] == newer
+    mock_discogs.rebuild_collection_and_research.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_recovery_accepts_newer_cache_only_when_it_matches_proven_singleton(resolver, mock_discogs):
+    key = ("miles davis", "kind of blue")
+    newer = make_discogs_result(100, 300)
+    _put_collection(resolver, key, newer)
+
+    identity = await resolver.recover_collection_instance(key, 100, 200, (300,))
+
+    assert identity == CollectionIdentity(100, 300)
+    mock_discogs.rebuild_collection_and_research.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("observed", [(200,), (), (300, 400)])
+async def test_recovery_refuses_same_instance_or_non_singleton_evidence(resolver, mock_discogs, observed):
+    """Missing/multiple/same evidence must evict only the known stale entry."""
+    key = ("miles davis", "kind of blue")
+    _put_collection(resolver, key, make_discogs_result(100, 200))
+
+    assert await resolver.recover_collection_instance(key, 100, 200, observed) is None
+    assert resolver._album_cache.get(key) is None
+    mock_discogs.rebuild_collection_and_research.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_recovery_refuses_different_release(resolver, mock_discogs):
+    key = ("miles davis", "kind of blue")
+    _put_collection(resolver, key, make_discogs_result(100, 200))
+    mock_discogs.rebuild_collection_and_research.return_value = make_discogs_result(101, 300)
+
+    assert await resolver.recover_collection_instance(key, 100, 200, (300,)) is None
+    assert resolver._album_cache.get(key) is None
+
+
+@pytest.mark.asyncio
+async def test_recovery_failure_leaves_known_stale_album_entry_invalidated(resolver, mock_discogs):
+    key = ("miles davis", "kind of blue")
+    _put_collection(resolver, key, make_discogs_result(100, 200))
+    mock_discogs.rebuild_collection_and_research.side_effect = ConnectionError("offline")
+
+    assert await resolver.recover_collection_instance(key, 100, 200, (300,)) is None
+    assert resolver._album_cache.get(key) is None
+
+
+@pytest.mark.asyncio
+async def test_recovery_refuses_same_instance(resolver, mock_discogs):
+    key = ("miles davis", "kind of blue")
+    _put_collection(resolver, key, make_discogs_result(100, 200))
+
+    assert await resolver.recover_collection_instance(key, 100, 200, (200,)) is None
+    assert resolver._album_cache.get(key) is None
+
+
+@pytest.mark.asyncio
+async def test_recovery_refuses_zero_or_multiple_replacement_instances(resolver, mock_discogs):
+    key = ("miles davis", "kind of blue")
+    for observed in ((), (300, 400)):
+        _put_collection(resolver, key, make_discogs_result(100, 200))
+        assert await resolver.recover_collection_instance(key, 100, 200, observed) is None
+        assert resolver._album_cache.get(key) is None
+
+
+@pytest.mark.asyncio
+async def test_recovery_empty_enumeration_invalidates_stale_entry_and_refuses(resolver, mock_discogs):
+    key = ("miles davis", "kind of blue")
+    _put_collection(resolver, key, make_discogs_result(100, 200))
+
+    assert await resolver.recover_collection_instance(key, 100, 200, ()) is None
+    assert resolver._album_cache.get(key) is None
+
+
+@pytest.mark.asyncio
+async def test_duplicate_instances_leave_album_key_uncached(resolver, mock_discogs):
+    """Invalid writer proof must not touch an immortal cache entry."""
+    key = ("miles davis", "kind of blue")
+    stale = make_discogs_result(100, 200)
+    _put_collection(resolver, key, stale)
+
+    assert await resolver.recover_collection_instance(key, 100, 200, (300, 300)) is None
+    assert resolver._album_cache.get(key)[1] == stale
+
+
+@pytest.mark.asyncio
+async def test_recovery_during_failed_speculative_cooldown_does_not_change_cooldown_state(
+    resolver, mock_discogs,
+):
+    key = ("miles davis", "kind of blue")
+    _put_collection(resolver, key, make_discogs_result(100, 200))
+    mock_discogs.rebuild_collection_and_research.return_value = make_discogs_result(100, 200)
+    mock_discogs._last_index_refresh_at = 123.0
+    mock_discogs._last_speculative_refresh_succeeded = False
+
+    await resolver.recover_collection_instance(key, 100, 200, (300,))
+
+    assert mock_discogs._last_index_refresh_at == 123.0
+    assert mock_discogs._last_speculative_refresh_succeeded is False
+
+
+@pytest.mark.asyncio
+async def test_waiting_resolve_rechecks_cache_after_acquiring_reader_gate(resolver, mock_discogs):
+    """Removing the post-lock check causes a second reader sequence."""
+    # pytest-asyncio's synchronous fixture runs before this test's loop on
+    # Python 3.9, so bind the contention lock in the active loop.
+    resolver._reader_gate = asyncio.Lock()
+    started, release = asyncio.Event(), asyncio.Event()
+    calls = 0
+
+    async def run(fn, *args):
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+        return fn(*args)
+
+    mock_discogs.run = AsyncMock(side_effect=run)
+    mock_discogs.search_collection.return_value = make_discogs_result()
+    first = asyncio.create_task(resolver.resolve(make_raw()))
+    await started.wait()
+    second = asyncio.create_task(resolver.resolve(make_raw(title="All Blues")))
+    release.set()
+    await asyncio.gather(first, second)
+
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_cache_misses_serialize_reader_sequences(resolver, mock_discogs):
+    """A removed gate lets the mutable reader sequence overlap."""
+    resolver._reader_gate = asyncio.Lock()
+    started, release = asyncio.Event(), asyncio.Event()
+    in_reader = maximum = 0
+
+    async def run(fn, *args):
+        nonlocal in_reader, maximum
+        in_reader += 1
+        maximum = max(maximum, in_reader)
+        started.set()
+        await release.wait()
+        try:
+            return fn(*args)
+        finally:
+            in_reader -= 1
+
+    mock_discogs.run = AsyncMock(side_effect=run)
+    mock_discogs.search_collection.return_value = make_discogs_result()
+    first = asyncio.create_task(resolver.resolve(make_raw(album="First")))
+    await started.wait()
+    second = asyncio.create_task(resolver.resolve(make_raw(album="Second")))
+    await asyncio.sleep(0)
+    assert maximum == 1
+    release.set()
+    await asyncio.gather(first, second)
+    assert maximum == 1
+
+
+@pytest.mark.asyncio
+async def test_collection_cache_fast_path_does_not_enter_reader_gate(resolver, mock_discogs):
+    """A positive cache hit must not wait behind unrelated recovery I/O."""
+    resolver._reader_gate = asyncio.Lock()
+    key = ("miles davis", "kind of blue")
+    _put_collection(resolver, key, make_discogs_result())
+    await resolver._reader_gate.acquire()
+    try:
+        result = await asyncio.wait_for(resolver.resolve(make_raw()), timeout=0.05)
+    finally:
+        resolver._reader_gate.release()
+    assert result.source is MetadataSource.DISCOGS_COLLECTION
+    mock_discogs.run.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ordinary_resolve_and_recovery_are_serialized_by_one_gate(resolver, mock_discogs):
+    """Recovery and ordinary resolution share, rather than race through, reader.run."""
+    resolver._reader_gate = asyncio.Lock()
+    started, release = asyncio.Event(), asyncio.Event()
+    calls = 0
+
+    async def run(fn, *args):
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+        return fn(*args)
+
+    mock_discogs.run = AsyncMock(side_effect=run)
+    mock_discogs.rebuild_collection_and_research.return_value = make_discogs_result(100, 200)
+    mock_discogs.search_collection.return_value = make_discogs_result(101, 301)
+    recovery = asyncio.create_task(
+        resolver.recover_collection_instance(("miles davis", "kind of blue"), 100, 200, (300,))
+    )
+    await started.wait()
+    ordinary = asyncio.create_task(resolver.resolve(make_raw(album="Other")))
+    await asyncio.sleep(0)
+    assert calls == 1
+    release.set()
+    await asyncio.gather(recovery, ordinary)
+    assert calls == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -14,6 +14,8 @@ Verifies:
 """
 import asyncio
 import time
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, AsyncMock
 import pytest
 
@@ -105,6 +107,110 @@ def _put_collection(resolver, key, result):
     resolver._album_cache.put(
         key, (MetadataSource.DISCOGS_COLLECTION, result, time.monotonic())
     )
+
+
+class _CancellationBarrierReader:
+    """Real executor seam: cancelling its await does not stop its worker."""
+
+    def __init__(self):
+        self._executor = ThreadPoolExecutor(max_workers=2)
+        self.started = threading.Event()
+        self.release = threading.Event()
+        self._state_lock = threading.Lock()
+        self.calls = 0
+        self.active = 0
+        self.maximum_active = 0
+
+    async def run(self, fn, *args):
+        return await asyncio.get_running_loop().run_in_executor(self._executor, fn, *args)
+
+    def _block_first_worker(self):
+        with self._state_lock:
+            self.calls += 1
+            call = self.calls
+            self.active += 1
+            self.maximum_active = max(self.maximum_active, self.active)
+        try:
+            if call == 1:
+                self.started.set()
+                self.release.wait(timeout=5)
+        finally:
+            with self._state_lock:
+                self.active -= 1
+
+    def search_collection(self, artist, album):
+        self._block_first_worker()
+        return make_discogs_result(100, 200)
+
+    def rebuild_collection_and_research(self, artist, album):
+        self._block_first_worker()
+        return make_discogs_result(100, 200)
+
+    def close(self):
+        self.release.set()
+        self._executor.shutdown(wait=True)
+
+
+async def _wait_for_thread_event(event):
+    await asyncio.get_running_loop().run_in_executor(None, event.wait)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_ordinary_reader_worker_keeps_gate_until_thread_completes(resolver):
+    """Cancelling the await must not let a second executor sequence overlap it."""
+    reader = _CancellationBarrierReader()
+    resolver.reader = reader
+    resolver._reader_gate = asyncio.Lock()
+    first = asyncio.create_task(resolver.resolve(make_raw(album="First")))
+    try:
+        await _wait_for_thread_event(reader.started)
+        first.cancel()
+        await asyncio.sleep(0)
+        second = asyncio.create_task(resolver.resolve(make_raw(album="Second")))
+        await asyncio.sleep(0.05)
+        assert reader.active == 1
+        assert reader.calls == 1
+        assert not first.done()
+        assert not second.done()
+
+        reader.release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+        await second
+        assert reader.calls == 2
+        assert reader.maximum_active == 1
+    finally:
+        reader.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_recovery_worker_keeps_gate_until_thread_completes(resolver):
+    """Recovery uses the same cancellation-safe reader boundary as resolve."""
+    reader = _CancellationBarrierReader()
+    resolver.reader = reader
+    resolver._reader_gate = asyncio.Lock()
+    key = ("miles davis", "kind of blue")
+    _put_collection(resolver, key, make_discogs_result(100, 200))
+    first = asyncio.create_task(resolver.recover_collection_instance(key, 100, 200, (300,)))
+    try:
+        await _wait_for_thread_event(reader.started)
+        first.cancel()
+        await asyncio.sleep(0)
+        second = asyncio.create_task(resolver.recover_collection_instance(key, 100, 200, (300,)))
+        await asyncio.sleep(0.05)
+        assert reader.active == 1
+        assert reader.calls == 1
+        assert not first.done()
+        assert not second.done()
+
+        reader.release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+        assert await second == CollectionIdentity(100, 300)
+        assert reader.calls == 2
+        assert reader.maximum_active == 1
+    finally:
+        reader.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -112,7 +112,7 @@ def _put_collection(resolver, key, result):
 class _CancellationBarrierReader:
     """Real executor seam: cancelling its await does not stop its worker."""
 
-    def __init__(self):
+    def __init__(self, raise_first=False):
         self._executor = ThreadPoolExecutor(max_workers=2)
         self.started = threading.Event()
         self.release = threading.Event()
@@ -120,6 +120,7 @@ class _CancellationBarrierReader:
         self.calls = 0
         self.active = 0
         self.maximum_active = 0
+        self.raise_first = raise_first
 
     async def run(self, fn, *args):
         return await asyncio.get_running_loop().run_in_executor(self._executor, fn, *args)
@@ -137,13 +138,18 @@ class _CancellationBarrierReader:
         finally:
             with self._state_lock:
                 self.active -= 1
+        return call
 
     def search_collection(self, artist, album):
-        self._block_first_worker()
+        call = self._block_first_worker()
+        if self.raise_first and call == 1:
+            raise RuntimeError("late worker exception")
         return make_discogs_result(100, 200)
 
     def rebuild_collection_and_research(self, artist, album):
-        self._block_first_worker()
+        call = self._block_first_worker()
+        if self.raise_first and call == 1:
+            raise RuntimeError("late worker exception")
         return make_discogs_result(100, 200)
 
     def close(self):
@@ -200,6 +206,64 @@ async def test_cancelled_recovery_worker_keeps_gate_until_thread_completes(resol
         await asyncio.sleep(0.05)
         assert reader.active == 1
         assert reader.calls == 1
+        assert not first.done()
+        assert not second.done()
+
+        reader.release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+        assert await second == CollectionIdentity(100, 300)
+        assert reader.calls == 2
+        assert reader.maximum_active == 1
+    finally:
+        reader.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_ordinary_reader_exception_still_propagates_cancellation(resolver):
+    """A late worker error must be drained, not replace caller cancellation."""
+    reader = _CancellationBarrierReader(raise_first=True)
+    resolver.reader = reader
+    resolver._reader_gate = asyncio.Lock()
+    first = asyncio.create_task(resolver.resolve(make_raw(album="First error")))
+    try:
+        await _wait_for_thread_event(reader.started)
+        first.cancel()
+        await asyncio.sleep(0)
+        second = asyncio.create_task(resolver.resolve(make_raw(album="Second error")))
+        await asyncio.sleep(0.05)
+        assert reader.calls == 1
+        assert reader.active == 1
+        assert not first.done()
+        assert not second.done()
+
+        reader.release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+        await second
+        assert reader.calls == 2
+        assert reader.maximum_active == 1
+    finally:
+        reader.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_recovery_reader_exception_still_propagates_cancellation(resolver):
+    """Recovery's late rebuild error likewise cannot turn cancellation into None."""
+    reader = _CancellationBarrierReader(raise_first=True)
+    resolver.reader = reader
+    resolver._reader_gate = asyncio.Lock()
+    key = ("miles davis", "kind of blue")
+    _put_collection(resolver, key, make_discogs_result(100, 200))
+    first = asyncio.create_task(resolver.recover_collection_instance(key, 100, 200, (300,)))
+    try:
+        await _wait_for_thread_event(reader.started)
+        first.cancel()
+        await asyncio.sleep(0)
+        second = asyncio.create_task(resolver.recover_collection_instance(key, 100, 200, (300,)))
+        await asyncio.sleep(0.05)
+        assert reader.calls == 1
+        assert reader.active == 1
         assert not first.done()
         assert not second.done()
 

--- a/tests/test_resolver_error_no_cache.py
+++ b/tests/test_resolver_error_no_cache.py
@@ -6,6 +6,7 @@ album to a downgraded fallback result for the rest of the session.  A clean
 "searched everywhere, no match" still caches the fallback (the existing,
 desired behaviour).
 """
+import asyncio
 from unittest.mock import MagicMock, AsyncMock
 
 import pytest
@@ -37,6 +38,7 @@ def make_resolver():
     r.coverart = MagicMock()
     r.coverart.get_cover_art_url.return_value = "https://coverartarchive.org/x/front"
     r._album_cache = BoundedCache(_ALBUM_CACHE_MAX)
+    r._reader_gate = asyncio.Lock()
     r._logged_discogs_config = {}
     return r
 

--- a/tests/test_resolver_error_no_cache.py
+++ b/tests/test_resolver_error_no_cache.py
@@ -12,8 +12,10 @@ import pytest
 
 from src.audio.recognizer import RawRecognitionResult
 from src.metadata.models import MetadataSource
+from src.metadata.discogs.outcomes import CollectionRefreshResult, CollectionRefreshState
 from src.metadata.resolver import MetadataResolver, _ALBUM_CACHE_MAX
 from src.util.cache import BoundedCache
+from tests.factories import make_discogs_reader
 
 
 def make_raw():
@@ -29,7 +31,9 @@ def make_resolver():
     r.reader.run = AsyncMock(side_effect=lambda fn, *a: fn(*a))
     # #191 (C): default the staleness-refresh to "still not owned" so a clean
     # collection miss + database hit degrades to DATABASE as these tests expect.
-    r.reader.refresh_index_and_research.return_value = None
+    r.reader.refresh_index_and_research.return_value = CollectionRefreshResult(
+        CollectionRefreshState.CLEAN_NO_MATCH
+    )
     r.coverart = MagicMock()
     r.coverart.get_cover_art_url.return_value = "https://coverartarchive.org/x/front"
     r._album_cache = BoundedCache(_ALBUM_CACHE_MAX)
@@ -82,6 +86,31 @@ async def test_clean_collection_miss_then_database_hit_is_cached():
 
     assert result.source == MetadataSource.DISCOGS_DATABASE
     assert len(r._album_cache) == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_refresh_then_cooldown_skip_keeps_database_uncached():
+    """#420: a failed speculative rebuild leaves the next cooldown skip
+    non-authoritative, so both displayed database results remain retryable."""
+    reader = make_discogs_reader()
+    reader.run = AsyncMock(side_effect=lambda fn, *a: fn(*a))
+    reader.search_collection = MagicMock(return_value=None)
+    reader.search_database = MagicMock(return_value={
+        "release_id": 100, "instance_id": None, "album": "Kind of Blue",
+    })
+    reader._build_collection_index = MagicMock(side_effect=ConnectionError("blip"))
+    reader._http.request = MagicMock()
+
+    r = make_resolver()
+    r.reader = reader
+
+    first = await r.resolve(make_raw())
+    second = await r.resolve(make_raw())
+
+    assert first.source is MetadataSource.DISCOGS_DATABASE
+    assert second.source is MetadataSource.DISCOGS_DATABASE
+    assert len(r._album_cache) == 0
+    assert reader._http.request.call_count == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_tracklist_neighbours.py
+++ b/tests/test_tracklist_neighbours.py
@@ -7,6 +7,7 @@ B-10 — numbered tracklists ('1'..'N', no side letters) now yield prev/next
 B-9  — TracklistEntry is frozen; each track of an album gets its own tracklist
        list; an explicit None tracklist is normalized to [].
 """
+import asyncio
 from unittest.mock import MagicMock
 
 import pytest
@@ -125,6 +126,7 @@ def _resolver():
     r.reader = MagicMock()
     r.coverart = MagicMock()
     r._album_cache = BoundedCache(_ALBUM_CACHE_MAX)
+    r._reader_gate = asyncio.Lock()
     r._logged_discogs_config = {}
     return r
 


### PR DESCRIPTION
## Summary

- make Discogs refresh outcomes explicit so a failed refresh followed by cooldown cannot cache a false clean miss
- recover a removed/re-added collection instance only from strict, writer-proven singleton evidence
- serialize ordinary metadata resolution and finalizer recovery across executor cancellation
- preserve absolute-set idempotency, bounded retries, META-7 behavior, and newer concurrent cache entries
- add cross-layer acceptance coverage and reconcile the durable remediation contract

## Safety contract

- incomplete, capped, malformed, multi-page, 404, duplicate-copy, changed-release, or same-stale-instance evidence never authorizes a write
- exactly one safe replacement may receive one absolute Play Count target and one Last Played attempt
- recovery never starts after an absolute write plan exists
- positive collection cache entries remain immortal during ordinary reads
- no live Discogs write or Pi hardware validation is claimed by this PR

## Verification

- integrated Wave 2 suite: **421 passed**
- final adversarial review: **SPEC PASS / QUALITY PASS**, zero open material findings
- `git diff --check origin/main...HEAD`: clean
- tracked worktree/status and changed-lines credential scan: clean
- local full-suite environment is unsupported Python 3.9 and sandbox-limited; exact-SHA Python 3.11/3.12/3.13 CI is required before merge

### Exact-SHA CI (`8dedd7be1f88a8169b8758a93ffbba6b8cd48ae1`)

- [tests run 32614143401](https://github.com/lanebecker/vinyl-now-playing/actions/runs/32614143401): Python 3.11, 3.12, and 3.13 passed
- [version metadata run 32614143358](https://github.com/lanebecker/vinyl-now-playing/actions/runs/32614143358): passed
- [dependency audit run 32614217459](https://github.com/lanebecker/vinyl-now-playing/actions/runs/32614217459): Python 3.11, 3.12, and 3.13 passed

## Follow-up

- #439 records the pre-existing, non-production-reachable writer-finalizer cancellation hardening seam discovered by the final review. It is unchanged from `origin/main` and does not block this Wave 2 change.

Closes #420
Closes #421
