### PR TITLE
feat(recognition): per-track polling — recognize ~1/track via Discogs duration + AudD offset (#454)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ Versions follow [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.PATCH`.
 
 ## [Unreleased]
 
+### Recognition backends (v1.6.0)
+
+- **Recognition is now a user-selectable backend (#453).** `recognition.backend`
+  selects `shazamio` (free, unofficial — the zero-config default, with documented
+  caveats) or **`audd`** (a commercial API; recommended for reliability after
+  ShazamIO proved unreliable in the field, returning no-match on audio AudD and the
+  official Shazam app matched). The AudD token lives in `recognition.audd.api_token`
+  (secret, gitignored) and is validated fail-fast at startup. See
+  `docs/recognition-backends.md`.
+- **Per-track recognition polling (#454).** Recognition now fires roughly **once per
+  track** instead of on every ~10 s hop: after a track confirms it idles until the
+  predicted next-track boundary — the Discogs track **duration** minus the AudD match
+  **offset** — reactivating on a needle drop or a configurable
+  `recognition.max_idle_recheck_seconds` safety re-check when no duration is
+  available. This cuts backend requests ~15–20×, keeping a paid backend (AudD) inside
+  a small monthly quota. Entirely internal — no on-screen progress/elapsed (the
+  display stays static).
+
 ## [1.5.36] — 2026-08-26
 
 > The `v1.5.35` tag and its GitHub Release were removed during a one-time

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -71,6 +71,10 @@ recognition:
   # Consecutive failed recognitions (while awaiting the first identification)
   # before the display shows "NO MATCH FOUND". Reposition the needle to retry.
   error_after_misses: 6
+  # #454: when a track has no Discogs duration to predict the next boundary from,
+  # re-check for a track change at most this often (seconds). Lower = snappier on
+  # gapless / unknown-duration tracks, but more recognition requests.
+  max_idle_recheck_seconds: 240
 
   # Only needed if backend is "acrcloud"
   acrcloud:

--- a/docs/recognition-backends.md
+++ b/docs/recognition-backends.md
@@ -40,9 +40,17 @@ The token is a secret — keep `config.yaml` mode `600` and never commit it (it 
 gitignored). Startup **fails fast** with a clear error if `backend: audd` is set
 without a token.
 
-**Cost note:** AudD bills per request. Today the app recognizes on every capture hop
-(~10 s); on a paid plan you will want per-track polling (roadmap #454) to keep usage
-low — until that lands, expect higher request counts on busy listening days.
+**Cost note:** AudD bills per request. As of v1.6.0, recognition runs **~once per
+track** — it identifies a track, then idles until the predicted next-track boundary
+(Discogs track duration minus the AudD match offset), so a normal listening month
+stays well inside a small quota. A track with no Discogs duration falls back to a
+re-check every `recognition.max_idle_recheck_seconds` (default 240 s), which also
+caps the idle between tracks so a bad duration never freezes the display.
+
+**ShazamIO note:** ShazamIO reports no match offset, so boundary prediction is less
+precise on it (it idles a full duration and may reactivate a little late); AudD
+reports the offset and lands the boundary accurately. Either way the re-check cap
+bounds the drift.
 
 ## Adding another backend
 

--- a/src/audio/recognizer.py
+++ b/src/audio/recognizer.py
@@ -73,6 +73,32 @@ _RECOGNITION_ERROR_LOG_INTERVAL_SECONDS = 60.0
 # per hop.
 _QUEUE_LAG_LOG_INTERVAL_SECONDS = 60.0
 
+# #454: per-track recognition scheduling. Recognize a few seconds PAST a predicted
+# boundary so we sample INTO the new track (past the old track's tail).
+_BOUNDARY_MARGIN_SECONDS = 3.0
+# Floor on the idle wait, so a match near a track's end (or slightly-off duration
+# data) still waits a beat rather than re-recognizing on the very next hop.
+_MIN_REACTIVATE_SECONDS = 10.0
+# When a reactivation finds the SAME track still playing (prediction ran early, or
+# the turntable is a touch slow), re-idle this long instead of polling every hop.
+_SAME_TRACK_RECHECK_SECONDS = 20.0
+
+
+def _parse_mmss(value) -> Optional[float]:
+    """Parse a Discogs duration / AudD timecode ("M:SS" or "H:MM:SS") to seconds.
+
+    Returns None for empty, non-string, or malformed input so callers fall back to
+    gap-detection / the safety timer rather than trusting a bogus boundary time."""
+    if not isinstance(value, str):
+        return None
+    parts = value.strip().split(":")
+    if not (2 <= len(parts) <= 3) or not all(p.isascii() and p.isdigit() for p in parts):
+        return None
+    secs = 0
+    for p in parts:
+        secs = secs * 60 + int(p)
+    return float(secs)
+
 
 @dataclass
 class RawRecognitionResult:
@@ -82,6 +108,10 @@ class RawRecognitionResult:
     album: str
     isrc: Optional[str] = None
     confidence: Optional[float] = None
+    # Seconds into the track where recognition matched (AudD's ``timecode``); None
+    # when the backend doesn't report one (ShazamIO). #454 uses it with the Discogs
+    # track duration to predict the next track boundary.
+    match_offset: Optional[float] = None
 
 
 class RecognizerBackend(ABC):
@@ -366,6 +396,7 @@ class AuddBackend(RecognizerBackend):
             artist=str(res.get("artist") or ""),
             album=str(res.get("album") or ""),
             isrc=None,
+            match_offset=_parse_mmss(res.get("timecode")),
         )
 
 
@@ -417,6 +448,13 @@ class RecognitionLoop:
         self.backend_name: str = config.backend
         # AudD backend credential (validated required-when-audd in config.py).
         self._audd_api_token: str = config.audd_api_token
+        # #454: per-track recognition gating. Recognition is "active" until a track
+        # confirms, then idles until the predicted next-track boundary (or a needle
+        # drop). Gates the COSTLY backend call only — capture/silence run unchanged.
+        self._recognition_active: bool = True
+        self._reactivate_at: float = 0.0
+        self._safety_recheck_seconds: float = config.max_idle_recheck_seconds
+        self._last_seen_session_epoch: int = 0
         self._audio_queue: asyncio.Queue = asyncio.Queue(maxsize=5)
         # R10-11 (#424): throttled health signal for recognition-queue lag. Single
         # key (the message carries the varying age/drop numbers, formatted at emit)
@@ -583,6 +621,13 @@ class RecognitionLoop:
                          % suppressed) if suppressed else "",
                     )
 
+            # #454: per-track gating — skip the (costly) backend call while idling
+            # between tracks. A fresh needle drop (new session epoch) still
+            # recognizes at once; everything above (dequeue, staleness drain) has
+            # already run, so capture never blocks.
+            if not self._wants_recognition(epoch, time.monotonic()):
+                continue
+
             try:
                 # PCONC-2: bound the recognition call itself. Without this a
                 # degraded shazamio call (its default retry is attempts=20 ×
@@ -743,8 +788,15 @@ class RecognitionLoop:
             # the pending, preserving hit/miss/hit accumulation of the SAME track;
             # a confirmed different current track is a stronger signal than a lone
             # stale competitor and legitimately resets it.
+            was_building = self._pending_count > 0
             self._pending_result = None
             self._pending_count = 0
+            # #454: same track still playing at reactivation (prediction early /
+            # turntable slow) — re-idle a short beat. If a NEW-track candidate was
+            # mid-confirmation, a stray current-track hit shouldn't send us idle
+            # (cold-review LOW) — keep recognizing to confirm the change.
+            if not was_building:
+                self._reidle_same_track(time.monotonic())
             return  # Same track still playing
 
         if self._same_track(result, self._pending_result):
@@ -765,6 +817,9 @@ class RecognitionLoop:
             await self.on_confirmed(result, epoch)
             self._pending_result = None
             self._pending_count = 0
+            # #454: track confirmed — idle recognition until the predicted next
+            # boundary (reads the just-committed state.current_track duration).
+            self._go_idle_until_boundary(result, time.monotonic())
         else:
             # A non-None result that neither matches the current track nor (yet)
             # confirms — unconfirmable churn (a noisy room, two records bleeding
@@ -785,6 +840,70 @@ class RecognitionLoop:
                 )
             self._register_miss()
 
