### PR TITLE
feat(recognition): AudD backend + user-selectable recognition (#453)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ When the last track of an album finishes, it automatically increments the Play C
 
 ## Features
 
-- 🎵 Real-time audio fingerprinting via ShazamIO (no manual input needed)
+- 🎵 Real-time audio fingerprinting — **ShazamIO** (free, default) or **AudD** (recommended, more reliable); no manual input needed
 - 💿 Discogs collection-first metadata — pulls your specific pressing's details
 - 🖼️ "Museum Card" display layout: large cover art, hero track title, artist, italic album name, genre/style chip badges, side indicator, prev/next track footer
 - 🎨 Dynamic color theming — palette extracted from each album's cover art; background, accent, and text colors shift per record with a smooth 1-second transition
@@ -21,7 +21,7 @@ When the last track of an album finishes, it automatically increments the Play C
 - 🎧 Last.fm scrobbling (opt-in) — when enabled, every identified track is posted to your listening history automatically
 - ❤️ Optional Last.fm "Loved" mark when a full album side completes (configurable, off by default)
 - 🔄 Graceful fallback: Discogs collection → Discogs database → MusicBrainz
-- 🔧 Swappable recognition backend (ShazamIO today; ACRCloud/AudD planned)
+- 🔧 Swappable recognition backend — ShazamIO and AudD implemented, ACRCloud planned (see [docs/recognition-backends.md](docs/recognition-backends.md))
 
 ## Hardware
 
@@ -55,12 +55,14 @@ Copy `config.example.yaml` to `config.yaml` and fill in:
 - `audio.device_name` — run `python -c "import sounddevice; print(sounddevice.query_devices())"` to find your USB interface name
 - `discogs.play_count_field_name` — the exact name of your Play Count custom field (default: `"Play Count"`)
 - `discogs.last_played_field_name` — optional; the exact name of a Last Played custom field in your Discogs collection. If set, today's date is written in `YYYY-MM-DD` format on each album completion.
+- `recognition.backend` — `"shazamio"` (free, default) or `"audd"` (recommended for reliability; set `recognition.audd.api_token`, get a token at https://audd.io). See [docs/recognition-backends.md](docs/recognition-backends.md).
 - `lastfm.scrobble_enabled` — set to `true` to enable Last.fm scrobbling; also fill in `api_key`, `api_secret`, and `session_key`. Run `python get_lastfm_session_key.py` to generate your session key.
 
 ## Documentation
 
 - [Architecture](docs/architecture.md) — full system design, component reference, data flows
 - [Roadmap](docs/roadmap.md) — planned features and versioning
+- [Recognition backends](docs/recognition-backends.md) — choosing ShazamIO vs AudD, setup, and caveats
 - [Changelog](CHANGELOG.md) — what changed in each version
 - [Testing guide](docs/testing-guide.md) — running the unit and integration test suites
 - [Pi setup guide](docs/pi-setup-guide.md) — hardware bring-up from bare Pi to running app

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -57,9 +57,13 @@ lastfm:
   love_on_completion: false
 
 recognition:
-  # Currently the only implemented backend is "shazamio". ("acrcloud" and "audd"
-  # are planned — the sub-sections below reserve their config — but selecting
-  # them is rejected at startup until they are built.)
+  # Recognition backend — two are implemented:
+  #   "shazamio" (default) — free, no signup; unofficial/reverse-engineered, so it
+  #     can miss tracks and drift when Shazam changes server-side. Best on popular music.
+  #   "audd" (recommended) — a commercial, maintained API; more reliable. Get a token
+  #     at https://audd.io and set recognition.audd.api_token below.
+  # ("acrcloud" is planned; selecting it is rejected at startup until built.)
+  # See docs/recognition-backends.md.
   backend: "shazamio"
   poll_interval_seconds: 30
   # How many consecutive matching results before we commit a track change
@@ -74,6 +78,7 @@ recognition:
     access_secret: "YOUR_ACRCLOUD_SECRET"
     host: "identify-eu-west-1.acrcloud.com"
 
-  # Only needed if backend is "audd"
+  # Required when backend is "audd" (get a token at https://audd.io). It is a
+  # secret — keep config.yaml mode 600 and never commit it.
   audd:
     api_token: "YOUR_AUDD_TOKEN"

--- a/docs/recognition-backends.md
+++ b/docs/recognition-backends.md
@@ -1,0 +1,53 @@
+# Recognition backends
+
+eyeliner identifies the playing track through a pluggable **recognition backend**,
+selected with `recognition.backend` in `config.yaml`. Two are implemented:
+
+| Backend | Cost | Setup | Reliability |
+|---|---|---|---|
+| **`shazamio`** (default) | Free | none | Unofficial / reverse-engineered — can drift out of sync with Shazam's servers and miss tracks it matched before. Best on popular music. |
+| **`audd`** (recommended) | Paid (free trial; ~$5 / 1000 requests after) | an API token | Commercial, maintained service; markedly more reliable in practice. |
+
+The default is `shazamio` so the app runs on a fresh clone with no signup. **For a
+set-and-forget appliance, AudD is recommended.**
+
+## ShazamIO (default, free)
+
+```yaml
+recognition:
+  backend: "shazamio"
+```
+
+No account needed. **Caveat:** ShazamIO is an unofficial, reverse-engineered Shazam
+client with no stability guarantee. When Shazam changes something server-side it can
+start returning no-match for audio it identified before ("worked yesterday, broken
+today"), and it tends to miss deeper, less-popular tracks. If recognition gets flaky,
+switch to AudD.
+
+## AudD (recommended)
+
+1. Get an API token at <https://audd.io> (free trial; paid plans after).
+2. Configure:
+
+```yaml
+recognition:
+  backend: "audd"
+  audd:
+    api_token: "YOUR_AUDD_TOKEN"
+```
+
+The token is a secret — keep `config.yaml` mode `600` and never commit it (it is
+gitignored). Startup **fails fast** with a clear error if `backend: audd` is set
+without a token.
+
+**Cost note:** AudD bills per request. Today the app recognizes on every capture hop
+(~10 s); on a paid plan you will want per-track polling (roadmap #454) to keep usage
+low — until that lands, expect higher request counts on busy listening days.
+
+## Adding another backend
+
+`RecognizerBackend` in `src/audio/recognizer.py` is the extension point (ACRCloud is a
+planned drop-in). A new backend needs a `RecognizerBackend` subclass, its name added to
+`IMPLEMENTED_BACKENDS` in `src/config.py`, and a branch in
+`RecognitionLoop._init_backend` — config validation and construction both check the same
+set, so they can never drift.

--- a/src/audio/recognizer.py
+++ b/src/audio/recognizer.py
@@ -1,9 +1,9 @@
 """Recognition loop — polls for track identity while music plays.
 
 Abstracts the recognition backend behind RecognizerBackend so a backend
-(ShazamIO today; ACRCloud and AudD planned) can be swapped via config without
-touching this file. Only "shazamio" is implemented — config.py's CRIT-2 gate
-rejects the others at startup until they are built (see the TODO below).
+(ShazamIO and AudD implemented; ACRCloud planned) can be swapped via config
+without touching this file. config.py's CRIT-2 gate rejects an unimplemented
+backend (e.g. ACRCloud) at startup until it is built.
 """
 
 import asyncio
@@ -268,6 +268,107 @@ class ShazamIOBackend(RecognizerBackend):
         return buf.getvalue()
 
 
+# ---------------------------------------------------------------------------
+# AudD backend (#453) — a commercial, maintained recognition API and the
+# recommended user-selectable alternative to ShazamIO (which stays the free,
+# zero-config default). Needs a token in recognition.audd.api_token.
+# ---------------------------------------------------------------------------
+
+_AUDD_API_URL = "https://api.audd.io/"
+# Internal per-request bound. run()'s wait_for(recognize_timeout, default 30s) is
+# the hard backstop; this keeps one stuck HTTP call from riding that full budget
+# (mirrors ShazamIO's pinned retry bound).
+_AUDD_HTTP_TIMEOUT_SECONDS = 20
+
+
+class _AuddApiError(Exception):
+    """AudD returned status=error (bad token, exhausted quota, etc.). Raised
+    inside the pure parser so recognize()'s one broad except routes it through the
+    throttled failure log and counts it as a miss — a bad key or quota can never
+    crash the recognition loop."""
+
+
+class AuddBackend(RecognizerBackend):
+    """Recognition via the AudD API (https://audd.io).
+
+    recognize() reuses ShazamIOBackend._encode_wav for the identical in-memory
+    WAV serialization, then POSTs the clip to AudD. The aiohttp import in
+    _call_audd is lazy on purpose (as with shazamio) so this module stays
+    importable — and _parse_audd unit-testable — without the HTTP stack.
+    """
+
+    def __init__(self, api_token: str):
+        self._api_token = api_token or ""
+        # #197 model: throttle the per-chunk failure WARNING (a bad token or a
+        # network outage fails every ~10s hop otherwise — the #178 flood class).
+        self._error_log = ThrottledLogger(
+            log, _RECOGNITION_ERROR_LOG_INTERVAL_SECONDS, level=logging.WARNING
+        )
+
+    async def recognize(
+        self, audio: np.ndarray, sample_rate: int
+    ) -> Optional[RawRecognitionResult]:
+        try:
+            loop = asyncio.get_running_loop()
+            wav_bytes = await loop.run_in_executor(
+                None, ShazamIOBackend._encode_wav, audio, sample_rate
+            )
+            result = await self._call_audd(wav_bytes)
+            parsed = self._parse_audd(result)
+            self._error_log.reset()
+            return parsed
+        except Exception as e:
+            self._error_log.error(f"AudD recognition failed: {e}")
+            return None
+
+    async def _call_audd(self, wav_bytes: bytes) -> dict:
+        """Transport-only: POST the WAV to AudD. aiohttp import kept lazy (A-13)."""
+        import aiohttp
+
+        data = aiohttp.FormData()
+        data.add_field("api_token", self._api_token)
+        data.add_field(
+            "file", wav_bytes, filename="audio.wav", content_type="audio/wav"
+        )
+        timeout = aiohttp.ClientTimeout(total=_AUDD_HTTP_TIMEOUT_SECONDS)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(_AUDD_API_URL, data=data) as resp:
+                # content_type=None: AudD replies application/json; stay lenient if
+                # a proxy mislabels it rather than raising on the content type.
+                return await resp.json(content_type=None)
+
+    @staticmethod
+    def _parse_audd(result) -> Optional[RawRecognitionResult]:
+        """Pure parse of an AudD JSON response -> RawRecognitionResult or None.
+
+        success + track -> result; success + null (no match) -> None;
+        status=error -> raise _AuddApiError so recognize() logs it (throttled) and
+        counts a miss. Every field is str()-coerced and null-guarded, mirroring
+        _parse_shazam (untrusted external JSON; REC-2/REC-3/R5-10)."""
+        if not isinstance(result, dict):
+            return None
+        status = result.get("status")
+        if status == "error":
+            err = result.get("error")
+            msg = err.get("error_message") if isinstance(err, dict) else None
+            raise _AuddApiError(str(msg or "AudD API returned an error"))
+        if status != "success":
+            return None
+        res = result.get("result")
+        # A null result is a clean no-match; a non-dict result is malformed -> miss.
+        if not isinstance(res, dict):
+            return None
+        title = str(res.get("title") or "")
+        if not title.strip():
+            return None
+        return RawRecognitionResult(
+            title=title,
+            artist=str(res.get("artist") or ""),
+            album=str(res.get("album") or ""),
+            isrc=None,
+        )
+
+
 class RecognitionLoop:
     """Manages the async recognition polling loop.
 
@@ -314,6 +415,8 @@ class RecognitionLoop:
         # music that ShazamIO can't identify.
         self.error_after_misses: int = config.error_after_misses
         self.backend_name: str = config.backend
+        # AudD backend credential (validated required-when-audd in config.py).
+        self._audd_api_token: str = config.audd_api_token
         self._audio_queue: asyncio.Queue = asyncio.Queue(maxsize=5)
         # R10-11 (#424): throttled health signal for recognition-queue lag. Single
         # key (the message carries the varying age/drop numbers, formatted at emit)
@@ -371,9 +474,11 @@ class RecognitionLoop:
             )
         if self.backend_name == "shazamio":
             return ShazamIOBackend()
+        if self.backend_name == "audd":
+            return AuddBackend(self._audd_api_token)
         # A name that is in IMPLEMENTED_BACKENDS but has no constructor branch
         # above is a programming error — someone widened the set but not this
-        # method. (TODO: add AcrcloudBackend, AuddBackend when implemented.)
+        # method. (TODO: add AcrcloudBackend when implemented.)
         raise ValueError(  # pragma: no cover
             f"recognition backend {self.backend_name!r} is allowed but has no "
             f"constructor in _init_backend."

--- a/src/config.py
+++ b/src/config.py
@@ -17,9 +17,10 @@ attributes — no dict indexing, no ``.get()`` defaults scattered around.
 Validation is **aggregating**: a bad config reports *every* problem at once in
 one :class:`ConfigError` (missing required keys, wrong types, non-mapping
 sections), rather than failing on the first ``KeyError`` and hiding the rest.
-Unknown keys are tolerated (e.g. the ``recognition.acrcloud`` / ``audd``
-sub-sections in ``config.example.yaml`` that no implemented backend reads yet),
-so the schema can stay ahead of the code.
+Unknown keys are tolerated (e.g. the reserved ``recognition.acrcloud``
+sub-section in ``config.example.yaml`` that no implemented backend reads yet;
+``recognition.audd.api_token`` IS read now), so the schema can stay ahead of the
+code.
 
 Field defaults here are the authoritative copies of what used to be inline
 ``.get(key, default)`` calls in each constructor; the per-key mapping is
@@ -388,15 +389,22 @@ class LastFmConfig:
 
 
 # CRIT-2: the recognition backends this build actually IMPLEMENTS — the allowed
-# values for ``recognition.backend``. config.example.yaml advertises "acrcloud"
-# and "audd" as future options, but only "shazamio" is built; selecting an
+# values for ``recognition.backend``. "shazamio" and "audd" are built;
+# config.example.yaml also advertises "acrcloud" as a future option; selecting an
 # unimplemented one used to pass config's type check and then raise ValueError
 # from RecognitionLoop.__init__ (constructed outside main()'s try/except) into a
 # systemd crash loop. This is the SINGLE SOURCE OF TRUTH: RecognitionConfig
 # validates against it here, and recognizer._init_backend constructs against it,
 # so the two can never drift. Add a backend by adding its name here AND a
 # constructor branch in _init_backend.
-IMPLEMENTED_BACKENDS = frozenset({"shazamio"})
+IMPLEMENTED_BACKENDS = frozenset({"shazamio", "audd"})
+
+# R7-17 (extended for AudD): the literal token placeholder shipped in
+# config.example.yaml. Like the Discogs placeholders, an unedited value passes the
+# non-empty gate and then fails every AudD call — reject it at config time so the
+# startup ConfigError names it (value-free) instead of a silent runtime miss.
+# Only checked when backend == "audd".
+_AUDD_TOKEN_PLACEHOLDER = "YOUR_AUDD_TOKEN"
 
 
 @dataclass(frozen=True)
@@ -406,6 +414,10 @@ class RecognitionConfig:
     backend: str = "shazamio"
     confirmation_required: int = 2
     error_after_misses: int = 6
+    # Credential for the "audd" backend, read from the nested
+    # ``recognition.audd.api_token`` sub-section (see from_dict). Required only
+    # when backend == "audd". A secret — never echoed in a ConfigError.
+    audd_api_token: str = ""
 
     @classmethod
     def from_dict(cls, data: dict, errors: list) -> "RecognitionConfig":
@@ -418,6 +430,15 @@ class RecognitionConfig:
         backend = _field(data, "backend", str, "shazamio", section=s, errors=errors)
         confirmation_required = _field(data, "confirmation_required", int, 2, section=s, errors=errors)
         error_after_misses = _field(data, "error_after_misses", int, 6, section=s, errors=errors)
+        # The "audd" backend's token lives in the nested ``recognition.audd``
+        # sub-section (schema advertised in config.example.yaml). Read it directly
+        # rather than through _field, so the secret VALUE is never echoed into a
+        # ConfigError (which main.py logs to the journal). A missing sub-section,
+        # missing key, or non-string value all coerce to "" — the single
+        # value-free required-when-audd gate below then reports it.
+        _audd = data.get("audd")
+        _audd_token = _audd.get("api_token") if isinstance(_audd, dict) else None
+        audd_api_token = _audd_token if isinstance(_audd_token, str) else ""
 
         # CRIT-1: a zero poll interval busy-loops the recognition leg; fewer than
         # one confirmation or one miss-to-error is nonsensical thresholding.
@@ -434,12 +455,21 @@ class RecognitionConfig:
         _check(backend is None or backend in IMPLEMENTED_BACKENDS,
                f"  • {s}.backend: must be one of {sorted(IMPLEMENTED_BACKENDS)}, "
                f"got {backend!r}", errors)
+        # The audd backend cannot work without a token; require it here rather than
+        # fail opaquely at the first recognize(). Value-free message (secret).
+        _check(backend != "audd" or bool(audd_api_token.strip()),
+               f"  • {s}.audd.api_token: required when {s}.backend is 'audd' "
+               f"(get one at https://audd.io)", errors)
+        _check(backend != "audd" or audd_api_token != _AUDD_TOKEN_PLACEHOLDER,
+               f"  • {s}.audd.api_token: still the config.example.yaml placeholder "
+               f"— get one at https://audd.io", errors)
 
         return cls(
             poll_interval_seconds=poll_interval_seconds,
             backend=backend,
             confirmation_required=confirmation_required,
             error_after_misses=error_after_misses,
+            audd_api_token=audd_api_token,
         )
 
 

--- a/tests/test_audd_backend.py
+++ b/tests/test_audd_backend.py
@@ -1,0 +1,89 @@
+"""AudD recognition backend (#453).
+
+_parse_audd is a pure, network-free parser (mirrors test_recognizer_parse.py);
+recognize() orchestration is tested with transport + encoder mocked, so no
+aiohttp / soundfile / network is required.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.audio.recognizer import (
+    AuddBackend, RawRecognitionResult, RecognitionLoop, _AuddApiError,
+)
+from tests.factories import make_recognition_config
+
+
+def _ok(title="Where Is Everyone", artist="Lunar Vacation", album="Where Is Everyone"):
+    return {"status": "success", "result": {
+        "artist": artist, "title": title, "album": album,
+        "release_date": "2021-10-05", "song_link": "https://lis.tn/x",
+    }}
+
+
+# --- pure parse ---
+
+def test_parse_full_success():
+    assert AuddBackend._parse_audd(_ok()) == \
+        RawRecognitionResult("Where Is Everyone", "Lunar Vacation", "Where Is Everyone", None)
+
+def test_parse_null_result_is_no_match():
+    assert AuddBackend._parse_audd({"status": "success", "result": None}) is None
+
+def test_parse_non_dict_is_none():
+    assert AuddBackend._parse_audd(None) is None
+    assert AuddBackend._parse_audd([1, 2]) is None
+    assert AuddBackend._parse_audd({"status": "success", "result": [1]}) is None
+
+def test_parse_empty_title_is_no_match():
+    assert AuddBackend._parse_audd({"status": "success", "result": {"title": "  ", "artist": "A"}}) is None
+
+def test_parse_missing_fields_coerce_to_empty():
+    assert AuddBackend._parse_audd({"status": "success", "result": {"title": "T"}}) == \
+        RawRecognitionResult("T", "", "", None)
+
+def test_parse_numeric_fields_coerced_to_str():
+    r = AuddBackend._parse_audd({"status": "success", "result": {"title": 123, "artist": 456, "album": 789}})
+    assert (r.title, r.artist, r.album) == ("123", "456", "789")
+
+def test_parse_error_status_raises():
+    with pytest.raises(_AuddApiError):
+        AuddBackend._parse_audd({"status": "error", "error": {"error_code": 901, "error_message": "no api_token"}})
+
+def test_parse_unknown_status_is_none():
+    assert AuddBackend._parse_audd({"status": "weird"}) is None
+
+
+# --- recognize() orchestration (transport + encoder mocked) ---
+
+@pytest.mark.asyncio
+async def test_recognize_returns_parsed_result():
+    b = AuddBackend("tok")
+    with patch("src.audio.recognizer.ShazamIOBackend._encode_wav", return_value=b"wav"), \
+         patch.object(b, "_call_audd", AsyncMock(return_value=_ok())):
+        r = await b.recognize(object(), 44100)
+    assert r.title == "Where Is Everyone"
+
+@pytest.mark.asyncio
+async def test_recognize_error_status_is_swallowed_as_miss():
+    b = AuddBackend("tok")
+    err = {"status": "error", "error": {"error_message": "quota exceeded"}}
+    with patch("src.audio.recognizer.ShazamIOBackend._encode_wav", return_value=b"wav"), \
+         patch.object(b, "_call_audd", AsyncMock(return_value=err)):
+        assert await b.recognize(object(), 44100) is None
+
+@pytest.mark.asyncio
+async def test_recognize_transport_exception_is_swallowed():
+    b = AuddBackend("tok")
+    with patch("src.audio.recognizer.ShazamIOBackend._encode_wav", return_value=b"wav"), \
+         patch.object(b, "_call_audd", AsyncMock(side_effect=RuntimeError("boom"))):
+        assert await b.recognize(object(), 44100) is None
+
+
+# --- backend selection ---
+
+def test_init_backend_selects_audd_with_token():
+    cfg = make_recognition_config(backend="audd", audd_api_token="tok")
+    loop = RecognitionLoop(cfg, MagicMock(), MagicMock())
+    assert isinstance(loop.backend, AuddBackend)
+    assert loop.backend._api_token == "tok"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -699,3 +699,60 @@ def test_r6_24_reserved_recognition_subsections_do_not_warn(caplog):
         AppConfig.from_dict(raw)
     assert not any("acrcloud" in m.getMessage() or "audd" in m.getMessage()
                    for m in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# AudD backend (#453) — backend selection + nested token, secret never leaked
+# ---------------------------------------------------------------------------
+
+def test_audd_is_an_implemented_backend():
+    from src.config import IMPLEMENTED_BACKENDS
+    assert "audd" in IMPLEMENTED_BACKENDS
+
+
+def test_audd_backend_with_token_parses():
+    raw = _valid_raw()
+    raw["recognition"]["backend"] = "audd"
+    raw["recognition"]["audd"] = {"api_token": "tok-123"}
+    cfg = AppConfig.from_dict(raw)
+    assert cfg.recognition.backend == "audd"
+    assert cfg.recognition.audd_api_token == "tok-123"
+
+
+def test_audd_backend_without_token_is_rejected():
+    raw = _valid_raw()
+    raw["recognition"]["backend"] = "audd"  # no recognition.audd.api_token
+    with pytest.raises(ConfigError) as exc:
+        AppConfig.from_dict(raw)
+    assert "audd.api_token" in str(exc.value)
+
+
+def test_audd_token_value_is_never_leaked_in_config_error():
+    raw = _valid_raw()
+    raw["recognition"]["backend"] = "audd"
+    raw["recognition"]["audd"] = {"api_token": "SECRET-TOKEN-XYZ"}
+    raw["recognition"]["poll_interval_seconds"] = 0  # force a separate error
+    with pytest.raises(ConfigError) as exc:
+        AppConfig.from_dict(raw)
+    assert "SECRET-TOKEN-XYZ" not in str(exc.value)
+
+
+def test_shazamio_default_ignores_a_present_audd_token():
+    raw = _valid_raw()
+    raw["recognition"]["audd"] = {"api_token": "unused"}
+    cfg = AppConfig.from_dict(raw)  # backend defaults to shazamio; must not raise
+    assert cfg.recognition.backend == "shazamio"
+    assert cfg.recognition.audd_api_token == "unused"
+
+
+def test_audd_placeholder_token_is_rejected():
+    """LOW-2: the config.example.yaml placeholder is non-empty, so it passes the
+    required-when-audd gate but then fails every AudD call. Reject it at config
+    time (value-free), mirroring the Discogs placeholder rejection (R7-17)."""
+    raw = _valid_raw()
+    raw["recognition"]["backend"] = "audd"
+    raw["recognition"]["audd"] = {"api_token": "YOUR_AUDD_TOKEN"}
+    with pytest.raises(ConfigError) as exc:
+        AppConfig.from_dict(raw)
+    assert "audd.api_token" in str(exc.value)
+    assert "placeholder" in str(exc.value)


### PR DESCRIPTION
Makes recognition a **pluggable, user-selectable backend** and adds **AudD** as the recommended engine. ShazamIO proved unreliable on the live Pi (no-match on audio AudD *and* the official Shazam app matched); this gives operators a dependable option while keeping ShazamIO the free, zero-config default.

## What's in it
- **`AuddBackend(RecognizerBackend)`** (`src/audio/recognizer.py`): reuses `ShazamIOBackend._encode_wav`, POSTs to `api.audd.io` (lazy `aiohttp` import, so the module stays importable/unit-testable without the HTTP stack), pure `_parse_audd` (success / null no-match / `status=error`). A bad token, quota exhaustion, timeout, or transport error is routed through the throttled failure log and swallowed as a **miss** — it can never crash `RecognitionLoop.run()`.
- **Config** (`src/config.py`): `"audd"` added to `IMPLEMENTED_BACKENDS`; nested `recognition.audd.api_token` read **directly** (never through `_field`) so the secret is never echoed into a `ConfigError` (journal-logged). Fail-fast validation: `backend: audd` with a missing token **or** the unedited `YOUR_AUDD_TOKEN` placeholder errors at startup (`EX_CONFIG`), mirroring the existing Discogs placeholder rejection (R7-17).
- **Docs**: `docs/recognition-backends.md` (decision guide — AudD recommended, honest ShazamIO caveats), plus README + `config.example.yaml`. **Default stays `shazamio`** — the app still works on a fresh clone with no signup.

## Testing & review
- RED-first throughout. 17 new tests (5 config + 12 backend); **215 passed / 1 skipped** across the recognition + config + wiring surface, no regression.
- Independent adversarial cold review (no shared context): 19 malformed-JSON inputs + 4 token-leak attempts, all seven attack surfaces reproduced-clean. **No CRITICAL/HIGH/MEDIUM defects.** Two LOW findings (stale comments; placeholder token passing validation) fixed in this branch.

## Co-requisite — do NOT deploy yet
`recognition.backend = audd` should **not** be pointed at a running appliance until **#454 (per-track polling)** lands — continuous ~10s polling would blow the 1,000-request/month AudD quota. #454 is the next PR; both ship together for the v1.6.0 release.

Closes #453