### PR TITLE
Harden finalizer cancellation around Discogs writes

### DIFF
--- a/src/tracking/listen_tracker.py
+++ b/src/tracking/listen_tracker.py
@@ -938,6 +938,38 @@ class ListenTracker:
                         _FINALIZE_WRITE_ATTEMPTS,
                     )
 
+    async def _run_writer_cancellation_safe(self, fn, *args):
+        """Run one Discogs writer operation without releasing on cancellation.
+
+        Cancelling a ``run_in_executor`` await does not stop an already-running
+        worker.  Every caller is under ``_finalize_lock``; keep that caller alive
+        until the submitted writer operation has actually finished, retrieve a
+        late success or exception, then re-propagate the original cancellation.
+        This prevents a second finalizer from entering the shared writer while
+        the cancelled finalizer's worker still owns it.
+        """
+        writer_task = asyncio.ensure_future(self.writer.run(fn, *args))
+        try:
+            return await asyncio.shield(writer_task)
+        except asyncio.CancelledError:
+            current_task = asyncio.current_task()
+            if current_task is not None:
+                current_task.uncancel()
+            while not writer_task.done():
+                try:
+                    await asyncio.shield(writer_task)
+                except asyncio.CancelledError:
+                    if current_task is not None:
+                        current_task.uncancel()
+                    continue
+                except BaseException:
+                    break
+            try:
+                writer_task.result()
+            except BaseException:
+                pass
+            raise asyncio.CancelledError
+
     async def _finalize_write_with_retry(self, label: str, attempt) -> bool:
         """Run one end-of-session write with a BOUNDED retry (#163).
 
@@ -1039,7 +1071,7 @@ class ListenTracker:
 
         async def _read_replacement() -> None:
             """Perform the replacement read without opening another recovery path."""
-            result = await self.writer.run(
+            result = await self._run_writer_cancellation_safe(
                 self.writer.read_play_count,
                 session.album_release_id,
                 session.album_instance_id,
@@ -1066,7 +1098,7 @@ class ListenTracker:
                     # spent and the established pair cannot change.
                     await _read_replacement()
                 else:
-                    result = await self.writer.run(
+                    result = await self._run_writer_cancellation_safe(
                         self.writer.read_play_count,
                         session.album_release_id,
                         session.album_instance_id,
@@ -1131,7 +1163,7 @@ class ListenTracker:
                         plan["field_id"] = result.field_id
                         plan["current"] = result.current_count
                         plan["target"] = result.current_count + 1
-            return await self.writer.run(
+            return await self._run_writer_cancellation_safe(
                 self.writer.set_play_count,
                 session.album_release_id,
                 session.album_instance_id,
@@ -1194,7 +1226,7 @@ class ListenTracker:
             # pre-NTP boot returns False on purpose and must not be retried). It
             # still inherits the crediting/committed split — it runs inside the
             # in-flight-guarded credit path.
-            last_played_success = await self.writer.run(
+            last_played_success = await self._run_writer_cancellation_safe(
                 self.writer.update_last_played,
                 session.album_release_id,
                 session.album_instance_id,

--- a/tests/test_listen_tracker.py
+++ b/tests/test_listen_tracker.py
@@ -1129,8 +1129,7 @@ async def test_full_album_increments_via_public_session_ended_path():
     await tracker.on_track_identified(make_track("Master-Dik"))  # the album closer
 
     tracker.on_silence_event(AudioEvent.SESSION_ENDED)
-    for _ in range(5):                  # let the scheduled task run to completion
-        await asyncio.sleep(0)
+    await tracker.drain()                # production completion contract for bg finalizers
 
     writer.increment_play_count.assert_called_once_with(12345, 67890)
     assert tracker._session is None

--- a/tests/test_listen_tracker_conc2.py
+++ b/tests/test_listen_tracker_conc2.py
@@ -14,6 +14,8 @@ work, so moving it off the lifecycle lock does not let two detached sessions hit
 the shared Discogs `requests.Session` (max_workers=2 pool) concurrently.
 """
 import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -24,6 +26,61 @@ from src.metadata.discogs.outcomes import (
 from src.metadata.models import PlaySession
 from src.tracking.listen_tracker import ListenTracker
 from tests.test_listen_tracker import make_tracker, make_track
+
+
+class _CancellationBarrierWriter:
+    """Real executor seam whose first Discogs write survives cancellation."""
+
+    def __init__(self, *, raise_first: bool = False):
+        self._executor = ThreadPoolExecutor(max_workers=2)
+        self._state_lock = threading.Lock()
+        self.started = threading.Event()
+        self.release = threading.Event()
+        self.raise_first = raise_first
+        self.calls = []
+        self.active = 0
+        self.maximum_active = 0
+
+    async def run(self, fn, *args):
+        return await asyncio.get_running_loop().run_in_executor(
+            self._executor, fn, *args
+        )
+
+    def set_play_count(self, *args):
+        with self._state_lock:
+            call_number = len(self.calls) + 1
+            self.calls.append(args)
+            self.active += 1
+            self.maximum_active = max(self.maximum_active, self.active)
+        try:
+            if call_number == 1:
+                self.started.set()
+                self.release.wait(timeout=5)
+                if self.raise_first:
+                    raise RuntimeError("late writer failure")
+            return True
+        finally:
+            with self._state_lock:
+                self.active -= 1
+
+    def close(self):
+        self.release.set()
+        self._executor.shutdown(wait=True)
+
+
+def _detached_creditable_session(release_id: int, instance_id: int) -> PlaySession:
+    session = PlaySession()
+    session.log_track(
+        make_track("Cotton Crown", release_id=release_id, instance_id=instance_id)
+    )
+    session.log_track(
+        make_track("Master-Dik", release_id=release_id, instance_id=instance_id)
+    )
+    return session
+
+
+async def _wait_for_thread_event(event: threading.Event):
+    await asyncio.get_running_loop().run_in_executor(None, event.wait)
 
 
 @pytest.mark.asyncio
@@ -138,6 +195,59 @@ async def test_conc2_finalizes_are_serialized_no_concurrent_writer_calls():
     assert max_inside == 1                    # never two writer calls at once
     assert writer.increment_play_count.call_count == 2  # both did credit, serially
     assert writer.set_play_count.call_count == 2            # the serialized write ran twice
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raise_first", [False, True])
+async def test_cancelled_finalize_keeps_lock_until_executor_writer_finishes(
+    raise_first,
+):
+    """Cancellation must not admit another finalizer while its writer lives.
+
+    Removing the cancellation-safe writer drain should make ``first`` finish
+    immediately and let the second executor worker overlap the blocked first.
+    Both late success and late failure must instead preserve the original
+    cancellation after the worker exits.
+    """
+    tracker, writer = make_tracker()
+    runner = _CancellationBarrierWriter(raise_first=raise_first)
+    writer.run = runner.run
+    writer.set_play_count = runner.set_play_count
+    writer.read_play_count.return_value = PlayCountReadResult(
+        PlayCountReadState.READY, 3, 0
+    )
+    first_session = _detached_creditable_session(111, 222)
+    second_session = _detached_creditable_session(333, 444)
+    first = asyncio.create_task(tracker._finalize_detached(first_session))
+    second = None
+    try:
+        await asyncio.wait_for(_wait_for_thread_event(runner.started), timeout=1)
+        first.cancel()
+        await asyncio.sleep(0)
+        assert not first.done()
+        first.cancel()  # repeated cancellation must not punch through the drain
+        await asyncio.sleep(0)
+        second = asyncio.create_task(tracker._finalize_detached(second_session))
+        await asyncio.sleep(0.05)
+
+        assert runner.active == 1
+        assert len(runner.calls) == 1
+        assert not first.done()
+        assert not second.done()
+
+        runner.release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+        await second
+
+        assert runner.maximum_active == 1
+        assert len(runner.calls) == 2
+        assert [call[:2] for call in runner.calls] == [(111, 222), (333, 444)]
+    finally:
+        runner.close()
+        if second is not None and not second.done():
+            second.cancel()
+            await asyncio.gather(second, return_exceptions=True)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- keep the finalizer lock held until an already-submitted executor-backed Discogs operation finishes
- preserve and re-propagate cancellation after late success or failure, including repeated cancellation
- replace a scheduling-count test assumption with the production drain contract

## Verification
- adversarial rereview: SPEC PASS / QUALITY PASS
- focused suite before repeated-cancel hardening: 100 passed
- Wave 2 integrated suite before repeated-cancel hardening: 423 passed
- Python 3.12 compile and deterministic repeated-cancellation control-flow verification passed
- supported 3.11/3.12/3.13 CI is the final gate

Closes #439