### PR TITLE
Add EYELINER_DEBUG_RECOGNITION opt-in recognition diagnostics (#472)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Versions follow [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.PATCH`.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`EYELINER_DEBUG_RECOGNITION` opt-in recognition diagnostics (#472).** Set it to a
+  truthy value to log each backend poll (result, match offset, status, pending
+  candidate) and each predicted next-track boundary — for debugging track skips /
+  mis-timing on real hardware without hand-patching the source. Off by default (one
+  bool check per poll, no output). See docs/recognition-backends.md.
+
 ## [1.6.3] — 2026-08-28
 
 ### Fixed

--- a/docs/recognition-backends.md
+++ b/docs/recognition-backends.md
@@ -59,3 +59,38 @@ planned drop-in). A new backend needs a `RecognizerBackend` subclass, its name a
 `IMPLEMENTED_BACKENDS` in `src/config.py`, and a branch in
 `RecognitionLoop._init_backend` — config validation and construction both check the same
 set, so they can never drift.
+
+## Debugging recognition (track skips / mis-timing)
+
+Set `EYELINER_DEBUG_RECOGNITION=1` to log, at INFO, two diagnostics per side: each
+backend poll (`recognition-debug poll: result=… off=… status=… cur=… pending=… xN`)
+and each predicted next-track boundary (`recognition-debug idle: dur=… off=… wait=…`).
+Off by default — normal runs emit nothing. It's the built-in replacement for
+hand-patching debug lines; use it to see whether a skipped track was a boundary
+overshoot (the `idle` wait landed past the track) or the backend simply not
+returning that track (`poll result=None` throughout it).
+
+**Manual run** (foreground, headless — audio + recognition still work over SSH):
+
+```bash
+systemctl --user stop eyeliner.service
+cd ~/eyeliner && SDL_VIDEODRIVER=dummy EYELINER_DEBUG_RECOGNITION=1 \
+  venv/bin/python main.py 2>&1 | tee ~/eyeliner-debug.log
+# ...play the side, Ctrl+C...
+systemctl --user restart eyeliner.service
+grep -E 'recognition-debug|Track confirmed|churning|NO MATCH' ~/eyeliner-debug.log
+```
+
+**Autostart service** (to capture without a manual run): add to the user unit
+`~/.config/systemd/user/eyeliner.service`, under `[Service]`:
+
+```ini
+Environment=EYELINER_DEBUG_RECOGNITION=1
+StandardOutput=append:%h/eyeliner-debug.log
+StandardError=append:%h/eyeliner-debug.log
+```
+
+then `systemctl --user daemon-reload && systemctl --user restart eyeliner.service`.
+The explicit logfile is the reliable path because `journalctl --user` can come back
+empty when the user journal isn't persisted (default on some Pi OS images). Remove
+those three lines (and `daemon-reload` + restart) to turn diagnostics back off.

--- a/src/audio/recognizer.py
+++ b/src/audio/recognizer.py
@@ -8,6 +8,7 @@ backend (e.g. ACRCloud) at startup until it is built.
 
 import asyncio
 import logging
+import os
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -100,6 +101,17 @@ _ERROR_RETRY_SECONDS = 30.0
 # resumes. (A sustained fresh-misrecognition-every-window side is still bounded, at
 # ~2.25x the idle rate — acceptably rare and far under the AudD quota.)
 _CANDIDATE_CONFIRM_ATTEMPTS = 7
+
+# #472: opt-in per-poll recognition diagnostics — each backend result (with its
+# match offset + the confirmation state) and each predicted next-track boundary.
+# For debugging track skips / mis-timing on real hardware WITHOUT hand-patching the
+# source. Off by default: one bool check per poll, zero output. Enable by setting
+# EYELINER_DEBUG_RECOGNITION to a truthy value (1/true/yes/on) in the environment
+# (e.g. the systemd unit's Environment=). Emitted at INFO so it shows under the
+# default log level. See docs/recognition-backends.md ("Debugging recognition").
+_DEBUG_RECOGNITION = os.environ.get(
+    "EYELINER_DEBUG_RECOGNITION", ""
+).strip().lower() in ("1", "true", "yes", "on")
 
 
 def _parse_mmss(value) -> Optional[float]:
