### PR TITLE
Fix #467: fill missing track durations from the album master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Versions follow [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.PATCH`.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Tracks no longer get skipped when the resolved release has no Discogs durations
+  (#467).** Some releases (a user's exact pressing included) carry no per-track
+  durations, so the per-track polling scheduler fell back to the 240s safety idle,
+  overshot the next track, and skipped it. Missing durations are now filled from the
+  album **master** — shared across every pressing, so boundaries are predictable and
+  identical regardless of which release a track resolves to. The master is fetched
+  only when a duration is actually missing (no added cost otherwise), matched by
+  track position with an index fallback, and degrades gracefully when absent.
+
 ## [1.6.2] — 2026-08-28
 
 ### Fixed

--- a/src/metadata/discogs/reader.py
+++ b/src/metadata/discogs/reader.py
@@ -650,6 +650,92 @@ class DiscogsReader:
             log.debug(f"Master year lookup failed for master {master_id}: {e}")
         return None
 
+    @staticmethod
+    def _master_id_of(release) -> Optional[int]:
+        """The release's master id, or None when it has no master / the attribute
+        access raises. Defensive like get_original_year: master data is best-effort
+        enrichment, never credit-critical."""
+        try:
+            master = release.master
+            return master.id if master else None
+        except Exception:
+            return None
+
+    def get_master_tracklist(self, release) -> list:
+        """The album MASTER's playable tracklist rows (position + duration), or []
+        when there is no master or the fetch fails. One GET per album, routed
+        through the rate-limited transport; only called when a release row is
+        missing its duration (see _overlay_master_durations)."""
+        master_id = self._master_id_of(release)
+        if not master_id:
+            return []
+        try:
+            resp = self._http.request("GET", f"{_API_BASE}/masters/{master_id}")
+            resp.raise_for_status()
+            rows = resp.json().get("tracklist") or []
+        except Exception as e:
+            # Best-effort enrichment with a graceful fallback (the scheduler's
+            # safety idle), so a transient master blip degrades rather than aborts
+            # the credit-capable resolve — mirrors get_original_year (#188).
+            log.debug(f"Master tracklist lookup failed for master {master_id}: {e}")
+            return []
+        out = []
+        for t in rows:
+            if not isinstance(t, dict):
+                continue
+            if (t.get("type_") or t.get("type")) == "heading":
+                continue
+            pos = t.get("position")
+            if not pos:
+                continue
+            out.append(TracklistEntry(
+                position=pos, title=t.get("title") or "", duration=t.get("duration") or None,
+            ))
+        return out
+
+    def _overlay_master_durations(self, release, tracklist: list) -> list:
+        """Return `tracklist` with any missing durations filled from the master.
+
+        No-ops (and skips the master GET) when every row already has a duration —
+        the common case, zero added cost. Matches master -> release rows by POSITION
+        first, then by unique normalized TITLE (handles a master whose position
+        scheme differs from the vinyl pressing's, or a side-balanced reorder — titles
+        are stable across pressings, order is not). Fails safe: a row that matches
+        neither, or whose title is ambiguous (duplicated in the master), keeps its
+        None duration and falls back to the scheduler's safety idle rather than
+        borrowing a wrong one — never an ordinal/index guess."""
+        if not tracklist or all(e.duration for e in tracklist):
+            return tracklist
+        master = self.get_master_tracklist(release)
+        if not master:
+            return tracklist
+
+        def _tkey(title):
+            return (title or "").strip().lower()
+
+        by_pos = {m.position: m.duration for m in master if m.duration}
+        # Title map: only titles that are UNIQUE in the master carry a duration, so a
+        # duplicated title never assigns a (possibly wrong) borrowed duration.
+        title_dur, title_seen = {}, {}
+        for m in master:
+            if not m.duration:
+                continue
+            k = _tkey(m.title)
+            title_seen[k] = title_seen.get(k, 0) + 1
+            title_dur[k] = m.duration
+        by_title = {k: d for k, d in title_dur.items() if title_seen[k] == 1}
+
+        out = []
+        for e in tracklist:
+            if e.duration:
+                out.append(e)
+                continue
+            d = by_pos.get(e.position) or by_title.get(_tkey(e.title))
+            out.append(
+                TracklistEntry(position=e.position, title=e.title, duration=d) if d else e
+            )
+        return out
+
     # -------------------------------------------------------------------------
     # Private helpers
     # -------------------------------------------------------------------------
@@ -979,6 +1065,13 @@ class DiscogsReader:
             _reraise_if_transient(e)
             log.warning(f"Failed to parse tracklist for release {release.id}: {e}")
             tracklist = []
+        # #467: fill any MISSING per-track durations from the album MASTER. Some
+        # Discogs release entries (a user's exact pressing included) carry no
+        # durations; without them the per-track polling scheduler falls back to the
+        # 240s safety idle and OVERSHOOTS the next track (measured: skips). The
+        # master is shared across pressings, so its durations are the release-
+        # agnostic source of truth. Only fetched when a row is actually missing one.
+        tracklist = self._overlay_master_durations(release, tracklist)
 
         # Genres and styles — styles are more specific so they come first.
         # Both are already present in the release object; no extra API call needed.

--- a/tests/test_master_durations.py
+++ b/tests/test_master_durations.py
@@ -1,0 +1,120 @@
+"""#467: fill missing per-track durations from the album MASTER, so the per-track
+polling scheduler can predict next-track boundaries even when the resolved release's
+Discogs entry carries no durations (the collection copy that skipped tracks live)."""
+from unittest.mock import MagicMock
+
+from src.metadata.models import TracklistEntry
+from tests.factories import make_discogs_reader
+
+
+def _rel(rid=555, master_id=999, tracklist=None):
+    r = MagicMock()
+    r.id = rid
+    r.images = []; r.labels = []; r.year = 1990; r.styles = ["Rock"]; r.genres = ["Rock"]
+    r.master = MagicMock(id=master_id) if master_id else None
+    r.tracklist = tracklist if tracklist is not None else [
+        MagicMock(type_=None, position="A1", title="One", duration=None),
+    ]
+    return r
+
+
+def _trow(position, title="x", duration=None, type_=None):
+    return MagicMock(type_=type_, position=position, title=title, duration=duration)
+
+
+def _master_resp(rows):
+    resp = MagicMock(); resp.status_code = 200
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {"tracklist": rows}
+    return resp
+
+
+def _mrow(position, duration, title="x", type_=None):
+    d = {"position": position, "title": title, "duration": duration}
+    if type_:
+        d["type_"] = type_
+    return d
+
+
+def test_missing_durations_filled_from_master_by_position():
+    reader = make_discogs_reader()
+    reader.get_original_year = MagicMock(return_value=None)   # isolate: skip the year master GET
+    reader._http.request = MagicMock(return_value=_master_resp(
+        [_mrow("A1", "3:04"), _mrow("A2", "3:15")]
+    ))
+    rel = _rel(tracklist=[_trow("A1", "Peddler", None), _trow("A2", "Shrug", None)])
+    result = reader._build_result(rel, instance_id=None)
+    durs = {e.position: e.duration for e in result["tracklist"]}
+    assert durs == {"A1": "3:04", "A2": "3:15"}
+
+
+def test_no_master_fetch_when_release_has_all_durations():
+    reader = make_discogs_reader()
+    reader.get_original_year = MagicMock(return_value=None)
+    reader._http.request = MagicMock()                       # would be the master GET
+    rel = _rel(tracklist=[_trow("A1", "One", "3:00")])
+    reader._build_result(rel, instance_id=None)
+    reader._http.request.assert_not_called()                 # efficiency: no master GET
+
+
+def test_title_match_when_position_schemes_differ():
+    """Master uses numbered positions, the vinyl pressing uses A1/A2 — same order,
+    different scheme. Position match misses; the unique-title match fills them."""
+    reader = make_discogs_reader()
+    reader.get_master_tracklist = MagicMock(return_value=[
+        TracklistEntry(position="1", title="Peddler", duration="3:04"),
+        TracklistEntry(position="2", title="Shrug", duration="3:15"),
+    ])
+    tl = [TracklistEntry("A1", "Peddler", None), TracklistEntry("A2", "Shrug", None)]
+    out = reader._overlay_master_durations(_rel(), tl)
+    assert [e.duration for e in out] == ["3:04", "3:15"]
+
+
+def test_no_master_leaves_durations_none():
+    reader = make_discogs_reader()
+    tl = [TracklistEntry("A1", "One", None)]
+    out = reader._overlay_master_durations(_rel(master_id=None), tl)
+    assert out[0].duration is None
+
+
+def test_master_fetch_failure_degrades_gracefully():
+    reader = make_discogs_reader()
+    reader._http.request = MagicMock(side_effect=ConnectionError("blip"))
+    assert reader.get_master_tracklist(_rel()) == []
+    tl = [TracklistEntry("A1", "One", None)]
+    assert reader._overlay_master_durations(_rel(), tl)[0].duration is None
+
+
+def test_title_match_when_positions_and_ORDER_both_differ():
+    """#467 cold-review #1: a side-balanced reorder (equal counts, different order
+    AND positions) must match by TITLE, never by ordinal — an index guess would
+    assign a wrong (off-by-a-track) duration."""
+    reader = make_discogs_reader()
+    reader.get_master_tracklist = MagicMock(return_value=[
+        TracklistEntry(position="1", title="Alpha", duration="3:00"),
+        TracklistEntry(position="2", title="Bravo", duration="4:00"),
+        TracklistEntry(position="3", title="Charlie", duration="5:00"),
+    ])
+    # vinyl playback order Alpha, Charlie, Bravo (side-balanced), no durations
+    tl = [
+        TracklistEntry("A1", "Alpha", None),
+        TracklistEntry("A2", "Charlie", None),
+        TracklistEntry("B1", "Bravo", None),
+    ]
+    out = reader._overlay_master_durations(_rel(), tl)
+    assert {e.title: e.duration for e in out} == {
+        "Alpha": "3:00", "Charlie": "5:00", "Bravo": "4:00",
+    }
+
+
+def test_ambiguous_duplicate_title_stays_none():
+    """A title duplicated in the master is ambiguous, so a position-less/differently-
+    positioned row with that title keeps None rather than borrowing a wrong duration."""
+    reader = make_discogs_reader()
+    reader.get_master_tracklist = MagicMock(return_value=[
+        TracklistEntry(position="1", title="Reprise", duration="1:00"),
+        TracklistEntry(position="2", title="Reprise", duration="2:00"),
+    ])
+    tl = [TracklistEntry("A1", "Reprise", None)]
+    out = reader._overlay_master_durations(_rel(), tl)
+    assert out[0].duration is None

--- a/tests/test_split_credit_inline_wait_r7_06.py
+++ b/tests/test_split_credit_inline_wait_r7_06.py
@@ -59,10 +59,14 @@ async def test_split_credit_honoring_retry_after_does_not_stall_the_leg(monkeypa
     elapsed = time.monotonic() - t0
 
     # DETERMINISTIC signal (no wall-clock threshold): when the leg returns, the
-    # credit is still honouring its Retry-After in the background — the first
-    # attempt has raised (1 call) but the retry has NOT yet landed. Had the leg
-    # blocked on the unbounded await, the whole finalize would be done here (2).
-    assert writer.increment_play_count.call_count == 1, (
+    # split credit has NOT finished inline — it is still in the background, either
+    # not yet started (0 calls) or mid-Retry-After after its first attempt (1 call).
+    # BOTH mean the leg was freed. Only a leg that blocked on the unbounded await
+    # would see the whole finalize done here (2 calls: raised once, then retried).
+    # (Was `== 1`, which additionally raced on whether the background task had been
+    # scheduled to fire its first attempt within the tiny inline window — flaky on a
+    # loaded CI runner, which returns 0. `< 2` is the true regression signal.)
+    assert writer.increment_play_count.call_count < 2, (
         "the recognition leg blocked until the credit finished — R7-06 stall"
     )
     # Secondary (loose) sanity: the leg returned near the bound, not the 0.4s wait.


### PR DESCRIPTION
Closes #467. On a gapless side, tracks were skipped when the album resolved to a release with no Discogs durations: the per-track scheduler fell back to the 240s safety idle and overshot the next track (measured live: every skip followed DBG idle dur=None wait=240s). Fill missing durations from the album master (shared across pressings, so stable regardless of which release a track resolves to), overlaid only when a row is missing one, matched by position then unique title. Recognizer unchanged. RED-first; cold-reviewed.