### PR TITLE
Fix #460: short-retry recognition after a failed opener on a gapless side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Versions follow [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.PATCH`.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A failed opener no longer blocks recognition of later tracks on a gapless side
+  (#460).** When an unrecognizable track (e.g. a short instrumental opener) latched
+  `NO MATCH FOUND`, per-track polling (#454) backed off to the full safety interval
+  (240s) — longer than a track — so it could never accumulate the two consecutive
+  matches needed to confirm a later, recognizable track: the whole side stayed stuck.
+  Recognition now retries at a short interval (~30s) while unidentified, so two
+  consecutive wakes land inside the same later track and reach the two-match
+  confirmation — later tracks are caught within ~60s; a genuinely all-instrumental
+  side remains bounded (~2 requests/min). A v1.6.0 regression.
+
 ## [1.6.0] — 2026-08-27
 
 ### Recognition backends

--- a/src/audio/recognizer.py
+++ b/src/audio/recognizer.py
@@ -82,6 +82,12 @@ _MIN_REACTIVATE_SECONDS = 10.0
 # When a reactivation finds the SAME track still playing (prediction ran early, or
 # the turntable is a touch slow), re-idle this long instead of polling every hop.
 _SAME_TRACK_RECHECK_SECONDS = 20.0
+# #460: while UNIDENTIFIED (NO MATCH FOUND latched), retry this often — short enough
+# that two consecutive wakes land inside the same later track, so it reaches the
+# 2-match confirmation and a failed opener no longer strands the rest of a gapless
+# side. Distinct from the (longer) between-known-tracks safety interval; still far
+# above the ~10s hop, so an all-instrumental side stays bounded (~2 requests/min).
+_ERROR_RETRY_SECONDS = 30.0
 
 
 def _parse_mmss(value) -> Optional[float]:
@@ -880,9 +886,11 @@ class RecognitionLoop:
         self._recognition_active = False
 
     def _back_off_after_error(self, now: float) -> None:
-        """NO MATCH FOUND — back recognition off to the safety interval so an
-        unrecognizable side can't hammer the backend (#454)."""
-        self._reactivate_at = now + self._safety_recheck_seconds
+        """NO MATCH FOUND — back recognition off so an unrecognizable side can't
+        hammer the backend, but only to the SHORT ERROR retry (#460), not the long
+        between-known-tracks safety interval: 240s exceeds a track, so it could never
+        accumulate the two consecutive matches needed to confirm a later track."""
+        self._reactivate_at = now + _ERROR_RETRY_SECONDS
         self._recognition_active = False
 
     def _wants_recognition(self, epoch: int, now: float) -> bool:

--- a/tests/test_per_track_polling.py
+++ b/tests/test_per_track_polling.py
@@ -67,10 +67,14 @@ def test_go_idle_uses_safety_interval_without_duration():
     loop._go_idle_until_boundary(SimpleNamespace(match_offset=None), now=100.0)
     assert loop._reactivate_at == 340.0 and loop._recognition_active is False
 
-def test_back_off_after_error_uses_safety_interval():
+def test_back_off_after_error_uses_short_error_retry():
+    # #460: ERROR backs off to the SHORT error retry, not the (long) safety interval —
+    # 240s exceeds a track and could never confirm a later one.
+    from src.audio.recognizer import _ERROR_RETRY_SECONDS
     loop = _loop(max_idle_recheck_seconds=120.0)
     loop._back_off_after_error(now=5.0)
-    assert loop._reactivate_at == 125.0 and loop._recognition_active is False
+    assert loop._reactivate_at == 5.0 + _ERROR_RETRY_SECONDS
+    assert loop._recognition_active is False
 
 def test_reidle_same_track_is_a_short_beat():
     loop = _loop()
@@ -180,3 +184,42 @@ async def test_same_track_reidle_only_when_not_building():
     loop2._recognition_active = True
     await loop2._handle_result(a)                      # building B -> stray A hit stays active
     assert loop2._recognition_active is True
+
+
+# --- #460: a failed opener must not block later-track recognition on a gapless side ---
+from src.state.player_state import PlayerStatus  # noqa: E402,F811
+import asyncio as _asyncio  # noqa: E402
+
+def test_error_backoff_uses_short_retry_not_safety_interval():
+    from src.audio.recognizer import _ERROR_RETRY_SECONDS
+    loop = _loop(max_idle_recheck_seconds=240.0)
+    loop._back_off_after_error(now=0.0)
+    assert loop._reactivate_at == _ERROR_RETRY_SECONDS
+    assert _ERROR_RETRY_SECONDS < 240.0
+
+async def test_later_track_confirms_across_error_retries():
+    """#460: in ERROR, a later recognizable track confirms across two short-retry
+    wakes ~30s apart (no needle lift). Hunk 1 (30s retry) is the fix; each wake is one
+    recognition, and two consecutive same-track hits reach confirmation_required."""
+    import src.audio.recognizer as rec
+    loop = _loop(confirmation_required=2)
+    loop.state.status = PlayerStatus.ERROR
+    loop.state.current_raw = None
+    loop.state.current_track = None
+    loop._last_seen_session_epoch = 5
+    peddler = RawRecognitionResult("Peddler", "Lunar Vacation", "X")
+
+    # wake 1 @ t=100: reactivates (timer), recognizes -> pending 1, backs off to t=130
+    loop._recognition_active = False
+    loop._reactivate_at = 100.0
+    assert loop._wants_recognition(epoch=5, now=100.0) is True
+    with patch.object(rec.time, "monotonic", return_value=100.0):
+        await loop._handle_result(peddler)
+    assert loop.on_confirmed.await_count == 0
+    assert loop._recognition_active is False and loop._reactivate_at == 130.0
+
+    # wake 2 @ t=131 (>= 130): reactivates, recognizes same track -> pending 2 -> confirm
+    assert loop._wants_recognition(epoch=5, now=131.0) is True
+    with patch.object(rec.time, "monotonic", return_value=131.0):
+        await loop._handle_result(peddler)
+    assert loop.on_confirmed.await_count == 1


### PR DESCRIPTION
Closes #460

An unrecognizable instrumental opener latched status ERROR, which backed off recognition for the full 240s safety interval. On a gapless side that exceeds a track length, so a later recognizable track could get one match but never the two consecutive matches confirmation requires — the whole side stayed stuck.

Fix: while unidentified (ERROR latched), retry at a short 30s interval instead of the 240s between-known-tracks safety cap, so two consecutive wakes land inside the same later track and reach the two-match confirmation. An all-instrumental side stays bounded at ~2 requests/min.

RED-first repro + full suite green.