### PR TITLE
Fix #464: fast-poll to confirm a candidate in ERROR, bounded against strays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Versions follow [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.PATCH`.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **A side that starts with an unidentifiable track no longer stays stuck on "NO
+  MATCH FOUND" (#464).** After an unfingerprintable opener latched the ERROR state,
+  recognition polled only every ~40s, but committing a track needs two consecutive
+  same-track matches — and AudD identifies a given track only intermittently, so a
+  later, recognizable track could never land twice before it ended. Once a candidate
+  is building, recognition now polls at the fast chunk rate to catch its confirming
+  second hit while the track is still playing, bounded so a stray misrecognition
+  can't keep polling the backend (a genuinely unrecognizable side stays at ~2
+  requests/min). Two-match confirmation is retained. A v1.6.0 regression, surfaced
+  by v1.6.1 hardware testing.
+
 ## [1.6.1] — 2026-08-27
 
 ### Fixed

--- a/src/audio/recognizer.py
+++ b/src/audio/recognizer.py
@@ -89,6 +89,18 @@ _SAME_TRACK_RECHECK_SECONDS = 20.0
 # above the ~10s hop, so an all-instrumental side stays bounded (~2 requests/min).
 _ERROR_RETRY_SECONDS = 30.0
 
+# #464: while a candidate is mid-confirmation we poll at the fast chunk rate to catch
+# its confirming second hit before the track ends. Cap the burst: after this many
+# non-confirming attempts (misses OR unconfirmable churn) void the candidate and
+# resume the slow back-off, so a stray/one-off misrecognition can't fast-poll the
+# backend forever. The FIRST hit consumes one attempt (it goes through the churn
+# branch), so a cap of 7 leaves ~6 chunk hops (~60s at a 10s hop) for the confirming
+# second hit — comfortably longer than the gap between two real hits of a playing
+# track — while bounding a stray's burst to ~7 fast polls before the 30s back-off
+# resumes. (A sustained fresh-misrecognition-every-window side is still bounded, at
+# ~2.25x the idle rate — acceptably rare and far under the AudD quota.)
+_CANDIDATE_CONFIRM_ATTEMPTS = 7
+
 
 def _parse_mmss(value) -> Optional[float]:
     """Parse a Discogs duration / AudD timecode ("M:SS" or "H:MM:SS") to seconds.
@@ -474,6 +486,9 @@ class RecognitionLoop:
         # session_epoch via clear()), so a leftover count can't let a single
         # spurious hit confirm a stale track into the NEXT record's session.
         self._pending_epoch: int = 0
+        # #464: non-confirming recognition attempts spent on the current candidate
+        # burst; bounds the fast-poll so a stray pending can't hammer the backend.
+        self._confirm_attempts: int = 0
         # PCONC-3: the epoch of the last chunk _handle_result saw, so a session
         # boundary (needle lift → session_epoch bump) can reset the per-session
         # health counters below. Epochs only increase and chunks are handled
@@ -763,6 +778,7 @@ class RecognitionLoop:
         if self._pending_result is not None and epoch != self._pending_epoch:
             self._pending_result = None
             self._pending_count = 0
+            self._confirm_attempts = 0
 
         if result is None:
             # REC-1: a None (unrecognized-audio) result carries NO recognition
@@ -779,6 +795,10 @@ class RecognitionLoop:
             # confirms first, so ERROR fires only when the side is genuinely
             # unrecognizable (and a later reappearance still recovers).
             self._register_miss()
+            if self._pending_count > 0:
+                self._confirm_attempts += 1
+                if self._confirm_attempts >= _CANDIDATE_CONFIRM_ATTEMPTS:
+                    self._void_stale_candidate(time.monotonic())
             return
 
         if self._same_track(result, self.state.current_raw):
@@ -797,6 +817,7 @@ class RecognitionLoop:
             was_building = self._pending_count > 0
             self._pending_result = None
             self._pending_count = 0
+            self._confirm_attempts = 0
             # #454: same track still playing at reactivation (prediction early /
             # turntable slow) — re-idle a short beat. If a NEW-track candidate was
             # mid-confirmation, a stray current-track hit shouldn't send us idle
@@ -823,6 +844,7 @@ class RecognitionLoop:
             await self.on_confirmed(result, epoch)
             self._pending_result = None
             self._pending_count = 0
+            self._confirm_attempts = 0
             # #454: track confirmed — idle recognition until the predicted next
             # boundary (reads the just-committed state.current_track duration).
             self._go_idle_until_boundary(result, time.monotonic())
@@ -845,6 +867,9 @@ class RecognitionLoop:
                     self._churn_count, result.artist, result.title,
                 )
             self._register_miss()
+            self._confirm_attempts += 1
+            if self._confirm_attempts >= _CANDIDATE_CONFIRM_ATTEMPTS:
+                self._void_stale_candidate(time.monotonic())
 
     def _current_track_duration_seconds(self) -> Optional[float]:
         """Duration (seconds) of the currently-committed track from its Discogs
