### PR TITLE
Fix #468: do not split the session on a same-album release flip (match by master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Versions follow [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.PATCH`.
 
 ### Fixed
 
+- **The same album no longer splits the listening session when it resolves to two
+  different Discogs releases mid-side (#468).** AudD returns slightly varying album
+  strings per track, so the resolver's album-cache key varied and a track could
+  re-resolve to a different release (a collection↔database tier flip) — which the
+  session-split detector saw as a new record and split on, distorting play-count and
+  scrobble grouping. The detector now recognises two releases that share the album's
+  **master** as the same album (in both directions, independent of the resolve_key
+  the #184 guard relied on) and continues the session. A genuinely different album
+  (different master, or no master to vouch sameness) still splits.
+
 - **Tracks no longer get skipped when the resolved release has no Discogs durations
   (#467).** Some releases (a user's exact pressing included) carry no per-track
   durations, so the per-track polling scheduler fell back to the 240s safety idle,

--- a/src/metadata/discogs/reader.py
+++ b/src/metadata/discogs/reader.py
@@ -1094,6 +1094,7 @@ class DiscogsReader:
             "catalog_number": catno,
             "release_id": release.id,
             "instance_id": instance_id,
+            "master_id": self._master_id_of(release),   # #468
             "cover_art_url": cover_url,
             "tracklist": tracklist,
             "genres": genres,

--- a/src/metadata/models.py
+++ b/src/metadata/models.py
@@ -378,6 +378,10 @@ class TrackMetadata:
     catalog_number: Optional[str] = None
     discogs_release_id: Optional[int] = None
     discogs_instance_id: Optional[int] = None  # Needed for collection field updates
+    # #468: the album's Discogs MASTER id (shared across every pressing). Lets the
+    # split detector see that two different release_ids are the SAME album (a
+    # collection/database tier flip) and suppress the spurious 'album change' split.
+    discogs_master_id: Optional[int] = None
     cover_art_url: Optional[str] = None
     tracklist: list["TracklistEntry"] = field(default_factory=list)
     genres: list[str] = field(default_factory=list)
@@ -484,6 +488,10 @@ class PlaySession:
     # and suppress the spurious split.
     last_release_source: Optional[MetadataSource] = None
     last_release_resolve_key: Optional[tuple] = None
+    # #468: the master id recorded beside last_release_id, so a flip to a DIFFERENT
+    # release_id that shares this master is recognised as the same album and does
+    # NOT split the session (robust to the resolve_key variance #184 relies on).
+    last_master_id: Optional[int] = None
     # Set True once this session's Play Count has actually been credited
     # (the write LANDED), so a re-entrant end (the B-2 race, or a split misfire
     # that finalizes the same session twice) cannot double-increment the same
@@ -757,6 +765,7 @@ class PlaySession:
             self.last_release_id = track.discogs_release_id
             self.last_release_source = track.source          # #184
             self.last_release_resolve_key = track.resolve_key
+            self.last_master_id = track.discogs_master_id    # #468
         # Latch the release/instance IDs from the first collection-sourced track.
         # We require BOTH release_id and instance_id to be set — a release_id alone
         # (which is what DISCOGS_DATABASE returns) is not enough to call the

--- a/src/metadata/resolver.py
+++ b/src/metadata/resolver.py
@@ -567,6 +567,7 @@ class MetadataResolver:
             catalog_number=discogs_result.get("catalog_number"),
             discogs_release_id=discogs_result.get("release_id"),
             discogs_instance_id=discogs_result.get("instance_id"),
+            discogs_master_id=discogs_result.get("master_id"),   # #468
             cover_art_url=discogs_result.get("cover_art_url"),
             # Shallow-copy the cached tracklist so each track of an album gets
             # its own list object — a defensive .sort()/append on one track's

--- a/src/tracking/listen_tracker.py
+++ b/src/tracking/listen_tracker.py
@@ -1366,6 +1366,20 @@ class ListenTracker:
                 # swap changes the key, and collection→database (unreachable —
                 # collection results are cached) stays a conservative split.
                 if (
+                    # #468: a DIFFERENT release_id that shares the album's MASTER is
+                    # just another pressing (a collection/database tier flip from the
+                    # AudD album-string variance that breaks the #184 resolve_key
+                    # match, in EITHER direction) — the same album, not a swap.
+                    track.discogs_master_id is not None
+                    and track.discogs_master_id == self._session.last_master_id
+                ):
+                    log.info(
+                        f"Same album master {track.discogs_master_id} — release "
+                        f"{self._session.last_release_id} → {track.discogs_release_id} "
+                        f"is a different pressing of the same album (#468), not an "
+                        f"album change; continuing the session."
+                    )
+                elif (
                     self._session.last_release_source is MetadataSource.DISCOGS_DATABASE
                     and track.source is MetadataSource.DISCOGS_COLLECTION
                     and track.resolve_key is not None

--- a/tests/test_listen_tracker.py
+++ b/tests/test_listen_tracker.py
@@ -100,6 +100,7 @@ def make_track(
     source=MetadataSource.DISCOGS_COLLECTION,
     tracklist=None,
     resolve_key=None,
+    master_id=None,
 ):
     return TrackMetadata(
         title=title,
@@ -108,6 +109,7 @@ def make_track(
         source=source,
         discogs_release_id=release_id,
         discogs_instance_id=instance_id,
+        discogs_master_id=master_id,
         tracklist=tracklist if tracklist is not None else make_tracklist(),
         resolve_key=resolve_key,
     )

--- a/tests/test_master_split_468.py
+++ b/tests/test_master_split_468.py
@@ -1,0 +1,49 @@
+"""#468: a mid-side flip to a DIFFERENT Discogs release that shares the album's
+MASTER (a collection/database tier flip driven by AudD album-string variance) must
+NOT be treated as an album change / session split."""
+import pytest
+
+from src.audio.silence import AudioEvent
+from tests.test_listen_tracker import make_tracker, make_track
+
+
+@pytest.mark.asyncio
+async def test_same_master_different_release_does_not_split():
+    tracker, writer = make_tracker()
+    tracker.on_silence_event(AudioEvent.MUSIC_STARTED)
+    await tracker.on_track_identified(
+        make_track("Catholic Block", release_id=100, master_id=500))
+    sess = tracker._session
+    # different pressing of the SAME album (same master) — the flip-flop
+    await tracker.on_track_identified(
+        make_track("Stereo Sanctity", release_id=200, master_id=500))
+    assert tracker._session is sess                       # not split
+    assert tracker._session.last_release_id == 200        # detector still tracks latest
+    assert tracker._session.last_master_id == 500
+
+
+@pytest.mark.asyncio
+async def test_different_master_still_splits():
+    tracker, writer = make_tracker()
+    tracker.on_silence_event(AudioEvent.MUSIC_STARTED)
+    await tracker.on_track_identified(
+        make_track("Catholic Block", release_id=100, master_id=500))
+    sess = tracker._session
+    # a genuinely different album (different master) still splits
+    await tracker.on_track_identified(
+        make_track("Foreign Song", release_id=200, master_id=999))
+    assert tracker._session is not sess
+
+
+@pytest.mark.asyncio
+async def test_masterless_flip_still_splits_conservatively():
+    """No master on either side → no album-identity vouch → the release_id change
+    stays a conservative split (unchanged pre-#468 behavior)."""
+    tracker, writer = make_tracker()
+    tracker.on_silence_event(AudioEvent.MUSIC_STARTED)
+    await tracker.on_track_identified(
+        make_track("Catholic Block", release_id=100, master_id=None))
+    sess = tracker._session
+    await tracker.on_track_identified(
+        make_track("Foreign Song", release_id=200, master_id=None))
+    assert tracker._session is not sess


### PR DESCRIPTION
Closes #468. AudD returns slightly varying album strings per track, so the resolver cache key varied and a track could re-resolve to a different Discogs release of the same album (a collection/database tier flip); the split detector compares release_id, so each flip false-split the session, distorting play-count and scrobble grouping. Generalize the #184 tier-upgrade guard using the album master id (stable across pressings, independent of the resolve_key #184 relied on): two releases sharing a master are the same album, so suppress the split in both directions. A genuinely different album (different/absent master) still splits. RED-first; cold-reviewed (no credit regression).