@@ -747,6 +759,16 @@ class RecognitionLoop:
         ``audio_epoch`` and fails safe, so the worst case is the guard discarding
         live commits (loud missed identifications), never a silent bad write.
         """
+        if _DEBUG_RECOGNITION:  # #472
+            log.info(
+                "recognition-debug poll: result=%s off=%s status=%s cur=%s pending=%s x%d",
+                (f"{result.artist} — {result.title}" if result else None),
+                getattr(result, "match_offset", None),
+                self.state.status.name,
+                (self.state.current_raw.title if self.state.current_raw else None),
+                (self._pending_result.title if self._pending_result else None),
+                self._pending_count,
+            )
         # PCONC-3: on a session boundary (the epoch changed since the last chunk),
         # reset the per-session HEALTH counters. `_miss_count` gates the LISTENING
         # "NO MATCH FOUND" screen and `_churn_count` the churn breadcrumb; both are
@@ -901,6 +923,11 @@ class RecognitionLoop:
         # garbage Discogs duration ("99:00" -> 99 min) can't freeze the display for a
         # whole side; the display lag is universally bounded.
         wait = min(wait, self._safety_recheck_seconds)
+        if _DEBUG_RECOGNITION:  # #472
+            log.info(
+                "recognition-debug idle: dur=%s off=%s wait=%.1fs (until next-track boundary)",
+                duration, (result.match_offset or 0.0), wait,
+            )
         self._reactivate_at = now + wait
         self._recognition_active = False
 

--- a/tests/test_recognition_debug_472.py
+++ b/tests/test_recognition_debug_472.py
@@ -1,0 +1,53 @@
+"""#472: EYELINER_DEBUG_RECOGNITION opt-in per-poll recognition diagnostics —
+a permanent, env-toggled replacement for hand-patching debug log lines."""
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+import src.audio.recognizer as rec
+from src.audio.recognizer import RawRecognitionResult
+from src.state.player_state import PlayerStatus
+from tests.test_per_track_polling import _loop, _track
+
+
+def test_idle_diagnostic_silent_when_flag_off(caplog):
+    loop = _loop()
+    loop.state.current_track = _track(0, ["4:00"])
+    with caplog.at_level(logging.INFO):
+        loop._go_idle_until_boundary(SimpleNamespace(match_offset=30.0), now=0.0)
+    assert not any("recognition-debug" in r.getMessage() for r in caplog.records)
+
+
+def test_idle_diagnostic_emitted_when_flag_on(caplog, monkeypatch):
+    monkeypatch.setattr(rec, "_DEBUG_RECOGNITION", True)
+    loop = _loop()
+    loop.state.current_track = _track(0, ["4:00"])   # 240s
+    with caplog.at_level(logging.INFO):
+        loop._go_idle_until_boundary(SimpleNamespace(match_offset=30.0), now=0.0)
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("recognition-debug idle:" in m and "wait=" in m for m in msgs)
+
+
+@pytest.mark.asyncio
+async def test_poll_diagnostic_emitted_when_flag_on(caplog, monkeypatch):
+    monkeypatch.setattr(rec, "_DEBUG_RECOGNITION", True)
+    loop = _loop()
+    loop.state.status = PlayerStatus.LISTENING
+    with caplog.at_level(logging.INFO):
+        await loop._handle_result(RawRecognitionResult("Peddler", "Lunar Vacation", "X"))
+    assert any("recognition-debug poll:" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_poll_diagnostic_silent_when_flag_off(caplog):
+    loop = _loop()
+    loop.state.status = PlayerStatus.LISTENING
+    with caplog.at_level(logging.INFO):
+        await loop._handle_result(RawRecognitionResult("Peddler", "Lunar Vacation", "X"))
+    assert not any("recognition-debug" in r.getMessage() for r in caplog.records)
+
+
+def test_flag_defaults_off():
+    """The shipped default must be OFF (no diagnostic spam in normal operation)."""
+    assert rec._DEBUG_RECOGNITION is False


### PR DESCRIPTION
Closes #472. Permanent env-toggled replacement for the debug log lines we hand-patched three times: set EYELINER_DEBUG_RECOGNITION truthy to log each backend poll (result, offset, status, pending) and each predicted next-track boundary, at INFO. Off by default (one bool check per poll, no output). Docs cover capturing logs from a manual headless run and from the autostart service (StandardOutput=append), including the empty journalctl --user workaround. RED-first; recognizer suite green.