@@ -893,6 +918,16 @@ class RecognitionLoop:
         self._reactivate_at = now + _ERROR_RETRY_SECONDS
         self._recognition_active = False
 
+    def _void_stale_candidate(self, now: float) -> None:
+        """#464: a candidate never got its confirming second hit within the fast-poll
+        burst (the track ended, or it was a stray/one-off misrecognition) — discard it
+        and resume the slow back-off, so a stranded pending can't fast-poll forever."""
+        self._pending_result = None
+        self._pending_count = 0
+        self._confirm_attempts = 0
+        self._reactivate_at = now + _ERROR_RETRY_SECONDS
+        self._recognition_active = False
+
     def _wants_recognition(self, epoch: int, now: float) -> bool:
         """Whether to run the (costly) backend on the just-dequeued chunk (#454).
 
@@ -907,6 +942,12 @@ class RecognitionLoop:
         # so a needle reposition out of ERROR/IDLE recovers at once (its brief
         # silence does NOT bump session_epoch), instead of waiting out the idle timer.
         if self.state.status == PlayerStatus.LISTENING:
+            self._recognition_active = True
+        # #464: a candidate is mid-confirmation — poll at the fast chunk rate,
+        # ignoring the ERROR/idle back-off timer, so its confirming second hit is
+        # caught while the same track is still playing. Bounded by _confirm_attempts
+        # in _handle_result (a stale candidate is voided), so this can't hammer.
+        if self._pending_count > 0:
             self._recognition_active = True
         if not self._recognition_active and now >= self._reactivate_at:
             self._recognition_active = True

--- a/tests/test_per_track_polling.py
+++ b/tests/test_per_track_polling.py
@@ -223,3 +223,108 @@ async def test_later_track_confirms_across_error_retries():
     with patch.object(rec.time, "monotonic", return_value=131.0):
         await loop._handle_result(peddler)
     assert loop.on_confirmed.await_count == 1
+
+
+# --- #464: fast-poll to confirm a candidate in ERROR, bounded so a stray can't hammer ---
+
+@pytest.mark.asyncio
+async def test_wants_recognition_fast_polls_while_candidate_building():
+    """#464: a pending candidate forces recognition active, ignoring the ERROR
+    back-off timer, so the confirming second hit is caught while the track plays."""
+    loop = _loop()
+    loop.state.status = PlayerStatus.ERROR
+    loop._recognition_active = False
+    loop._reactivate_at = 1e12          # far future — the timer alone would say "wait"
+    loop._last_seen_session_epoch = 0
+    loop._pending_result = RawRecognitionResult("Peddler", "Lunar Vacation", "X")
+    loop._pending_count = 1
+    assert loop._wants_recognition(epoch=0, now=0.0) is True
+
+def test_all_none_side_never_fast_polls():
+    """A genuinely unrecognizable side never builds a candidate, so it never
+    fast-polls — the slow ERROR back-off (cost bound, ~2 req/min) is preserved."""
+    loop = _loop()
+    loop.state.status = PlayerStatus.ERROR
+    loop._recognition_active = False
+    loop._reactivate_at = 1e12
+    loop._last_seen_session_epoch = 0
+    assert loop._pending_count == 0
+    assert loop._wants_recognition(epoch=0, now=0.0) is False
+
+@pytest.mark.asyncio
+async def test_intermittent_track_confirms_via_fast_poll_in_error():
+    """#464 core: after ERROR latches on an unfingerprintable opener, a later track
+    AudD identifies (with a miss between the two hits) reaches the two-match
+    confirmation via fast-polling — no wall-clock wait needed."""
+    loop = _loop(confirmation_required=2)
+    loop.state.status = PlayerStatus.ERROR
+    loop.state.current_raw = None
+    loop._last_seen_session_epoch = 0
+    peddler = RawRecognitionResult("Peddler", "Lunar Vacation", "X")
+    await loop._handle_result(peddler)
+    assert loop._pending_count == 1 and loop.on_confirmed.await_count == 0
+    assert loop._wants_recognition(epoch=0, now=0.0) is True     # fast-poll armed
+    await loop._handle_result(None)                              # a miss between hits
+    assert loop._pending_count == 1                              # REC-1: miss keeps pending
+    await loop._handle_result(peddler)
+    assert loop.on_confirmed.await_count == 1                    # confirmed via fast-poll
+
+@pytest.mark.asyncio
+async def test_stray_candidate_voided_after_cap_then_slow_backoff():
+    """A stray hit that never gets a confirming second hit is voided after the attempt
+    cap, and recognition drops back to the slow back-off — a stranded pending cannot
+    fast-poll the backend forever (the cost guard)."""
+    from src.audio.recognizer import _CANDIDATE_CONFIRM_ATTEMPTS
+    loop = _loop(confirmation_required=2)
+    loop.state.status = PlayerStatus.ERROR
+    loop.state.current_raw = None
+    stray = RawRecognitionResult("I'll Stick With The Old Stuff", "Claybank", "Y")
+    await loop._handle_result(stray)
+    for _ in range(_CANDIDATE_CONFIRM_ATTEMPTS):
+        await loop._handle_result(None)
+    assert loop._pending_count == 0
+    assert loop.on_confirmed.await_count == 0
+    loop._recognition_active = False
+    assert loop._wants_recognition(epoch=0, now=0.0) is False
+
+@pytest.mark.asyncio
+async def test_flip_flopping_candidates_are_voided():
+    """One-off misrecognitions in a row never confirm and never reset the burst
+    counter, so they are voided rather than fast-polled indefinitely."""
+    loop = _loop(confirmation_required=2)
+    loop.state.status = PlayerStatus.ERROR
+    loop.state.current_raw = None
+    voided = False
+    for t in ["A","B","C","D","E","F","G","H"]:
+        await loop._handle_result(RawRecognitionResult(t, t + "-artist", "id"))
+        if loop._pending_count == 0:
+            voided = True
+            break
+    assert voided and loop.on_confirmed.await_count == 0
+
+@pytest.mark.asyncio
+async def test_confirm_tolerance_boundary_tracks_the_cap():
+    """#464 (cold-review #3): document the confirm-tolerance edge and tie it to the
+    cap. A real track whose two hits are within the burst budget confirms; one hit
+    beyond it is voided before the second hit lands."""
+    from src.audio.recognizer import _CANDIDATE_CONFIRM_ATTEMPTS as CAP
+    A = RawRecognitionResult("A", "artist", "id")
+    # within tolerance: (CAP-2) misses between the two hits still confirms
+    loop = _loop(confirmation_required=2)
+    loop.state.status = PlayerStatus.ERROR
+    loop.state.current_raw = None
+    await loop._handle_result(A)                        # attempt 1 (first hit)
+    for _ in range(CAP - 2):                            # misses keep attempts < CAP
+        await loop._handle_result(None)
+    await loop._handle_result(A)                        # confirming second hit
+    assert loop.on_confirmed.await_count == 1
+    # just beyond: (CAP-1) misses void the candidate before the second hit
+    loop2 = _loop(confirmation_required=2)
+    loop2.state.status = PlayerStatus.ERROR
+    loop2.state.current_raw = None
+    await loop2._handle_result(A)                       # attempt 1
+    for _ in range(CAP - 1):                            # attempts reaches CAP -> void
+        await loop2._handle_result(None)
+    assert loop2._pending_count == 0
+    await loop2._handle_result(A)                       # a lone hit -> pending 1, unconfirmed
+    assert loop2.on_confirmed.await_count == 0


### PR DESCRIPTION
Closes #464. After an unfingerprintable opener latched ERROR, recognition polled only every ~40s but confirmation needs two consecutive same-track hits, and AudD identifies a track only intermittently, so later tracks never confirmed and the side stayed stuck on NO MATCH FOUND (measured live on the Pi at v1.6.1). Once a candidate is building, poll at the fast chunk rate to catch the confirming second hit, bounded by a burst cap so a stray misrecognition cannot fast-poll the backend forever. A genuinely unrecognizable side stays ~2 req/min. Two-match confirmation retained. RED-first with intermittent-hit, stray-void, flip-flop, and boundary tests; cold-reviewed.