+    def _current_track_duration_seconds(self) -> Optional[float]:
+        """Duration (seconds) of the currently-committed track from its Discogs
+        tracklist row, or None when unknown (no track, unmatched row, a row with no
+        duration string, or any malformed metadata — all fall back to the safety
+        timer)."""
+        try:
+            track = self.state.current_track
+            if track is None:
+                return None
+            idx = track.side_index.global_index
+            if idx is None or not (0 <= idx < len(track.tracklist)):
+                return None
+            return _parse_mmss(track.tracklist[idx].duration)
+        except Exception:
+            return None
+
+    def _go_idle_until_boundary(self, result: "RawRecognitionResult", now: float) -> None:
+        """A track just confirmed — idle recognition until the predicted next-track
+        boundary (Discogs duration minus the AudD match offset), or the safety
+        re-check interval when no duration is available (#454)."""
+        duration = self._current_track_duration_seconds()
+        if duration is not None:
+            remaining = duration - (result.match_offset or 0.0)
+            wait = max(remaining, _MIN_REACTIVATE_SECONDS) + _BOUNDARY_MARGIN_SECONDS
+        else:
+            wait = self._safety_recheck_seconds
+        # #454 (cold-review MEDIUM): never idle longer than the safety interval, so a
+        # garbage Discogs duration ("99:00" -> 99 min) can't freeze the display for a
+        # whole side; the display lag is universally bounded.
+        wait = min(wait, self._safety_recheck_seconds)
+        self._reactivate_at = now + wait
+        self._recognition_active = False
+
+    def _reidle_same_track(self, now: float) -> None:
+        """Reactivation found the same track still playing — re-idle a short beat
+        rather than recognizing every hop until it actually changes (#454)."""
+        self._reactivate_at = now + _SAME_TRACK_RECHECK_SECONDS
+        self._recognition_active = False
+
+    def _back_off_after_error(self, now: float) -> None:
+        """NO MATCH FOUND — back recognition off to the safety interval so an
+        unrecognizable side can't hammer the backend (#454)."""
+        self._reactivate_at = now + self._safety_recheck_seconds
+        self._recognition_active = False
+
+    def _wants_recognition(self, epoch: int, now: float) -> bool:
+        """Whether to run the (costly) backend on the just-dequeued chunk (#454).
+
+        A new session (needle drop → epoch bump) always recognizes immediately —
+        even mid-idle — so a fresh record is identified at once. Otherwise, while
+        idling between tracks, recognize only once the reactivation time arrives.
+        """
+        if epoch != self._last_seen_session_epoch:
+            self._last_seen_session_epoch = epoch
+            self._recognition_active = True
+        # #454 (cold-review HIGH): LISTENING means no track is up yet — always try,
+        # so a needle reposition out of ERROR/IDLE recovers at once (its brief
+        # silence does NOT bump session_epoch), instead of waiting out the idle timer.
+        if self.state.status == PlayerStatus.LISTENING:
+            self._recognition_active = True
+        if not self._recognition_active and now >= self._reactivate_at:
+            self._recognition_active = True
+        return self._recognition_active
+
     def _register_miss(self):
         """Count a failed recognition; surface ERROR after enough of them.
 
@@ -804,5 +923,13 @@ class RecognitionLoop:
                 )
                 self._miss_count = 0
                 self.state.set_status(PlayerStatus.ERROR)
+                # #454: back off after NO MATCH FOUND so an unrecognizable side
+                # can't hammer the backend; a needle move / the safety timer retries.
+                self._back_off_after_error(time.monotonic())
         else:
             self._miss_count = 0
+            # #454 (cold-review MEDIUM): a miss while ERROR is latched must re-back-off,
+            # not fall through to recognizing every hop — each still-unmatched wake
+            # from the safety timer re-idles again (bounded requests, not a flood).
+            if self.state.status == PlayerStatus.ERROR:
+                self._back_off_after_error(time.monotonic())

--- a/src/config.py
+++ b/src/config.py
@@ -418,6 +418,9 @@ class RecognitionConfig:
     # ``recognition.audd.api_token`` sub-section (see from_dict). Required only
     # when backend == "audd". A secret — never echoed in a ConfigError.
     audd_api_token: str = ""
+    # #454: upper bound on how long recognition idles between tracks when it has
+    # no Discogs duration to predict the next boundary from (the safety re-check).
+    max_idle_recheck_seconds: float = 240.0
 
     @classmethod
     def from_dict(cls, data: dict, errors: list) -> "RecognitionConfig":
@@ -430,6 +433,7 @@ class RecognitionConfig:
         backend = _field(data, "backend", str, "shazamio", section=s, errors=errors)
         confirmation_required = _field(data, "confirmation_required", int, 2, section=s, errors=errors)
         error_after_misses = _field(data, "error_after_misses", int, 6, section=s, errors=errors)
+        max_idle_recheck_seconds = _field(data, "max_idle_recheck_seconds", float, 240.0, section=s, errors=errors)
         # The "audd" backend's token lives in the nested ``recognition.audd``
         # sub-section (schema advertised in config.example.yaml). Read it directly
         # rather than through _field, so the secret VALUE is never echoed into a
@@ -448,6 +452,8 @@ class RecognitionConfig:
                f"  • {s}.confirmation_required: must be >= 1, got {confirmation_required!r}", errors)
         _check(error_after_misses is None or error_after_misses >= 1,
                f"  • {s}.error_after_misses: must be >= 1, got {error_after_misses!r}", errors)
+        _check(max_idle_recheck_seconds is None or max_idle_recheck_seconds > 0,
+               f"  • {s}.max_idle_recheck_seconds: must be > 0, got {max_idle_recheck_seconds!r}", errors)
         # CRIT-2: a type-valid but UNIMPLEMENTED backend (acrcloud/audd) would pass
         # here and then crash RecognitionLoop.__init__ outside main()'s try/except.
         # (A type error already fell back to the valid "shazamio" default, so this
@@ -470,6 +476,7 @@ class RecognitionConfig:
             confirmation_required=confirmation_required,
             error_after_misses=error_after_misses,
             audd_api_token=audd_api_token,
+            max_idle_recheck_seconds=max_idle_recheck_seconds,
         )
 
 

--- a/tests/test_audd_backend.py
+++ b/tests/test_audd_backend.py
@@ -87,3 +87,18 @@ def test_init_backend_selects_audd_with_token():
     loop = RecognitionLoop(cfg, MagicMock(), MagicMock())
     assert isinstance(loop.backend, AuddBackend)
     assert loop.backend._api_token == "tok"
+
+
+# --- #454 step 1: surface AudD match offset (timecode) ---
+
+def test_parse_populates_match_offset_from_timecode():
+    r = AuddBackend._parse_audd({"status": "success", "result": {"title": "T", "timecode": "01:33"}})
+    assert r.match_offset == 93.0
+
+def test_parse_missing_timecode_offset_is_none():
+    assert AuddBackend._parse_audd({"status": "success", "result": {"title": "T"}}).match_offset is None
+
+def test_parse_malformed_timecode_offset_is_none():
+    for bad in ("xx", "", "1", "1:2:3:4", "a:b"):
+        r = AuddBackend._parse_audd({"status": "success", "result": {"title": "T", "timecode": bad}})
+        assert r.match_offset is None, bad

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -756,3 +756,18 @@ def test_audd_placeholder_token_is_rejected():
         AppConfig.from_dict(raw)
     assert "audd.api_token" in str(exc.value)
     assert "placeholder" in str(exc.value)
+
+
+def test_max_idle_recheck_seconds_default_and_override():
+    cfg = AppConfig.from_dict(_valid_raw())
+    assert cfg.recognition.max_idle_recheck_seconds == 240.0
+    raw = _valid_raw()
+    raw["recognition"]["max_idle_recheck_seconds"] = 90
+    assert AppConfig.from_dict(raw).recognition.max_idle_recheck_seconds == 90.0
+
+def test_max_idle_recheck_seconds_must_be_positive():
+    raw = _valid_raw()
+    raw["recognition"]["max_idle_recheck_seconds"] = 0
+    with pytest.raises(ConfigError) as exc:
+        AppConfig.from_dict(raw)
+    assert "max_idle_recheck_seconds" in str(exc.value)

--- a/tests/test_per_track_polling.py
+++ b/tests/test_per_track_polling.py
@@ -1,0 +1,182 @@
+"""#454: per-track recognition scheduling — gate the costly backend call between
+tracks, driven by Discogs duration + AudD match offset, with safety fallbacks."""
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pytest
+
+from src.audio.recognizer import (
+    RawRecognitionResult, RecognitionLoop,
+    _BOUNDARY_MARGIN_SECONDS, _MIN_REACTIVATE_SECONDS, _SAME_TRACK_RECHECK_SECONDS,
+)
+from tests.factories import make_recognition_config
+
+
+def _loop(**cfg):
+    config = make_recognition_config(**cfg)
+    with patch.object(RecognitionLoop, "_init_backend", return_value=MagicMock()):
+        return RecognitionLoop(config, MagicMock(), AsyncMock())
+
+
+def _track(idx, durations):
+    return SimpleNamespace(
+        side_index=SimpleNamespace(global_index=idx),
+        tracklist=[SimpleNamespace(duration=d) for d in durations],
+    )
+
+
+# --- duration extraction ---
+
+def test_duration_from_current_track():
+    loop = _loop()
+    loop.state.current_track = _track(1, ["3:00", "4:12"])
+    assert loop._current_track_duration_seconds() == 252.0
+
+def test_duration_none_for_missing_track_bad_index_or_no_string():
+    loop = _loop()
+    loop.state.current_track = None
+    assert loop._current_track_duration_seconds() is None
+    loop.state.current_track = _track(None, ["3:00"])
+    assert loop._current_track_duration_seconds() is None
+    loop.state.current_track = _track(5, ["3:00"])       # out of range
+    assert loop._current_track_duration_seconds() is None
+    loop.state.current_track = _track(0, [None])         # no duration string
+    assert loop._current_track_duration_seconds() is None
+
+
+# --- idle scheduling ---
+
+def test_go_idle_predicts_boundary_from_duration_and_offset():
+    loop = _loop()
+    loop.state.current_track = _track(0, ["4:00"])       # 240s
+    loop._go_idle_until_boundary(SimpleNamespace(match_offset=30.0), now=1000.0)
+    assert loop._recognition_active is False
+    assert loop._reactivate_at == 1000.0 + (240.0 - 30.0) + _BOUNDARY_MARGIN_SECONDS
+
+def test_go_idle_floors_a_near_end_match():
+    loop = _loop()
+    loop.state.current_track = _track(0, ["4:00"])
+    loop._go_idle_until_boundary(SimpleNamespace(match_offset=239.0), now=0.0)
+    assert loop._reactivate_at == _MIN_REACTIVATE_SECONDS + _BOUNDARY_MARGIN_SECONDS
+
+def test_go_idle_uses_safety_interval_without_duration():
+    loop = _loop(max_idle_recheck_seconds=240.0)
+    loop.state.current_track = None
+    loop._go_idle_until_boundary(SimpleNamespace(match_offset=None), now=100.0)
+    assert loop._reactivate_at == 340.0 and loop._recognition_active is False
+
+def test_back_off_after_error_uses_safety_interval():
+    loop = _loop(max_idle_recheck_seconds=120.0)
+    loop._back_off_after_error(now=5.0)
+    assert loop._reactivate_at == 125.0 and loop._recognition_active is False
+
+def test_reidle_same_track_is_a_short_beat():
+    loop = _loop()
+    loop._reidle_same_track(now=0.0)
+    assert loop._reactivate_at == _SAME_TRACK_RECHECK_SECONDS and loop._recognition_active is False
+
+
+# --- gating decision ---
+
+def test_wants_recognition_active_true():
+    assert _loop()._wants_recognition(epoch=0, now=0.0) is True
+
+def test_wants_recognition_idle_before_boundary_false():
+    loop = _loop(); loop._recognition_active = False
+    loop._reactivate_at = 1000.0; loop._last_seen_session_epoch = 0
+    assert loop._wants_recognition(epoch=0, now=500.0) is False
+
+def test_wants_recognition_idle_past_boundary_reactivates():
+    loop = _loop(); loop._recognition_active = False
+    loop._reactivate_at = 100.0; loop._last_seen_session_epoch = 0
+    assert loop._wants_recognition(epoch=0, now=150.0) is True
+    assert loop._recognition_active is True
+
+def test_wants_recognition_new_session_reactivates_immediately():
+    loop = _loop(); loop._recognition_active = False
+    loop._reactivate_at = 1e12; loop._last_seen_session_epoch = 0
+    assert loop._wants_recognition(epoch=1, now=0.0) is True     # needle drop
+    assert loop._recognition_active is True and loop._last_seen_session_epoch == 1
+
+
+# --- integration: run() skips the backend while idling ---
+
+@pytest.mark.asyncio
+async def test_run_idles_after_confirm_and_skips_backend():
+    loop = _loop(confirmation_required=1)
+    loop.state.session_epoch = 7
+    loop.state.current_raw = None
+    loop.state.current_track = None                              # -> safety idle
+    loop.backend.recognize = AsyncMock(return_value=RawRecognitionResult("T", "A", "Al"))
+
+    await loop.enqueue(np.zeros(4, dtype=np.float32), 44100)     # confirms (req=1)
+    task = asyncio.create_task(loop.run())
+    for _ in range(10):
+        await asyncio.sleep(0)
+        if loop.on_confirmed.await_count:
+            break
+    assert loop.backend.recognize.await_count == 1
+    assert loop._recognition_active is False                     # idled after confirm
+
+    loop._reactivate_at = 1e12                                   # force "not yet"
+    await loop.enqueue(np.ones(4, dtype=np.float32), 44100)      # same epoch, idling
+    for _ in range(10):
+        await asyncio.sleep(0)
+    assert loop.backend.recognize.await_count == 1              # skipped, still 1
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+# --- cold-review fixes (#454) ---
+from src.state.player_state import PlayerStatus  # noqa: E402
+
+def test_listening_status_forces_active_recovery():
+    """HIGH: reposition out of ERROR/IDLE re-enters LISTENING WITHOUT a session-epoch
+    bump — recognition must re-arm at once, not wait out the idle timer."""
+    loop = _loop()
+    loop._recognition_active = False
+    loop._reactivate_at = 1e12
+    loop._last_seen_session_epoch = 3
+    loop.state.status = PlayerStatus.LISTENING
+    assert loop._wants_recognition(epoch=3, now=0.0) is True
+    assert loop._recognition_active is True
+
+def test_error_miss_rebacks_off_instead_of_hammering():
+    """MEDIUM: a miss while ERROR is latched re-backs-off (not recognize-every-hop)."""
+    loop = _loop(max_idle_recheck_seconds=120.0)
+    loop.state.status = PlayerStatus.ERROR
+    loop._recognition_active = True
+    loop._reactivate_at = 0.0
+    loop._register_miss()
+    assert loop._recognition_active is False
+
+def test_go_idle_clamps_garbage_duration_to_safety():
+    """MEDIUM: a valid-but-garbage Discogs duration is clamped to the safety cap."""
+    loop = _loop(max_idle_recheck_seconds=240.0)
+    loop.state.current_track = _track(0, ["99:00"])   # 5940s
+    loop._go_idle_until_boundary(SimpleNamespace(match_offset=0.0), now=0.0)
+    assert loop._reactivate_at == 240.0
+
+def test_parse_mmss_rejects_unicode_digits():
+    from src.audio.recognizer import _parse_mmss
+    assert _parse_mmss("²:00") is None
+
+async def test_same_track_reidle_only_when_not_building():
+    a = RawRecognitionResult("A", "Ar", "Al")
+    loop = _loop(confirmation_required=2)
+    loop.state.current_raw = a
+    loop._pending_result = None; loop._pending_count = 0
+    loop._recognition_active = True
+    await loop._handle_result(a)                       # steady state -> re-idle
+    assert loop._recognition_active is False
+
+    loop2 = _loop(confirmation_required=2)
+    loop2.state.current_raw = a
+    loop2._pending_result = RawRecognitionResult("B", "Ar", "Al"); loop2._pending_count = 1
+    loop2._recognition_active = True
+    await loop2._handle_result(a)                      # building B -> stray A hit stays active
+    assert loop2._recognition_active is True


### PR DESCRIPTION
Co-requisite of #453 (AudD backend). Recognition now fires **~once per track** instead of on every ~10s hop, so a **paid** backend (AudD) stays inside a small monthly quota. Both make **v1.6.0** (the CHANGELOG `[Unreleased]` entry here covers both).

## Mechanism
Gate the costly `backend.recognize()` call:
- **Predicted boundary:** after a track confirms, idle until `Discogs track duration − AudD match offset (+margin)`, read from the just-committed `state.current_track`. Precise per-track timing.
- **Fallbacks (graceful degradation):** no offset (ShazamIO) → idle a full duration; no duration (DB/MusicBrainz/no match) → `recognition.max_idle_recheck_seconds` safety re-check (default 240s, which also **caps** every idle so a garbage duration can't freeze the display); a needle drop (session-epoch bump) reactivates at once; same-track-at-reactivation re-idles a short beat; `NO MATCH FOUND` backs off instead of hammering.
- **Durations were already surfaced** (`TrackMetadata.tracklist[*].duration`) — no new API call. Internal only — no on-screen progress/elapsed (PRODUCT.md static-display holds).

New: `match_offset` on `RawRecognitionResult` (from AudD `timecode`; ShazamIO `None`), shared `_parse_mmss` parser, `recognition.max_idle_recheck_seconds` config.

## Review
Two independent adversarial cold-review passes:
1. First pass found a **HIGH regression** (ERROR→reposition recovery gated for ~240s), 2 MEDIUM (ERROR hammering after first back-off; garbage-duration freeze), 2 LOW — **all fixed** (one LOW closed a *pre-existing* latent crash on adversarial AudD timecodes). Root fix: LISTENING always recognizes; each ERROR miss re-backs-off; idle clamped to the safety cap.
2. Tight second pass over *only* the reworked hunks: **clean**, converged.

RED-first throughout; 17 scheduler tests + config/offset tests; **254 passed / 1 skipped** across recognizer + config + error-state + wiring, no regression.

## Rollout
Safe to point a live appliance at `backend: audd` **after this merges** (together with #453). Then cut **v1.6.0**.

Closes #454